### PR TITLE
feat: ship #41 campaign hierarchy wiring + #45 walkable demo fallback

### DIFF
--- a/src/actions/campaign-crud.ts
+++ b/src/actions/campaign-crud.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto'
 import { cookies } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { validateEdit, validateDelete } from '@/lib/campaign-lifecycle'
+import { validateCampaignParentAssignment } from '@/lib/campaign-hierarchy'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,6 +100,8 @@ export type CreateCampaignInput = {
   startDate?: string | null
   /** Scheduled end */
   endDate?: string | null
+  /** Optional parent campaign (same instance only) */
+  parentCampaignId?: string | null
 }
 
 export type CreateCampaignResult =
@@ -187,9 +190,14 @@ export async function createCampaign(
   })
   if (existing) return { error: `A campaign with slug "${slug}" already exists` }
 
+  const parentCheck = await validateCampaignParentAssignment(db, {
+    instanceId: input.instanceId,
+    parentCampaignId: input.parentCampaignId,
+  })
+  if ('error' in parentCheck) return { error: parentCheck.error }
+
   // --- Create the campaign in DRAFT status ---
-  const campaign = await db.campaign.create({
-    data: {
+  const createData: Prisma.CampaignUncheckedCreateInput = {
       slug,
       name: input.name.trim(),
       description: input.description?.trim() || null,
@@ -208,7 +216,11 @@ export async function createCampaign(
       endDate: input.endDate ? new Date(input.endDate) : null,
       instanceId: input.instanceId,
       createdById: playerId,
-    },
+      parentCampaignId: input.parentCampaignId?.trim() || null,
+  }
+
+  const campaign = await db.campaign.create({
+    data: createData,
   })
 
   revalidatePath('/campaigns')
@@ -297,7 +309,7 @@ export async function updateCampaign(
 
   const campaign = await db.campaign.findUnique({
     where: { id: campaignId },
-    select: { status: true, slug: true },
+    select: { status: true, slug: true, instanceId: true },
   })
   if (!campaign) return { error: 'Campaign not found' }
 
@@ -306,7 +318,7 @@ export async function updateCampaign(
   if (!editCheck.valid) return { error: editCheck.reason }
 
   // Build update data — only include fields that were explicitly passed
-  const data: Prisma.CampaignUpdateInput = {}
+  const data: Prisma.CampaignUncheckedUpdateInput = {}
   if (input.name !== undefined) data.name = input.name.trim()
   if (input.description !== undefined) data.description = input.description?.trim() || null
   if (input.allyshipDomain !== undefined) data.allyshipDomain = input.allyshipDomain || null
@@ -321,6 +333,15 @@ export async function updateCampaign(
   }
   if (input.startDate !== undefined) data.startDate = input.startDate ? new Date(input.startDate) : null
   if (input.endDate !== undefined) data.endDate = input.endDate ? new Date(input.endDate) : null
+  if (input.parentCampaignId !== undefined) {
+    const parentCheck = await validateCampaignParentAssignment(db, {
+      instanceId: campaign.instanceId,
+      parentCampaignId: input.parentCampaignId,
+      campaignId,
+    })
+    if ('error' in parentCheck) return { error: parentCheck.error }
+    data.parentCampaignId = input.parentCampaignId?.trim() || null
+  }
 
   // Check if any fields were set
   if (Object.keys(data).length === 0) {
@@ -424,6 +445,13 @@ export type StewardInstance = {
   slug: string
   name: string
   campaignCount: number
+  campaigns: {
+    id: string
+    slug: string
+    name: string
+    parentCampaignId: string | null
+    status: string
+  }[]
 }
 
 export async function listStewardInstances(): Promise<StewardInstance[]> {
@@ -441,6 +469,16 @@ export async function listStewardInstances(): Promise<StewardInstance[]> {
         slug: true,
         name: true,
         _count: { select: { campaigns: true } },
+        campaigns: {
+          orderBy: { name: 'asc' },
+          select: {
+            id: true,
+            slug: true,
+            name: true,
+            parentCampaignId: true,
+            status: true,
+          },
+        },
       },
     })
     return instances.map((i) => ({
@@ -448,6 +486,7 @@ export async function listStewardInstances(): Promise<StewardInstance[]> {
       slug: i.slug,
       name: i.name,
       campaignCount: i._count.campaigns,
+      campaigns: i.campaigns,
     }))
   }
 
@@ -464,6 +503,16 @@ export async function listStewardInstances(): Promise<StewardInstance[]> {
           slug: true,
           name: true,
           _count: { select: { campaigns: true } },
+          campaigns: {
+            orderBy: { name: 'asc' },
+            select: {
+              id: true,
+              slug: true,
+              name: true,
+              parentCampaignId: true,
+              status: true,
+            },
+          },
         },
       },
     },
@@ -476,6 +525,7 @@ export async function listStewardInstances(): Promise<StewardInstance[]> {
       slug: m.instance.slug,
       name: m.instance.name,
       campaignCount: m.instance._count.campaigns,
+      campaigns: m.instance.campaigns,
     }))
 }
 

--- a/src/app/admin/campaigns/create/CampaignCreateWizard.tsx
+++ b/src/app/admin/campaigns/create/CampaignCreateWizard.tsx
@@ -18,14 +18,15 @@ import { QuestTemplateCustomizeForm } from '@/components/campaign/QuestTemplateC
 // Types
 // ---------------------------------------------------------------------------
 
-type WizardStep = 'name' | 'description' | 'instance' | 'quests' | 'customize' | 'review' | 'done'
+type WizardStep = 'name' | 'description' | 'instance' | 'parent' | 'quests' | 'customize' | 'review' | 'done'
 
-const STEP_ORDER: WizardStep[] = ['name', 'description', 'instance', 'quests', 'customize', 'review']
+const STEP_ORDER: WizardStep[] = ['name', 'description', 'instance', 'parent', 'quests', 'customize', 'review']
 
 const STEP_LABELS: Record<WizardStep, string> = {
   name: 'Name',
   description: 'Description',
   instance: 'Instance',
+  parent: 'Parent',
   quests: 'Quests',
   customize: 'Customize',
   review: 'Confirm',
@@ -190,6 +191,7 @@ export function CampaignCreateWizard({
   const [instanceId, setInstanceId] = useState(
     instances.length === 1 ? instances[0].id : '',
   )
+  const [parentCampaignId, setParentCampaignId] = useState('')
   const [questTemplates, setQuestTemplates] = useState<SelectedTemplate[]>([])
   const [error, setError] = useState<string | null>(null)
   const [createdSlug, setCreatedSlug] = useState<string | null>(null)
@@ -263,6 +265,7 @@ export function CampaignCreateWizard({
         slug: effectiveSlug,
         description: description.trim() || undefined,
         allyshipDomain: allyshipDomain || undefined,
+        parentCampaignId: parentCampaignId || undefined,
         questTemplateConfig: questTemplateConfig.length > 0 ? questTemplateConfig : undefined,
       }
       const result = await createCampaign(input)
@@ -326,6 +329,7 @@ export function CampaignCreateWizard({
               setDescription('')
               setAllyshipDomain('')
               setInstanceId(instances.length === 1 ? instances[0].id : '')
+              setParentCampaignId('')
               setQuestTemplates([])
               setError(null)
               setCreatedSlug(null)
@@ -508,6 +512,7 @@ export function CampaignCreateWizard({
                   type="button"
                   onClick={() => {
                     setInstanceId(inst.id)
+                    setParentCampaignId('')
                     setError(null)
                   }}
                   className={`w-full text-left px-4 py-3 rounded-xl border transition-colors ${
@@ -536,6 +541,63 @@ export function CampaignCreateWizard({
             onBack={goBack}
             onNext={() => validateInstance() && goNext()}
             nextDisabled={!instanceId}
+            isPending={isPending}
+          />
+        </>
+      )}
+
+      {/* ----- Step: PARENT CAMPAIGN ----- */}
+      {step === 'parent' && (
+        <>
+          <StepTitle>Choose parent campaign</StepTitle>
+          <StepDescription>
+            Optional. Leave blank to create a root campaign, or attach this as a
+            child under an existing campaign in the same instance.
+          </StepDescription>
+
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={() => setParentCampaignId('')}
+              className={`w-full text-left px-4 py-3 rounded-xl border transition-colors ${
+                parentCampaignId === ''
+                  ? 'border-purple-600/60 bg-purple-950/30 text-purple-100'
+                  : 'border-zinc-800 bg-zinc-900/50 text-zinc-300 hover:border-zinc-600'
+              }`}
+            >
+              <div className="font-medium text-sm">No parent (root campaign)</div>
+              <div className="text-xs text-zinc-500 mt-0.5">
+                Top-level campaign in /{selectedInstance?.slug}
+              </div>
+            </button>
+            {(selectedInstance?.campaigns ?? []).map((campaign) => (
+              <button
+                key={campaign.id}
+                type="button"
+                onClick={() => setParentCampaignId(campaign.id)}
+                className={`w-full text-left px-4 py-3 rounded-xl border transition-colors ${
+                  parentCampaignId === campaign.id
+                    ? 'border-purple-600/60 bg-purple-950/30 text-purple-100'
+                    : 'border-zinc-800 bg-zinc-900/50 text-zinc-300 hover:border-zinc-600'
+                }`}
+              >
+                <div className="font-medium text-sm">{campaign.name}</div>
+                <div className="text-xs text-zinc-500 mt-0.5">
+                  /{campaign.slug} · {campaign.status}
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {(selectedInstance?.campaigns ?? []).length === 0 && (
+            <p className="text-xs text-zinc-500">
+              No campaigns yet in this instance. This will be created as a root campaign.
+            </p>
+          )}
+
+          <NavButtons
+            onBack={goBack}
+            onNext={goNext}
             isPending={isPending}
           />
         </>
@@ -679,6 +741,16 @@ export function CampaignCreateWizard({
                 </span>
               </p>
             </div>
+            {parentCampaignId && (
+              <div>
+                <span className="text-xs uppercase tracking-widest text-zinc-500">
+                  Parent Campaign
+                </span>
+                <p className="text-sm text-zinc-300">
+                  {selectedInstance?.campaigns.find((c) => c.id === parentCampaignId)?.name ?? 'Selected parent'}
+                </p>
+              </div>
+            )}
             <div>
               <span className="text-xs uppercase tracking-widest text-zinc-500">
                 Quests

--- a/src/app/world/[instanceSlug]/[roomSlug]/page.tsx
+++ b/src/app/world/[instanceSlug]/[roomSlug]/page.tsx
@@ -16,7 +16,7 @@ import { dbBase } from '@/lib/db'
 import { slugify } from '@/lib/spatial-world/utils'
 import { computeSpatialBindKey } from '@/lib/spatial-world/spatial-room-bind'
 import { resolveSpawnForRoom } from '@/lib/spatial-world/spawn-resolver'
-import { resolveAvatarConfigForPlayer, getWalkableSpriteUrl, parseAvatarConfig } from '@/lib/avatar-utils'
+import { resolveAvatarConfigForPlayer, resolveWorldWalkableSprite } from '@/lib/avatar-utils'
 import { getSpokeStatesForRoom } from '@/actions/campaign-spoke-states'
 import {
   canAccessNationRoom,
@@ -139,9 +139,10 @@ export default async function WorldRoomPage({
   }))
 
   const avatarConfig = resolveAvatarConfigForPlayer(player)
-  const walkableSpriteUrl = avatarConfig
-    ? getWalkableSpriteUrl(parseAvatarConfig(avatarConfig))
-    : null
+  const walkableSpriteDemoEnabled =
+    process.env.NEXT_PUBLIC_WALKABLE_SPRITE_DEMO === '1' ||
+    process.env.NEXT_PUBLIC_WALKABLE_SPRITE_DEMO === 'true'
+  const worldSprite = resolveWorldWalkableSprite(avatarConfig, walkableSpriteDemoEnabled)
 
   const spatialBindKey = computeSpatialBindKey(room.id, tilemap, anchors)
 
@@ -160,9 +161,10 @@ export default async function WorldRoomPage({
       player={{
         id: player.id,
         name: player.name,
-        avatarConfig: avatarConfig ?? null,
-        walkableSpriteUrl,
+        avatarConfig: worldSprite.avatarConfig,
+        walkableSpriteUrl: worldSprite.walkableSpriteUrl,
       }}
+      walkableSpriteDemo={worldSprite.walkableSpriteDemo}
       room={{ id: room.id, name: room.name, tilemap, anchors }}
       allRooms={allRooms}
       instanceSlug={instanceSlug}

--- a/src/lib/__tests__/walkable-sprite-demo-world.test.ts
+++ b/src/lib/__tests__/walkable-sprite-demo-world.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Run: npx tsx src/lib/__tests__/walkable-sprite-demo-world.test.ts
+ */
+import { resolveWorldWalkableSprite, WALKABLE_SPRITE_DEMO_AVATAR } from '@/lib/avatar-utils'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function run() {
+  const real = resolveWorldWalkableSprite(
+    JSON.stringify({ nationKey: 'argyra', archetypeKey: 'bold-heart', variant: 'default' }),
+    true
+  )
+  assert(real.walkableSpriteDemo === false, 'real avatar config should not be marked as demo')
+  assert(real.walkableSpriteUrl === '/sprites/walkable/argyra-bold-heart.png', 'real avatar should resolve sheet path')
+
+  const demo = resolveWorldWalkableSprite(null, true)
+  assert(demo.walkableSpriteDemo === true, 'demo flag should be true when enabled with missing avatar')
+  assert(
+    demo.walkableSpriteUrl === '/sprites/walkable/argyra-bold-heart.png',
+    'demo fallback should resolve argyra-bold-heart sheet'
+  )
+  assert(
+    demo.avatarConfig === JSON.stringify(WALKABLE_SPRITE_DEMO_AVATAR),
+    'demo fallback should provide demo avatar config'
+  )
+
+  const missing = resolveWorldWalkableSprite(null, false)
+  assert(missing.walkableSpriteDemo === false, 'demo flag should be false when disabled')
+  assert(missing.walkableSpriteUrl === null, 'missing avatar and demo off should not resolve sprite url')
+  assert(missing.avatarConfig === null, 'missing avatar and demo off should keep null avatarConfig')
+
+  console.log('walkable-sprite-demo-world tests OK')
+}
+
+run()

--- a/src/lib/avatar-utils.ts
+++ b/src/lib/avatar-utils.ts
@@ -160,6 +160,43 @@ export function getWalkableSpriteUrl(config: AvatarConfig | null): string {
     return `/sprites/walkable/${key}.png`
 }
 
+/**
+ * Resolve world-room sprite inputs, including demo-mode fallback for #45.
+ * When demo mode is on and a player has no avatar config, we force the demo
+ * walkable sheet and bypass MapAvatarGate.
+ */
+export function resolveWorldWalkableSprite(
+    avatarConfig: string | null,
+    demoEnabled: boolean
+): {
+    avatarConfig: string | null
+    walkableSpriteUrl: string | null
+    walkableSpriteDemo: boolean
+} {
+    const parsed = parseAvatarConfig(avatarConfig)
+    if (parsed) {
+        return {
+            avatarConfig,
+            walkableSpriteUrl: getWalkableSpriteUrl(parsed),
+            walkableSpriteDemo: false,
+        }
+    }
+
+    if (demoEnabled) {
+        return {
+            avatarConfig: JSON.stringify(WALKABLE_SPRITE_DEMO_AVATAR),
+            walkableSpriteUrl: getWalkableSpriteUrl(WALKABLE_SPRITE_DEMO_AVATAR),
+            walkableSpriteDemo: true,
+        }
+    }
+
+    return {
+        avatarConfig: null,
+        walkableSpriteUrl: null,
+        walkableSpriteDemo: false,
+    }
+}
+
 /** Player shape for resolving avatar config (nation/archetype included). */
 export type PlayerForAvatar = {
     avatarConfig?: string | null


### PR DESCRIPTION
## Summary
- Ship parent-campaign wiring for campaign hierarchy creation/update flows (#41)
- Ship world-room walkable demo fallback path + deterministic test (#45)

## Problem Solved
- #41: campaign hierarchy existed at schema/helper level but lacked create-wizard + action wiring to reliably set parent/child relationships.
- #45: demo env behavior for walkable sprites was specified but not fully enforced on world-room entry when avatar config was missing.

## Risks and Tradeoffs
- #41: parent assignment now validated at action boundaries; invalid parent links are rejected (same-instance, cycle, depth checks).
- #45: demo mode now intentionally bypasses avatar gate using a deterministic demo avatar; behavior is env-gated to avoid production impact.

## Verification
- [x] `npm run check` (passes; existing repo-wide lint warnings remain)
- [x] `npx tsx src/lib/__tests__/campaign-hierarchy.test.ts`
- [x] `npx tsx src/lib/__tests__/walkable-sprite-demo-world.test.ts`

## Issues
- Closes #41
- Closes #45
- Related #38

## Rollout Notes (Optional)
- PR ergonomics automation was implemented locally but could not be pushed with current token permissions (workflow scope required). I can open a follow-up PR for that as soon as workflow scope is available.
