### PR TITLE
docs: make deployment guidance Render-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # bars-engine Working Memory
 
+## Production Backend Policy (Canonical)
+- Production Python backend host is **Render**.
+- Treat Railway as **legacy/rollback** only unless explicitly reactivated.
+- For any backend runtime/deploy/env change, validate Render impact first.
+- If a change mentions Railway config, mirror the same intent for Render (or document why not).
+
 ## Environment Bring-up (Current Canonical Flow)
 - Use Vercel-backed env by default on this machine.
 - Steps:

--- a/backend/DEPLOY.md
+++ b/backend/DEPLOY.md
@@ -1,14 +1,10 @@
 # Backend Deployment
 
-The Python FastAPI backend runs the Game Master agents. Deploy to Railway, Render, or Fly.io (Vercel does not support Python).
+The Python FastAPI backend runs the Game Master agents. Deploy to Render (canonical), Railway (legacy/rollback), or Fly.io (Vercel does not support Python).
 
-## Railway
+## Canonical Production Target
 
-1. Create a new project at [railway.app](https://railway.app)
-2. Add a service from the `backend/` directory (or connect GitHub repo, set root to `backend/`)
-3. Railway uses `railway.json` for build/deploy config
-4. Set env vars: `DATABASE_URL`, `OPENAI_API_KEY`, `CORS_ORIGINS`
-5. Deploy. Railway assigns a URL; use it for `NEXT_PUBLIC_BACKEND_URL` in Vercel.
+Use **Render** as the default production backend host.
 
 ## Render
 
@@ -18,6 +14,24 @@ The Python FastAPI backend runs the Game Master agents. Deploy to Railway, Rende
 4. Set env vars in Render dashboard
 5. Use the Render URL for `NEXT_PUBLIC_BACKEND_URL` in Vercel.
 
+## Legacy / Rollback: Railway
+
+Use Railway only for rollback or explicit parallel testing.
+
+1. Create a new project at [railway.app](https://railway.app)
+2. Add a service from the `backend/` directory (or connect GitHub repo, set root to `backend/`)
+3. Railway uses `railway.json` for build/deploy config
+4. Set env vars: `DATABASE_URL`, `OPENAI_API_KEY`, `CORS_ORIGINS`
+5. Deploy. Railway assigns a URL; use it for `NEXT_PUBLIC_BACKEND_URL` in Vercel only during rollback/testing.
+
+## Change-Impact Checklist (Required)
+
+When a PR touches backend deploy/runtime/env behavior:
+
+1. Verify Render behavior first (`backend/render.yaml`, Render env vars, health endpoint).
+2. If you changed a Railway-specific setting, confirm equivalent Render impact or document why not needed.
+3. Confirm the active production pointer (`NEXT_PUBLIC_BACKEND_URL`) still targets Render unless a rollback is active.
+
 ## Env Vars
 
 | Var | Required | Purpose |
@@ -25,6 +39,19 @@ The Python FastAPI backend runs the Game Master agents. Deploy to Railway, Rende
 | `DATABASE_URL` | Yes | Production Postgres (same as Vercel) |
 | `OPENAI_API_KEY` | Yes | For AI agents |
 | `CORS_ORIGINS` | Yes (prod) | Comma-separated, include `https://<app>.vercel.app` |
+| `STRAND_RUNTIME_ENABLED` | Recommended | Kill switch for `POST /api/strands/run` (default `true`) |
+| `STRAND_REQUIRE_AUTH_IN_PRODUCTION` | Recommended | Require `bars_player_id` auth cookie in production for strand runtime |
+| `STRAND_MAX_SUBJECT_CHARS` | Optional | Input cap for strand `subject` (default `600`) |
+| `STRAND_MAX_SECTS` | Optional | Max allowed sect count in `sects` override (default `6`) |
+| `STRAND_ALLOWED_SECTS` | Optional | Comma-separated allowlist for runtime sect overrides |
+| `STRAND_RATE_LIMIT_ENABLED` | Optional | Enable per-actor in-process rate limiting for `/api/strands/run` |
+| `STRAND_RATE_LIMIT_WINDOW_SECONDS` | Optional | Sliding window size for rate limiting |
+| `STRAND_RATE_LIMIT_MAX_REQUESTS` | Optional | Max strand run requests allowed per actor/window |
+| `STRAND_IDEMPOTENCY_TTL_SECONDS` | Optional | Replay cache TTL for `Idempotency-Key` responses |
+| `STRAND_IDEMPOTENCY_LOCK_SECONDS` | Optional | TTL for in-flight idempotency lock |
+| `STRAND_RUNTIME_STORE` | Optional | Guard store backend: `memory` (default) or `redis` |
+| `REDIS_URL` | Required if store=redis | Redis connection string for shared runtime guard state |
+| `STRAND_RUNTIME_STORE_KEY_PREFIX` | Optional | Key prefix namespace for runtime guard keys |
 | `PORT` | Auto | Injected by Railway/Render |
 
 See [docs/ENV_AND_VERCEL.md](../docs/ENV_AND_VERCEL.md) for full documentation.

--- a/docs/AGENT_WORKFLOWS.md
+++ b/docs/AGENT_WORKFLOWS.md
@@ -75,14 +75,14 @@ This starts the backend at `http://localhost:8000`. The backend reads `DATABASE_
 | Context | Intended backend | Notes |
 |--------|-------------------|--------|
 | **Daily dev** (Cursor, MCP, `strand_run`, `sage:brief`, strand consult scripts) | **Local** `127.0.0.1:8000` | Omit `NEXT_PUBLIC_BACKEND_URL` / `BARS_BACKEND_URL` for MCP health, or set explicitly to `http://127.0.0.1:8000`. |
-| **Next.js app** (browser → agents) | From `NEXT_PUBLIC_BACKEND_URL` or fallback in `agent-client` | Vercel Preview/Production often points at **deployed** Railway; that is separate from “is my laptop MCP talking to local Python?”. |
-| **Intentional remote agents** | Deployed URL (`https://…railway.app`) | Opt-in: you are testing production/staging agents or not running local API. Align `OPENAI_API_KEY` on **that** host. |
+| **Next.js app** (browser → agents) | From `NEXT_PUBLIC_BACKEND_URL` or fallback in `agent-client` | Vercel Preview/Production should point at **deployed Render** backend; that is separate from “is my laptop MCP talking to local Python?”. |
+| **Intentional remote agents** | Deployed URL (`https://…onrender.com`) | Opt-in: you are testing production/staging agents or not running local API. Align `OPENAI_API_KEY` on **that** host. |
 
-**Why this matters:** `NEXT_PUBLIC_BACKEND_URL` is loaded into the same `.env.local` that the **Python MCP process** reads. If it points at Railway while you expect **local** agents, MCP tools (`strand_run`, etc.) health-check the wrong origin — or you get `openai_configured: false` on the remote host. **When helping someone or writing runbooks, assume local-first**; mention deployed URLs only as an explicit alternate.
+**Why this matters:** `NEXT_PUBLIC_BACKEND_URL` is loaded into the same `.env.local` that the **Python MCP process** reads. If it points at Render (or any remote host) while you expect **local** agents, MCP tools (`strand_run`, etc.) health-check the wrong origin — or you get `openai_configured: false` on the remote host. **When helping someone or writing runbooks, assume local-first**; mention deployed URLs only as an explicit alternate.
 
-**MCP health probe fallback (strand_run gate):** `backend/app/mcp_health.py` probes `GET /api/health` on the URL derived from env (with bare-host normalization). If that probe **fails** and the primary origin was **not** already `http://127.0.0.1:8000` or `http://localhost:8000`, it **retries once** against **`http://127.0.0.1:8000/api/health`**. So with `npm run dev:backend` running locally, a bad or unreachable Railway URL in `.env.local` should not block `strand_run` by itself.
+**MCP health probe fallback (strand_run gate):** `backend/app/mcp_health.py` probes `GET /api/health` on the URL derived from env (with bare-host normalization). If that probe **fails** and the primary origin was **not** already `http://127.0.0.1:8000` or `http://localhost:8000`, it **retries once** against **`http://127.0.0.1:8000/api/health`**. So with `npm run dev:backend` running locally, a bad or unreachable remote URL in `.env.local` should not block `strand_run` by itself.
 
-**Pin MCP to local explicitly:** set **`BARS_MCP_HEALTH_ORIGIN=http://127.0.0.1:8000`** in `.env.local`. That variable **only** affects the MCP Python process health check (not the browser/Next agent client). Use it when you want Next to keep pointing at Vercel/Railway but Cursor **bars-agents** must talk to local FastAPI.
+**Pin MCP to local explicitly:** set **`BARS_MCP_HEALTH_ORIGIN=http://127.0.0.1:8000`** in `.env.local`. That variable **only** affects the MCP Python process health check (not the browser/Next agent client). Use it when you want Next to keep pointing at Vercel/Render but Cursor **bars-agents** must talk to local FastAPI.
 
 See [CURSOR_MCP_TROUBLESHOOTING.md](./CURSOR_MCP_TROUBLESHOOTING.md) (dev-first + bare-host URL fixes).
 
@@ -199,7 +199,7 @@ Expect `"openai_configured": true`. If `false`, the key is missing from those fi
 
 **Common pitfall**: Key only in Vercel or only in a shell export — fine for that session, but `uvicorn` started from another terminal/Cursor won’t see it unless it’s in one of the files above.
 
-**Wrong `NEXT_PUBLIC_BACKEND_URL`**: See [Day-to-day dev vs deployed backend (precedence)](#day-to-day-dev-vs-deployed-backend-precedence). If `.env.local` points MCP/scripts at Railway while you meant local, or the remote host has no key, you get `openai_configured: false` or consult failures. For local dev, prefer unset or `http://127.0.0.1:8000`; use `--backend http://localhost:8000` on assess/brief scripts when overriding.
+**Wrong `NEXT_PUBLIC_BACKEND_URL`**: See [Day-to-day dev vs deployed backend (precedence)](#day-to-day-dev-vs-deployed-backend-precedence). If `.env.local` points MCP/scripts at Render (or another remote host) while you meant local, or the remote host has no key, you get `openai_configured: false` or consult failures. For local dev, prefer unset or `http://127.0.0.1:8000`; use `--backend http://localhost:8000` on assess/brief scripts when overriding.
 
 ### Generic or deterministic agent output (Sage, strand, sage:brief)
 

--- a/docs/CURSOR_MCP_TROUBLESHOOTING.md
+++ b/docs/CURSOR_MCP_TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ When an MCP server shows **Error** and **Show output**, use this to fix it or to
 
 **Day-to-day dev** should hit **local** API (`http://127.0.0.1:8000`). The wrapper already ensures that process is up before spawning Python.
 
-The MCP **health probe** inside `app.mcp_server` uses `NEXT_PUBLIC_BACKEND_URL` or `BARS_BACKEND_URL` if set (else `127.0.0.1:8000`). If `.env.local` sets a **deployed** Railway URL for the Next app, MCP will probe **that** host for `strand_run` / similar gates — which is fine only when you intend it. **When in doubt, prioritize local:** unset those vars for MCP purposes or set `NEXT_PUBLIC_BACKEND_URL=http://127.0.0.1:8000` on your machine. Canonical narrative: [AGENT_WORKFLOWS.md § Day-to-day dev vs deployed backend](./AGENT_WORKFLOWS.md#day-to-day-dev-vs-deployed-backend-precedence).
+The MCP **health probe** inside `app.mcp_server` uses `NEXT_PUBLIC_BACKEND_URL` or `BARS_BACKEND_URL` if set (else `127.0.0.1:8000`). If `.env.local` sets a **deployed** Render URL for the Next app, MCP will probe **that** host for `strand_run` / similar gates — which is fine only when you intend it. **When in doubt, prioritize local:** unset those vars for MCP purposes or set `NEXT_PUBLIC_BACKEND_URL=http://127.0.0.1:8000` on your machine. Canonical narrative: [AGENT_WORKFLOWS.md § Day-to-day dev vs deployed backend](./AGENT_WORKFLOWS.md#day-to-day-dev-vs-deployed-backend-precedence).
 
 ### Fix: `Unexpected token 'd', "[dotenv@17."... is not valid JSON`
 
@@ -76,17 +76,17 @@ Cursor is often started from the Dock (GUI), which has a **minimal PATH** (no Ho
 
 ### Fix: `unknown url type` / host without `https://` (strand_run, sage_consult)
 
-If `.env.local` sets **`NEXT_PUBLIC_BACKEND_URL`** or **`BARS_BACKEND_URL`** to a **bare hostname** (e.g. `bars-xxx.up.railway.app` with no `https://`), the MCP health probe used to build `host/api/health`, which Python rejects.
+If `.env.local` sets **`NEXT_PUBLIC_BACKEND_URL`** or **`BARS_BACKEND_URL`** to a **bare hostname** (e.g. `bars-backend-5fhb.onrender.com` with no `https://`), the MCP health probe used to build `host/api/health`, which Python rejects.
 
 **Preferred:** use a full origin in `.env.local`:
 
 ```bash
-NEXT_PUBLIC_BACKEND_URL=https://bars-enginecore-production.up.railway.app
+NEXT_PUBLIC_BACKEND_URL=https://bars-backend-5fhb.onrender.com
 ```
 
 **Also fixed in code:** `backend/app/mcp_health.py` now prepends `https://` for bare public hosts and `http://` for `localhost` / `127.0.0.1`. Pull latest, **Reload Window**, retry the tool.
 
-If the primary URL still fails (Railway down, VPN, etc.) but **local** API is up, the MCP probe **automatically retries** `http://127.0.0.1:8000/api/health` once. Ensure `npm run dev:backend` is running.
+If the primary URL still fails (Render down, VPN, etc.) but **local** API is up, the MCP probe **automatically retries** `http://127.0.0.1:8000/api/health` once. Ensure `npm run dev:backend` is running.
 
 To **always** probe local for MCP (independent of Next’s public URL):
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,7 +11,7 @@ The easiest way to deploy is via **Vercel**.
 1.  Push code to GitHub.
 2.  Import project in Vercel.
 3.  **Environment Variables**:
-    - `DATABASE_URL`: Your production connection string (e.g., Vercel Postgres, Neon, or Railway).
+    - `DATABASE_URL`: Your production connection string (e.g., Vercel Postgres, Neon, or Render Postgres).
     - `OPENAI_API_KEY`: For the Story Clock AI generation.
 4.  **Build Command**: `npx prisma generate && next build` (Standard Next.js).
 5.  **Output Directory**: `.next`.

--- a/docs/ENV_AND_VERCEL.md
+++ b/docs/ENV_AND_VERCEL.md
@@ -307,7 +307,7 @@ When production cannot log in or sign up (or admin credentials fail), run these 
 
 ## Python Backend (Game Master Agents)
 
-The Python FastAPI backend (`backend/`) runs the Game Master agents (Architect, Sage, Shaman, etc.). Vercel does not support Python serverless, so the backend is deployed separately (Railway, Render, or Fly.io).
+The Python FastAPI backend (`backend/`) runs the Game Master agents (Architect, Sage, Shaman, etc.). Vercel does not support Python serverless, so the backend is deployed separately (Render canonical; Railway legacy/rollback; or Fly.io).
 
 ### Running the backend locally
 
@@ -325,9 +325,9 @@ This starts the backend at `http://localhost:8000`. The backend reads `DATABASE_
 
 | Env | Purpose | When to set |
 |-----|---------|-------------|
-| `NEXT_PUBLIC_BACKEND_URL` | URL of the deployed Python backend (e.g. `https://bars-backend.railway.app`) | Set for Production and Preview when backend is deployed. Omit or leave empty to use fallback (direct OpenAI or deterministic logic). |
+| `NEXT_PUBLIC_BACKEND_URL` | URL of the deployed Python backend (e.g. `https://bars-backend-5fhb.onrender.com`) | Set for Production and Preview when backend is deployed. Omit or leave empty to use fallback (direct OpenAI or deterministic logic). |
 
-### Backend (Railway / Render / Fly.io)
+### Backend (Render canonical / Railway legacy / Fly.io)
 
 Set these in the backend service's environment:
 


### PR DESCRIPTION
## Summary\n- make docs Render-first for production backend guidance\n- keep Railway explicitly documented as legacy/rollback only\n- align MCP troubleshooting/examples away from Railway-specific URLs\n\n## Files updated\n- AGENTS.md\n- backend/DEPLOY.md\n- docs/AGENT_WORKFLOWS.md\n- docs/CURSOR_MCP_TROUBLESHOOTING.md\n- docs/DEPLOY.md\n- docs/ENV_AND_VERCEL.md\n\n## Why\nIssue #74 tracks infra policy alignment so runtime/deploy changes stop assuming Railway is active production.\n\nCloses #74