### PR TITLE
Fix altar modal close after refresh

### DIFF
--- a/src/components/valkyrie-party/AltarApp.tsx
+++ b/src/components/valkyrie-party/AltarApp.tsx
@@ -238,11 +238,11 @@ export function AltarApp() {
     const query = filter !== 'all' ? `?category=${encodeURIComponent(filter)}` : ''
     const json = await getJson<{ posts: AltarBoardEntry[]; categories: string[]; reaction_types: string[] }>(`/api/party/valkyrie/altar${query}`)
     setBoard(json)
-    if (focusedEntry) {
-      const refreshed = json.posts.find((entry) => entry.post.id === focusedEntry.post.id) || null
-      setFocusedEntry(refreshed)
-    }
-  }, [filter, focusedEntry])
+    setFocusedEntry((current) => {
+      if (!current) return null
+      return json.posts.find((entry) => entry.post.id === current.post.id) || null
+    })
+  }, [filter])
 
   const loadPlayerContext = useCallback(async () => {
     const [discoveryJson, savesJson] = await Promise.all([


### PR DESCRIPTION
## Summary

Follow-up fix for the Valkyrie party altar modal on mobile.

## Fixes

- prevents the altar detail modal from reopening itself after board refreshes
- allows the close button to actually dismiss the modal after replying or interacting with a post

## Notes

This is a follow-up to the already merged Valkyrie party PR.