### PR TITLE
Scaffold MTGOA game + completable trust/attune Priya encounter

### DIFF
--- a/mtgoa-game/.env.example
+++ b/mtgoa-game/.env.example
@@ -1,0 +1,9 @@
+# MTGOA — environment configuration
+#
+# AI integration is OPTIONAL. With no endpoint set, the game runs fully on the
+# canonical data + deterministic fallbacks (the project's dual-track principle).
+#
+# VITE_AI_ENDPOINT points at a SAME-ORIGIN backend proxy that holds the Anthropic
+# API key server-side and exposes /intake, /npc-generator, /resolution routes.
+# NEVER put an Anthropic API key in the browser / in a VITE_ var.
+VITE_AI_ENDPOINT=

--- a/mtgoa-game/.gitignore
+++ b/mtgoa-game/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+dist-ssr
+*.local
+.env
+.env.*
+!.env.example
+
+# Editor / OS
+.DS_Store
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.log
+npm-debug.log*

--- a/mtgoa-game/README.md
+++ b/mtgoa-game/README.md
@@ -1,0 +1,110 @@
+# Mastering the Game of Allyship (MTGOA)
+
+A digital card game about increasing the capacity for **mutual satisfaction over
+time**. This is the migration of the working Claude.ai artifact (~900-line single
+file, stress-tested on the Priya encounter) into a proper project structure.
+
+Stack: **Vite + React 18 + TypeScript + Tailwind CSS** with shadcn/ui-style base
+components. Game state is a single `useReducer` state machine. The data layer is
+fully separated from the UI; no inline styles (all aesthetic flows through design
+tokens → Tailwind).
+
+> Canonical design sources (Google Drive): *MTGOA — Core Architecture*,
+> *MTGOA — NPC Test Suite*, *MTGOA — Claude Code Migration Brief*. Those documents
+> are the source of truth; this code implements them.
+
+## Quick start
+
+```bash
+npm install
+npm run dev        # http://localhost:5173
+npm run build      # tsc -b && vite build
+npm run typecheck  # tsc --noEmit
+npm test           # vitest — engine Verification Quest
+```
+
+## Project structure
+
+Mirrors the Migration Brief's target architecture (`.js` → `.ts`/`.tsx`, CRA
+entry → Vite):
+
+```
+mtgoa-game/
+  design-system/
+    tokens.ts            # colors / typography / spacing (Brief § Design System)
+    theme.ts             # element → channel color/class maps
+  tailwind.config.ts     # consumes tokens (single source of truth)
+  src/
+    data/                # DATA LAYER (no UI imports)
+      channels.ts        # Wuxing elements + generative cycle
+      superpowers.ts     # six player archetypes
+      domains.ts         # four domains
+      milestones.ts      # milestone pool + Show Up target
+      moves.ts           # card primitives + the six canonical counter moves
+      npcs.ts            # eight NPCs (Priya fully authored) + Six Faces
+    engine/              # PURE GAME ENGINE (no React)
+      rules.ts           # tunable constants (canonical vs provisional, flagged)
+      bars.ts            # BAR economy
+      alchemy.ts         # channel generation, metabolize, exile
+      deckBuilder.ts     # starting deck by superpower
+      combat.ts          # NPC turn logic, shadow activation, conversion
+      gameState.ts       # the useReducer state machine
+      __tests__/         # engine smoke test (Verification Quest)
+    api/                 # AI integration points (graceful fallback)
+      client.ts          # transport + model config (claude-opus-4-8)
+      intake.ts          # #1 Applied Mode intake
+      npcGenerator.ts    # #2 NPC generation
+      resolution.ts      # #3 resolution narrative
+    components/          # presentational components (+ ui/ shadcn-style primitives)
+    screens/             # ModeSelect / SuperpowerSelect / Encounter / Domain / End
+    hooks/useGame.ts     # binds the reducer to React
+    App.tsx              # phase → screen router
+```
+
+## What's canonical vs. provisional
+
+Everything traceable to the design docs is encoded faithfully and **not** invented:
+
+- **Canonical:** the Wuxing channel system + generative cycle; the four BAR types
+  and their functions; the six Superpowers (channels, shadows, synergy bonuses);
+  the four Domains; the Six Faces; all eight NPC six-question profiles, milestones,
+  and forest seeds; **Priya's complete light/shadow decks** (effects + counters);
+  the stress system, contagion deltas, shadow-activation bands, conversion
+  threshold (3 of 6), and the Show Up victory target (10). The design-system tokens.
+
+- **Provisional** (clearly flagged in code via `provisional: true` or `PROVISIONAL`
+  comments, and never presented as final balance): the full tiered *player* move
+  catalog with channel costs/effects (this lived in the artifact, not the docs);
+  the exact metabolize/exile channel costs (docs say "matching"/"higher" without
+  numbers); and the seven non-Priya NPC decks (generated from channels until
+  authored). A couple of loop edge cases (rupture/exhaustion definitions) are
+  marked `INTERP` where the docs are thin.
+
+If you have the original ~900-line artifact, dropping its exact player-card
+definitions into `src/data/moves.ts` is the cleanest way to replace the
+provisional set.
+
+## AI integration
+
+Three Claude API call-sites (Migration Brief § AI Integration Points), all
+**optional** and degrading gracefully:
+
+1. **Intake** — Applied Mode six-question conversation → structured game config.
+2. **NPC generation** — situation seed → full NPC profile (the 8 NPCs are the cache).
+3. **Resolution narrative** — 2–3 sentence emotional payoff after a resolution.
+
+This is a browser SPA, so the Anthropic key must never ship to the client. The
+`api/` modules POST to a configurable same-origin backend proxy
+(`VITE_AI_ENDPOINT`) that holds the key and calls the Anthropic SDK server-side.
+With no endpoint configured, the game runs entirely on canonical data plus
+deterministic fallbacks. Default model: `claude-opus-4-8` (swappable in
+`api/client.ts`).
+
+## Build order status (Migration Brief)
+
+Done in this pass: design system (1), data-layer extraction (2), reducer state
+machine (3), NPC turn AI (4), full NPC roster (6), superpower → encounter → domain
+flow (7), end/reflection screen (10/11). Resolution API call (5) is wired with a
+fallback. Remaining: Applied Mode intake UI (8), deck/collection viewer (9),
+game→real-world bridge text (12), and replacing provisional cards with the
+artifact's canonical catalog.

--- a/mtgoa-game/design-system/theme.ts
+++ b/mtgoa-game/design-system/theme.ts
@@ -1,0 +1,44 @@
+/**
+ * MTGOA Design System — Theme
+ *
+ * Dark-mode game theme. Maps semantic roles to design tokens so the rest of the
+ * app references intent ("element channel", "superpower accent") rather than raw
+ * hex. Channel/superpower lookups are keyed by the canonical names used in the
+ * data layer.
+ */
+import { colors } from "./tokens";
+import type { Element } from "@/data/channels";
+
+/** Wuxing element → channel color. */
+export const channelColor: Record<Element, string> = {
+  Wood: colors.wood,
+  Fire: colors.fire,
+  Earth: colors.earth,
+  Metal: colors.metal,
+  Water: colors.water,
+};
+
+/** Tailwind text/border/bg class fragments per element (no inline styles). */
+export const channelClass: Record<Element, { text: string; border: string; bg: string }> = {
+  Wood: { text: "text-wood", border: "border-wood", bg: "bg-wood" },
+  Fire: { text: "text-fire", border: "border-fire", bg: "bg-fire" },
+  Earth: { text: "text-earth", border: "border-earth", bg: "bg-earth" },
+  Metal: { text: "text-metal", border: "border-metal", bg: "bg-metal" },
+  Water: { text: "text-water", border: "border-water", bg: "bg-water" },
+};
+
+export const theme = {
+  mode: "dark" as const,
+  surface: {
+    page: colors.bg,
+    raised: colors.surf,
+    card: colors.card,
+    border: colors.border,
+  },
+  textColor: {
+    primary: colors.text,
+    dim: colors.dim,
+    muted: colors.muted,
+    accent: colors.accent,
+  },
+} as const;

--- a/mtgoa-game/design-system/tokens.ts
+++ b/mtgoa-game/design-system/tokens.ts
@@ -1,0 +1,62 @@
+/**
+ * MTGOA Design System — Tokens
+ *
+ * Canonical source: "MTGOA Game — Claude Code Migration Brief" (Design System Tokens).
+ * These values are the single source of truth for the game aesthetic. They are
+ * consumed by tailwind.config.js (as theme colors) so that components style
+ * exclusively through Tailwind classes — never inline styles.
+ */
+
+export const colors = {
+  // Surfaces (dark-mode game theme)
+  bg: "#0d0d1a",
+  surf: "#16182e",
+  card: "#1c1f38",
+  border: "#2e3258",
+  accent: "#8b7ff5",
+  text: "#f0f0f8",
+  dim: "#c8c8e0",
+  muted: "#8888aa",
+
+  // Channel colors (Wuxing five elements)
+  wood: "#27ae60",
+  fire: "#c0392b",
+  earth: "#d4a017",
+  metal: "#8e8e93",
+  water: "#2980b9",
+
+  // Card-type colors
+  emotional: "#5ba8e0",
+  relational: "#4ec994",
+  cognitive: "#b07fe8",
+  action: "#e06060",
+
+  // Superpower colors
+  Strategist: "#e67e22",
+  Connector: "#27ae60",
+  Storyteller: "#8e44ad",
+  Alchemist: "#2980b9",
+  Disruptor: "#c0392b",
+  "Escape Artist": "#d4a017",
+} as const;
+
+export const typography = {
+  cardTitle: { fontSize: "13px", fontWeight: 700, lineHeight: 1.3 },
+  cardBody: { fontSize: "12px", lineHeight: 1.6 },
+  cardMeta: { fontSize: "10px", fontWeight: 600 },
+  label: {
+    fontSize: "10px",
+    fontWeight: 600,
+    letterSpacing: "0.8px",
+    textTransform: "uppercase" as const,
+  },
+  tag: { fontSize: "10px", fontWeight: 600, letterSpacing: "0.8px" },
+} as const;
+
+export const spacing = {
+  cardPad: "10px 10px",
+  cardRadius: "10px",
+  sectionGap: "12px",
+} as const;
+
+export type ColorToken = keyof typeof colors;

--- a/mtgoa-game/index.html
+++ b/mtgoa-game/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mastering the Game of Allyship</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/mtgoa-game/package-lock.json
+++ b/mtgoa-game/package-lock.json
@@ -1,0 +1,5177 @@
+{
+  "name": "mtgoa-game",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mtgoa-game",
+      "version": "0.1.0",
+      "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.469.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "tailwind-merge": "^2.6.0",
+        "tailwindcss-animate": "^1.0.7"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@vitejs/plugin-react": "^4.3.4",
+        "autoprefixer": "^10.4.20",
+        "eslint": "^9.17.0",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5.7.3",
+        "vite": "^6.0.7",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/mtgoa-game/package.json
+++ b/mtgoa-game/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "mtgoa-game",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Mastering the Game of Allyship — digital card game. Migrated from Claude.ai artifact to a standalone Vite + React + TypeScript app.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.6.0",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.17.0",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.7",
+    "vitest": "^2.1.8"
+  }
+}

--- a/mtgoa-game/postcss.config.js
+++ b/mtgoa-game/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/mtgoa-game/src/App.tsx
+++ b/mtgoa-game/src/App.tsx
@@ -1,0 +1,28 @@
+/**
+ * App — top-level phase router. The game state machine (engine/gameState.ts)
+ * owns `phase`; this component maps each phase to its screen.
+ *
+ * Applied Mode intake (IntakeConversation) is a future build step (Migration
+ * Brief priority #8); for now both modes route through Superpower → Encounter →
+ * Domain so the core loop is playable end-to-end.
+ */
+import { useGame } from "@/hooks/useGame";
+import { ModeSelect } from "@/screens/ModeSelect";
+import { SuperpowerSelect } from "@/screens/SuperpowerSelect";
+import { EncounterScreen } from "@/screens/EncounterScreen";
+import { DomainScreen } from "@/screens/DomainScreen";
+import { EndScreen } from "@/screens/EndScreen";
+
+export default function App() {
+  const { state, dispatch } = useGame();
+
+  return (
+    <div className="min-h-screen bg-bg text-text">
+      {state.phase === "mode-select" && <ModeSelect dispatch={dispatch} />}
+      {state.phase === "superpower-select" && <SuperpowerSelect dispatch={dispatch} />}
+      {state.phase === "encounter" && <EncounterScreen state={state} dispatch={dispatch} />}
+      {state.phase === "domain" && <DomainScreen state={state} dispatch={dispatch} />}
+      {state.phase === "end" && <EndScreen state={state} dispatch={dispatch} />}
+    </div>
+  );
+}

--- a/mtgoa-game/src/App.tsx
+++ b/mtgoa-game/src/App.tsx
@@ -6,15 +6,31 @@
  * Brief priority #8); for now both modes route through Superpower → Encounter →
  * Domain so the core loop is playable end-to-end.
  */
+import { useState } from "react";
+
 import { useGame } from "@/hooks/useGame";
 import { ModeSelect } from "@/screens/ModeSelect";
 import { SuperpowerSelect } from "@/screens/SuperpowerSelect";
 import { EncounterScreen } from "@/screens/EncounterScreen";
 import { DomainScreen } from "@/screens/DomainScreen";
 import { EndScreen } from "@/screens/EndScreen";
+import { TrustEncounterScreen } from "@/screens/TrustEncounterScreen";
 
 export default function App() {
   const { state, dispatch } = useGame();
+  // Trust/attune rebuild: a self-contained, provably-completable Level-1 Priya
+  // loop, reachable via a prototype toggle without disturbing the channel engine.
+  const [trustProto, setTrustProto] = useState(
+    typeof window !== "undefined" && window.location.hash === "#l1-priya",
+  );
+
+  if (trustProto) {
+    return (
+      <div className="min-h-screen bg-bg text-text">
+        <TrustEncounterScreen onExit={() => setTrustProto(false)} />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-bg text-text">
@@ -23,6 +39,13 @@ export default function App() {
       {state.phase === "encounter" && <EncounterScreen state={state} dispatch={dispatch} />}
       {state.phase === "domain" && <DomainScreen state={state} dispatch={dispatch} />}
       {state.phase === "end" && <EndScreen state={state} dispatch={dispatch} />}
+
+      <button
+        onClick={() => setTrustProto(true)}
+        className="fixed bottom-3 right-3 rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-semibold text-accent hover:bg-accent/20"
+      >
+        ▶ Play Level-1 Priya (trust prototype)
+      </button>
     </div>
   );
 }

--- a/mtgoa-game/src/api/client.ts
+++ b/mtgoa-game/src/api/client.ts
@@ -1,0 +1,55 @@
+/**
+ * AI client configuration and transport.
+ *
+ * The three AI integration points (intake, NPC generation, resolution narrative)
+ * are documented in the Migration Brief § AI Integration Points. This module is
+ * the shared transport.
+ *
+ * SECURITY: This is a browser SPA. The Anthropic API key must NEVER ship to the
+ * client, so these helpers POST to a same-origin backend endpoint that holds the
+ * key and proxies to the Anthropic SDK server-side. When no endpoint is
+ * configured, every call degrades gracefully to a deterministic local fallback
+ * (the project's dual-track principle: the game must work without a model).
+ *
+ * MODEL: defaulted to claude-opus-4-8 (current most-capable Opus; the canonical
+ * default). The Migration Brief references claude-sonnet-4 / Fable 5 — swap
+ * AI_MODEL here if a different model is desired. The model id is sent to the
+ * backend, which is responsible for the actual Anthropic SDK call.
+ */
+
+export const AI_MODEL = "claude-opus-4-8" as const;
+
+/** Base path of the AI proxy backend. Empty string disables remote calls. */
+export const AI_ENDPOINT: string =
+  (import.meta.env?.VITE_AI_ENDPOINT as string | undefined) ?? "";
+
+export const aiEnabled = (): boolean => AI_ENDPOINT.trim().length > 0;
+
+export interface AiRequest {
+  /** One of: "intake" | "npc-generator" | "resolution". */
+  kind: string;
+  system: string;
+  /** Free-form structured input for the call. */
+  input: unknown;
+  model?: string;
+}
+
+/**
+ * POST an AI request to the backend proxy. Returns parsed JSON of type T.
+ * Throws if the backend is unreachable or returns a non-2xx — callers wrap this
+ * and fall back to deterministic content.
+ */
+export async function callAi<T>(req: AiRequest): Promise<T> {
+  if (!aiEnabled()) {
+    throw new Error("AI endpoint not configured");
+  }
+  const res = await fetch(`${AI_ENDPOINT}/${req.kind}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: req.model ?? AI_MODEL, system: req.system, input: req.input }),
+  });
+  if (!res.ok) {
+    throw new Error(`AI proxy ${req.kind} failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}

--- a/mtgoa-game/src/api/intake.ts
+++ b/mtgoa-game/src/api/intake.ts
@@ -1,0 +1,57 @@
+/**
+ * AI Integration Point #1 — Applied Mode Intake.
+ *
+ * Migration Brief: "Conversational — guides player through 6 unpacking questions.
+ * Final output: structured JSON game config." Core Architecture § Six Unpacking
+ * Questions maps each answer to a game parameter.
+ *
+ * This module owns the system prompt and the structured output contract. The
+ * conversational UI (IntakeConversation) calls `intakeStep` per turn; the final
+ * turn returns a `config`. Without an AI backend, intake is unavailable and the
+ * UI should route the player to Character Select instead (dual-track).
+ */
+import { callAi, aiEnabled } from "./client";
+import type { Element } from "@/data/channels";
+
+export const INTAKE_SYSTEM = `You are the intake guide for "Mastering the Game of Allyship" (Applied Mode).
+Walk the player through the Six Unpacking Questions, one at a time, conversationally:
+1. What experience do you want to create?            → milestone
+2. What satisfied emotional state will that get you? → target channel
+3. Compared to that, what is life like right now?    → stakes / forest pressure
+4. How does it feel to live here?                    → stuck channel(s) (surface COMPOUND emotions: betrayal = Water+Fire, shame = Water+Metal)
+5. What would have to be true for someone to feel this way? → root epiphany (hidden card)
+6. What reservations do you have about your creation?      → forest seeds
+
+Ask warmly, reflect back, and only advance when the answer is real. After question 6,
+emit the final structured game config. Channels are the five Wuxing elements:
+Wood, Fire, Earth, Metal, Water.`;
+
+export interface IntakeConfig {
+  milestoneTitle: string;
+  milestoneBody: string;
+  targetChannel: Element;
+  stuckChannels: Element[];
+  epiphany: string;
+  forestSeeds: string[];
+}
+
+export interface IntakeTurn {
+  /** Assistant message to show the player. */
+  message: string;
+  /** Present only on the final turn. */
+  config?: IntakeConfig;
+}
+
+export interface IntakeHistoryItem {
+  role: "assistant" | "user";
+  text: string;
+}
+
+export async function intakeStep(history: IntakeHistoryItem[]): Promise<IntakeTurn> {
+  if (!aiEnabled()) {
+    throw new Error(
+      "Applied Mode intake requires an AI backend. Use Character Select mode instead.",
+    );
+  }
+  return callAi<IntakeTurn>({ kind: "intake", system: INTAKE_SYSTEM, input: { history } });
+}

--- a/mtgoa-game/src/api/npcGenerator.ts
+++ b/mtgoa-game/src/api/npcGenerator.ts
@@ -1,0 +1,42 @@
+/**
+ * AI Integration Point #2 — NPC Generation.
+ *
+ * Migration Brief: "Single call — generates fully realized NPC from situation
+ * seed. Output: JSON with all six-question answers + game parameters. Can be
+ * pre-generated and cached (finite combinatorial space)."
+ *
+ * The eight test NPCs in src/data/npcs.ts are the canonical, pre-generated cache.
+ * This module generates a NEW NPC from a free-text situation seed when an AI
+ * backend is available; otherwise it returns null and the caller falls back to
+ * the canonical roster.
+ */
+import { callAi, aiEnabled } from "./client";
+import type { NpcProfile } from "@/data/npcs";
+
+export const NPC_GENERATOR_SYSTEM = `You generate a fully realized NPC for "Mastering the Game of Allyship"
+from a one-line situation seed. Run the seed through the Six Unpacking Questions and
+return a complete NPC profile matching the game's schema:
+- face: one of Shaman | Challenger | Regent | Architect | Diplomat | Sage
+- superpower: one of Strategist | Connector | Storyteller | Alchemist | Disruptor | Escape Artist
+- stuckChannels: one or more of Wood | Fire | Earth | Metal | Water (surface COMPOUND emotions)
+- targetChannel: one Wuxing element
+- startingStress: 0–7, calibrated to complexity
+- sixQuestions, milestone {title, body}, forestSeeds[]
+- shadowDeck[] (6 cards, weighted across stuck channels, each with a counter move)
+- lightDeck[] (post-conversion cooperation moves)
+The NPC must be a node in a network — also an ally to someone else.`;
+
+/** Returns a generated NPC, or null to fall back to the canonical roster. */
+export async function generateNpc(situationSeed: string): Promise<NpcProfile | null> {
+  if (!aiEnabled()) return null;
+  try {
+    const { npc } = await callAi<{ npc: NpcProfile }>({
+      kind: "npc-generator",
+      system: NPC_GENERATOR_SYSTEM,
+      input: { situationSeed },
+    });
+    return npc;
+  } catch {
+    return null;
+  }
+}

--- a/mtgoa-game/src/api/resolution.ts
+++ b/mtgoa-game/src/api/resolution.ts
@@ -1,0 +1,49 @@
+/**
+ * AI Integration Point #3 — Resolution Narrative.
+ *
+ * Migration Brief: "Called after each successful situation resolution. Context:
+ * milestone + domain + moves played + NPC state. Output: 2–3 sentence narrative
+ * confirmation. This is the emotional payoff moment — needs to feel personal."
+ *
+ * Degrades gracefully to a deterministic, template-built narrative when no AI
+ * backend is configured.
+ */
+import { callAi, aiEnabled } from "./client";
+import type { NpcProfile } from "@/data/npcs";
+
+export const RESOLUTION_SYSTEM = `You write the emotional payoff narration for "Mastering the Game of Allyship".
+Given a milestone, the move just played, and the NPC's state, write 2–3 sentences
+confirming what just happened between the player and the NPC. Second person, present
+tense, grounded and specific — never generic. Honor the NPC's developmental Face and
+their compound emotional state. Do not summarize game mechanics; describe the human moment.`;
+
+export interface ResolutionContext {
+  npc: Pick<NpcProfile, "name" | "face" | "milestone">;
+  moveName: string;
+  converted: boolean;
+  npcStress: number;
+}
+
+export async function resolutionNarrative(ctx: ResolutionContext): Promise<string> {
+  if (aiEnabled()) {
+    try {
+      const { text } = await callAi<{ text: string }>({
+        kind: "resolution",
+        system: RESOLUTION_SYSTEM,
+        input: ctx,
+      });
+      return text;
+    } catch {
+      // fall through to deterministic narration
+    }
+  }
+  return fallbackResolution(ctx);
+}
+
+function fallbackResolution(ctx: ResolutionContext): string {
+  const { npc, moveName, converted } = ctx;
+  if (converted) {
+    return `${npc.name} stops performing and meets your eyes. Something shifts — the wall they built isn't gone, but for the first time you're on the same side of it. "${npc.milestone.title}" suddenly feels possible.`;
+  }
+  return `You play ${moveName}. ${npc.name} doesn't soften all at once, but the room loosens by a degree. You're still in it together, and that's the point.`;
+}

--- a/mtgoa-game/src/components/BARTracker.tsx
+++ b/mtgoa-game/src/components/BARTracker.tsx
@@ -1,0 +1,35 @@
+/**
+ * BARTracker — the four BAR types (Core Architecture § The BAR Economy).
+ * Show Up is the score; it carries the milestone target.
+ */
+import { BAR_META, BAR_TYPES, type BarLedger } from "@/engine/bars";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  bars: BarLedger;
+  showUpTarget: number;
+}
+
+const accent: Record<string, string> = {
+  wakeUp: "text-cognitive",
+  cleanUp: "text-water",
+  growUp: "text-relational",
+  showUp: "text-accent",
+};
+
+export function BARTracker({ bars, showUpTarget }: Props) {
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {BAR_TYPES.map((t) => (
+        <div key={t} className="flex flex-col rounded-md border border-border bg-surf px-2 py-1.5">
+          <span className="ds-label text-muted">{BAR_META[t].label}</span>
+          <span className={cn("text-lg font-bold tabular-nums", accent[t])}>
+            {bars[t]}
+            {t === "showUp" && <span className="text-xs text-muted">/{showUpTarget}</span>}
+          </span>
+          <span className="text-[9px] leading-tight text-muted">{BAR_META[t].function}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/ChannelDisplay.tsx
+++ b/mtgoa-game/src/components/ChannelDisplay.tsx
@@ -1,0 +1,39 @@
+/**
+ * ChannelDisplay — Wuxing channel energy readout.
+ * Shows each element's glyph, name, and current pool amount in its token color.
+ */
+import { CHANNELS, ELEMENTS, type ChannelPool } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  pool: ChannelPool;
+}
+
+export function ChannelDisplay({ pool }: Props) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ELEMENTS.map((el) => {
+        const def = CHANNELS[el];
+        const amount = pool[el] ?? 0;
+        return (
+          <div
+            key={el}
+            className={cn(
+              "flex min-w-[64px] flex-col items-center rounded-md border bg-surf px-2 py-1.5",
+              channelClass[el].border,
+              amount === 0 && "opacity-40",
+            )}
+            title={`${def.element} · ${def.emotion} · ${def.quality}`}
+          >
+            <span className={cn("text-lg leading-none", channelClass[el].text)}>{def.glyph}</span>
+            <span className="ds-label mt-1 text-muted">{el}</span>
+            <span className={cn("text-sm font-bold tabular-nums", channelClass[el].text)}>
+              {amount}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/DomainCard.tsx
+++ b/mtgoa-game/src/components/DomainCard.tsx
@@ -1,0 +1,25 @@
+/**
+ * DomainCard — a domain/situation tile (Core Architecture § The Four Domains).
+ * Shows the domain's purpose and, when available, the NPC's domain relevance text.
+ */
+import type { DomainName } from "@/data/domains";
+import { DOMAINS } from "@/data/domains";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+
+interface Props {
+  domain: DomainName;
+  relevance?: string;
+}
+
+export function DomainCard({ domain, relevance }: Props) {
+  const def = DOMAINS[domain];
+  return (
+    <Card className="bg-surf">
+      <CardHeader>
+        <CardTitle className="text-sm">{def.name}</CardTitle>
+        <span className="ds-label text-muted">{def.purpose}</span>
+      </CardHeader>
+      {relevance && <CardContent className="text-[11px]">{relevance}</CardContent>}
+    </Card>
+  );
+}

--- a/mtgoa-game/src/components/MoveCard.tsx
+++ b/mtgoa-game/src/components/MoveCard.tsx
@@ -1,0 +1,86 @@
+/**
+ * MoveCard — a player card with play / metabolize / exile actions.
+ * Shadow cards expose the alchemy cost ladder (Core Architecture § Dual-State Deck).
+ */
+import type { MoveCard as MoveCardData } from "@/data/moves";
+import { CHANNELS } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { RULES } from "@/engine/rules";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { cn } from "@/lib/utils";
+
+const typeColor: Record<string, string> = {
+  emotional: "text-emotional",
+  relational: "text-relational",
+  cognitive: "text-cognitive",
+  action: "text-action",
+};
+
+interface Props {
+  card: MoveCardData;
+  /** Names of NPC shadows currently on the board this card could counter. */
+  counterableNames?: string[];
+  onPlay: (id: string) => void;
+  onMetabolize: (id: string) => void;
+  onExile: (id: string) => void;
+  disabled?: boolean;
+}
+
+export function MoveCard({ card, counterableNames = [], onPlay, onMetabolize, onExile, disabled }: Props) {
+  const isShadow = card.state === "shadow";
+  const ch = channelClass[card.channel];
+  const counters = card.counters && counterableNames.includes(card.counters);
+
+  return (
+    <div
+      className={cn(
+        "flex w-44 flex-col gap-2 rounded-card border bg-card p-2.5",
+        isShadow ? "border-fire/50" : ch.border,
+        counters && "ring-2 ring-accent",
+      )}
+    >
+      <div className="flex items-start justify-between gap-1">
+        <span className="text-card-title font-bold leading-tight text-text">{card.name}</span>
+        <span className={cn("text-base leading-none", ch.text)}>{CHANNELS[card.channel].glyph}</span>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        <Badge className={cn("bg-surf", ch.text)}>{card.channel}</Badge>
+        <Badge className={cn("bg-surf", typeColor[card.type])}>{card.type}</Badge>
+        {isShadow && <Badge className="bg-fire/20 text-fire">shadow</Badge>}
+        {card.provisional && <Badge className="bg-surf text-muted">provisional</Badge>}
+      </div>
+
+      <p className="text-card-body leading-snug text-dim">{card.text}</p>
+
+      <div className="mt-auto flex flex-col gap-1">
+        <Button size="sm" variant={counters ? "default" : "subtle"} disabled={disabled} onClick={() => onPlay(card.id)}>
+          {counters ? `Counter ${card.counters}` : "Play"}
+        </Button>
+        {isShadow && (
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              className="flex-1"
+              disabled={disabled}
+              onClick={() => onMetabolize(card.id)}
+            >
+              Metabolize ({RULES.alchemy.metabolizeCost})
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="flex-1"
+              disabled={disabled}
+              onClick={() => onExile(card.id)}
+            >
+              Exile ({RULES.alchemy.exileCost})
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/NPCProfile.tsx
+++ b/mtgoa-game/src/components/NPCProfile.tsx
@@ -1,0 +1,91 @@
+/**
+ * NPCProfile — the encounter card. Surfaces the NPC's Face, Superpower, compound
+ * stuck channels, milestone, and (optionally) their full six-question profile.
+ */
+import type { NpcProfile as NpcData } from "@/data/npcs";
+import { FACES } from "@/data/npcs";
+import { CHANNELS } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Badge } from "./ui/badge";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  npc: NpcData;
+  /** Show the full six-question intake (used on the encounter screen). */
+  expanded?: boolean;
+}
+
+export function NPCProfile({ npc, expanded }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">{npc.name}</CardTitle>
+          <span className="text-xs text-muted">{npc.age}</span>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          <Badge className="bg-surf text-accent" title={FACES[npc.face].coreQuestion}>
+            {npc.face}
+          </Badge>
+          <Badge className="bg-surf text-dim">{npc.superpower}</Badge>
+          {npc.stuckChannels.map((el) => (
+            <Badge key={el} className={cn("bg-surf", channelClass[el].text)}>
+              {CHANNELS[el].glyph} {el}
+            </Badge>
+          ))}
+          <Badge className={cn("bg-surf", channelClass[npc.targetChannel].text)}>
+            → {npc.targetChannel}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div>
+          <span className="ds-label text-muted">Milestone — {npc.milestone.title}</span>
+          <p className="mt-1 text-dim">{npc.milestone.body}</p>
+        </div>
+
+        {npc.note && <p className="text-[11px] italic text-muted">{npc.note}</p>}
+
+        {expanded && (
+          <>
+            <SixQuestions npc={npc} />
+            <div>
+              <span className="ds-label text-muted">Forest Seeds</span>
+              <ul className="mt-1 list-disc pl-4 text-dim">
+                {npc.forestSeeds.map((s) => (
+                  <li key={s}>{s}</li>
+                ))}
+              </ul>
+            </div>
+            <p className="text-[11px] text-muted">
+              Also allying with: <span className="text-dim">{npc.alsoAllyingWith}</span>
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SixQuestions({ npc }: { npc: NpcData }) {
+  const q = npc.sixQuestions;
+  const rows: [string, string][] = [
+    ["Wants to create", q.experience],
+    ["Satisfied state", q.satisfiedState],
+    ["Life right now", q.currentLife],
+    ["How it feels", q.howItFeels],
+    ["Epiphany (hidden)", q.epiphany],
+  ];
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="ds-label text-muted">Six Questions</span>
+      {rows.map(([label, val]) => (
+        <div key={label} className="text-[11px]">
+          <span className="text-muted">{label}: </span>
+          <span className="text-dim">{val}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/NPCShadowCard.tsx
+++ b/mtgoa-game/src/components/NPCShadowCard.tsx
@@ -1,0 +1,31 @@
+/**
+ * NPCShadowCard — an NPC resistance card on the board, showing its effect and
+ * the player move that counters it (Core Architecture § NPC Shadow Activation).
+ */
+import type { NpcShadowCard as ShadowData } from "@/data/npcs";
+import { CHANNELS } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { Badge } from "./ui/badge";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  card: ShadowData;
+}
+
+export function NPCShadowCard({ card }: Props) {
+  const ch = channelClass[card.channel];
+  return (
+    <div className={cn("flex w-44 flex-col gap-1.5 rounded-card border-2 border-fire/60 bg-card p-2.5")}>
+      <div className="flex items-start justify-between gap-1">
+        <span className="text-card-title font-bold leading-tight text-fire">{card.name}</span>
+        <span className={cn("text-base leading-none", ch.text)}>{CHANNELS[card.channel].glyph}</span>
+      </div>
+      <Badge className={cn("w-fit bg-surf", ch.text)}>{card.channel} shadow</Badge>
+      <p className="text-card-body leading-snug text-dim">{card.text}</p>
+      <div className="mt-1 rounded bg-surf px-2 py-1">
+        <span className="ds-label text-muted">Counter</span>
+        <span className="block text-card-body font-semibold text-relational">{card.counter}</span>
+      </div>
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/StressBar.tsx
+++ b/mtgoa-game/src/components/StressBar.tsx
@@ -1,0 +1,50 @@
+/**
+ * StressBar — a single 0–7 stress meter. Encounter/Domain screens render two
+ * (player + NPC) for the dual-state contagion view (Core Architecture § Stress).
+ */
+import { RULES } from "@/engine/rules";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  label: string;
+  value: number;
+  /** Whether contagion-threshold annotations should be shown. */
+  showThresholds?: boolean;
+}
+
+const MAX = RULES.stress.max;
+
+function segmentColor(i: number, value: number): string {
+  if (i >= value) return "bg-border";
+  if (i >= RULES.stress.dysregulationThreshold - 1) return "bg-fire";
+  if (i >= RULES.stress.sympatheticThreshold - 1) return "bg-earth";
+  if (i >= RULES.stress.contagionThreshold - 1) return "bg-water";
+  return "bg-relational";
+}
+
+export function StressBar({ label, value, showThresholds }: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between">
+        <span className="ds-label text-muted">{label} Stress</span>
+        <span className="text-sm font-bold tabular-nums text-dim">
+          {value}/{MAX}
+        </span>
+      </div>
+      <div className="flex gap-1" role="meter" aria-valuenow={value} aria-valuemax={MAX}>
+        {Array.from({ length: MAX }, (_, i) => (
+          <div key={i} className={cn("h-2.5 flex-1 rounded-sm", segmentColor(i, value))} />
+        ))}
+      </div>
+      {showThresholds && value >= RULES.stress.contagionThreshold && (
+        <span className="text-[10px] text-muted">
+          {value >= RULES.stress.dysregulationThreshold
+            ? "Dysregulation — action phase blocked"
+            : value >= RULES.stress.sympatheticThreshold
+              ? "Sympathetic state — can spend but not receive"
+              : "Contagion active — dysregulation spreads"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/mtgoa-game/src/components/ui/badge.tsx
+++ b/mtgoa-game/src/components/ui/badge.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/** Small uppercase tag, mirrors tokens.typography.label / .tag. */
+export function Badge({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-label",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/mtgoa-game/src/components/ui/button.tsx
+++ b/mtgoa-game/src/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+/**
+ * shadcn/ui-style Button. Variants map to the MTGOA dark game theme tokens.
+ */
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:pointer-events-none disabled:opacity-40",
+  {
+    variants: {
+      variant: {
+        default: "bg-accent text-bg hover:bg-accent/90",
+        outline: "border border-border bg-transparent text-dim hover:bg-surf hover:text-text",
+        ghost: "bg-transparent text-dim hover:bg-surf hover:text-text",
+        subtle: "bg-surf text-text hover:bg-card",
+      },
+      size: {
+        sm: "h-8 px-3",
+        md: "h-10 px-4",
+        lg: "h-12 px-6 text-base",
+      },
+    },
+    defaultVariants: { variant: "default", size: "md" },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />
+  ),
+);
+Button.displayName = "Button";
+
+export { buttonVariants };

--- a/mtgoa-game/src/components/ui/card.tsx
+++ b/mtgoa-game/src/components/ui/card.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/** shadcn/ui-style Card surfaces, themed to the MTGOA card token. */
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-card border border-border bg-card text-text", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col gap-1 p-3", className)} {...props} />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("text-card-title font-bold", className)} {...props} />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-3 pt-0 text-card-body text-dim", className)} {...props} />
+  ),
+);
+CardContent.displayName = "CardContent";

--- a/mtgoa-game/src/data/channels.ts
+++ b/mtgoa-game/src/data/channels.ts
@@ -1,0 +1,75 @@
+/**
+ * Wuxing Channel System — the five Taoist elements, each aligned to an emotional state.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § Emotional Alchemy.
+ * Generative cycle: Wood → Fire → Earth → Metal → Water → Wood.
+ * When a move generates a channel, it also generates +1 of the NEXT element in
+ * the cycle automatically (engine/alchemy.ts applies this).
+ */
+
+export type Element = "Wood" | "Fire" | "Earth" | "Metal" | "Water";
+
+export type Emotion = "Joy" | "Anger" | "Neutrality" | "Fear" | "Sadness";
+
+export interface ChannelDef {
+  element: Element;
+  glyph: string;
+  emotion: Emotion;
+  quality: string;
+  /** The next element in the generative (sheng) cycle. */
+  generates: Element;
+}
+
+export const CHANNELS: Record<Element, ChannelDef> = {
+  Wood: {
+    element: "Wood",
+    glyph: "木",
+    emotion: "Joy",
+    quality: "Growth, expansion, vision",
+    generates: "Fire",
+  },
+  Fire: {
+    element: "Fire",
+    glyph: "火",
+    emotion: "Anger",
+    quality: "Action, confrontation, boundary",
+    generates: "Earth",
+  },
+  Earth: {
+    element: "Earth",
+    glyph: "土",
+    emotion: "Neutrality",
+    quality: "Center, mediation, holding",
+    generates: "Metal",
+  },
+  Metal: {
+    element: "Metal",
+    glyph: "金",
+    emotion: "Fear",
+    quality: "Precision, perception, clarity",
+    generates: "Water",
+  },
+  Water: {
+    element: "Water",
+    glyph: "水",
+    emotion: "Sadness",
+    quality: "Flow, repair, depth",
+    generates: "Wood",
+  },
+};
+
+export const ELEMENTS: Element[] = ["Wood", "Fire", "Earth", "Metal", "Water"];
+
+/** The element generated downstream in the Wuxing cycle. */
+export function nextInCycle(element: Element): Element {
+  return CHANNELS[element].generates;
+}
+
+/** A bag of channel energy, keyed by element. Missing keys read as 0. */
+export type ChannelPool = Partial<Record<Element, number>>;
+
+/** Compound emotions documented in Core Architecture § Six Unpacking Questions. */
+export const COMPOUND_EMOTIONS: Record<string, Element[]> = {
+  Betrayal: ["Water", "Fire"], // sadness + anger
+  Shame: ["Water", "Metal"], // sadness + fear
+};

--- a/mtgoa-game/src/data/domains.ts
+++ b/mtgoa-game/src/data/domains.ts
@@ -1,0 +1,44 @@
+/**
+ * The Four Domains — where encounters are located and situations resolved.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § The Encounter Engine.
+ * Card acquisition follows the Pokemon model: each domain card carries a loot
+ * table (2–3 possible move cards) earned by resolving the situation, not bought.
+ */
+
+export type DomainName =
+  | "Gather Resources"
+  | "Raise Awareness"
+  | "Direct Action"
+  | "Skillful Organizing";
+
+export interface DomainDef {
+  name: DomainName;
+  purpose: string;
+}
+
+export const DOMAINS: Record<DomainName, DomainDef> = {
+  "Gather Resources": {
+    name: "Gather Resources",
+    purpose: "Increase available capacity",
+  },
+  "Raise Awareness": {
+    name: "Raise Awareness",
+    purpose: "Increase accuracy",
+  },
+  "Direct Action": {
+    name: "Direct Action",
+    purpose: "Create change",
+  },
+  "Skillful Organizing": {
+    name: "Skillful Organizing",
+    purpose: "Create stability",
+  },
+};
+
+export const DOMAIN_NAMES: DomainName[] = [
+  "Gather Resources",
+  "Raise Awareness",
+  "Direct Action",
+  "Skillful Organizing",
+];

--- a/mtgoa-game/src/data/milestones.ts
+++ b/mtgoa-game/src/data/milestones.ts
@@ -1,0 +1,20 @@
+/**
+ * Milestone Pool.
+ *
+ * Canonical source: each NPC's milestone (NPC Test Suite). In Character Select
+ * mode a milestone arrives bound to the chosen encounter NPC; in Applied Mode it
+ * is produced by the six-question intake (Core Architecture § Two Game Modes).
+ *
+ * The default victory target is 10 Show Up BARs (Core Architecture § Victory).
+ */
+import type { Milestone } from "./npcs";
+import { NPCS } from "./npcs";
+
+export const DEFAULT_SHOW_UP_TARGET = 10;
+
+/** Every NPC milestone, keyed by NPC id, for the Character Select flow. */
+export const MILESTONES_BY_NPC: Record<string, Milestone> = Object.fromEntries(
+  NPCS.map((n) => [n.id, n.milestone]),
+);
+
+export const MILESTONE_POOL: Milestone[] = NPCS.map((n) => n.milestone);

--- a/mtgoa-game/src/data/moves.ts
+++ b/mtgoa-game/src/data/moves.ts
@@ -1,0 +1,160 @@
+/**
+ * Move Cards — player-side card definitions and shared card primitives.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" (channels, card types,
+ * superpower shadows) and "NPC Test Suite" (the six named counter moves that
+ * appear in Priya's shadow deck).
+ *
+ * SCOPE NOTE: The docs specify the four card-TYPE colors, the per-superpower
+ * shadow NAMES, and the six canonical counter moves. They do NOT enumerate the
+ * full tiered player move catalog with channel costs/effects — that detail lived
+ * in the ~900-line artifact and is a deliberate design space. Cards below marked
+ * `provisional: true` are scaffolding stand-ins (clearly flagged, not canonical
+ * balance) so the engine is exercisable; canonical cards omit that flag.
+ */
+import type { Element } from "./channels";
+import type { SuperpowerName } from "./superpowers";
+import { SUPERPOWERS } from "./superpowers";
+
+/** Card-type taxonomy (colors from the design-system tokens). */
+export type CardType = "emotional" | "relational" | "cognitive" | "action";
+
+/** Light = cooperation/capacity move. Shadow = resistance/dysregulation move. */
+export type CardState = "light" | "shadow";
+
+export type CardTier = 1 | 2 | 3;
+
+export interface MoveCard {
+  id: string;
+  name: string;
+  state: CardState;
+  /** Primary Wuxing channel this card operates in / generates. */
+  channel: Element;
+  type: CardType;
+  tier: CardTier;
+  /** Player-facing description of what the card does. */
+  text: string;
+  /**
+   * If set, playing this move counters/metabolizes the NPC shadow card whose
+   * `counter` field names this move. Canonical for the six named counters.
+   */
+  counters?: string;
+  /** True for scaffolding stand-ins whose numbers are not canonical design. */
+  provisional?: boolean;
+}
+
+/**
+ * The six canonical counter moves, named in Priya's shadow deck (NPC Test Suite).
+ * Each metabolizes a specific shadow. Channel is inferred from the shadow family
+ * it answers (Water shadows ← Water/Earth holding moves; Fire shadows ← Fire
+ * naming moves), consistent with the Alchemy metabolize rule (pay matching channel).
+ */
+export const COUNTER_MOVES: MoveCard[] = [
+  {
+    id: "bear-witness",
+    name: "Bear Witness",
+    state: "light",
+    channel: "Water",
+    type: "emotional",
+    tier: 1,
+    text: "Stay present to what is real without fixing it. Metabolizes Performed Compliance.",
+    counters: "Performed Compliance",
+  },
+  {
+    id: "check-in",
+    name: "Check In",
+    state: "light",
+    channel: "Water",
+    type: "relational",
+    tier: 1,
+    text: "Reach toward the person who went quiet. Metabolizes Strategic Withdrawal.",
+    counters: "Strategic Withdrawal",
+  },
+  {
+    id: "name-the-feeling",
+    name: "Name the Feeling",
+    state: "light",
+    channel: "Water",
+    type: "emotional",
+    tier: 1,
+    text: "Put words to what is underneath the performance. Metabolizes Loyalty Performance.",
+    counters: "Loyalty Performance",
+  },
+  {
+    id: "sit-with-it",
+    name: "Sit With It",
+    state: "light",
+    channel: "Earth",
+    type: "emotional",
+    tier: 1,
+    text: "Hold the distance without rushing to close it. Metabolizes Managed Distance.",
+    counters: "Managed Distance",
+  },
+  {
+    id: "name-the-pattern",
+    name: "Name the Pattern",
+    state: "light",
+    channel: "Fire",
+    type: "cognitive",
+    tier: 1,
+    text: "Name the principle-as-armor without attacking the person. Metabolizes Righteous Detachment.",
+    counters: "Righteous Detachment",
+  },
+  {
+    id: "speak-up",
+    name: "Speak Up",
+    state: "light",
+    channel: "Fire",
+    type: "action",
+    tier: 1,
+    text: "Say the true thing before the door closes. Metabolizes Pre-emptive Exit.",
+    counters: "Pre-emptive Exit",
+  },
+];
+
+/**
+ * Provisional generic player moves, one per element in each card type, used by
+ * the deck builder to fill out a starting hand when no canonical superpower
+ * catalog is available. NUMBERS/EFFECTS ARE SCAFFOLDING, NOT CANONICAL DESIGN.
+ */
+function provisionalMove(
+  channel: Element,
+  type: CardType,
+  state: CardState,
+  label: string,
+): MoveCard {
+  return {
+    id: `prov-${state}-${channel}-${type}-${label}`.toLowerCase().replace(/\s+/g, "-"),
+    name: label,
+    state,
+    channel,
+    type,
+    tier: 1,
+    text:
+      state === "light"
+        ? `Generate ${channel} channel. (Provisional move — replace with canonical ${channel} card.)`
+        : `Generate ${channel} channel but add 1 Stress. (Provisional shadow — replace with canonical card.)`,
+    provisional: true,
+  };
+}
+
+/**
+ * Provisional shadow cards seeded from a Superpower's documented shadow names.
+ * The names are canonical; the channel mapping uses the archetype's affinity and
+ * the effects are provisional.
+ */
+export function shadowSeedsForSuperpower(name: SuperpowerName): MoveCard[] {
+  const def = SUPERPOWERS[name];
+  return def.shadows.map((shadowName, i) => ({
+    id: `shadow-${name}-${i}`.toLowerCase().replace(/\s+/g, "-"),
+    name: shadowName,
+    state: "shadow" as const,
+    channel: def.channels[i % def.channels.length],
+    type: "emotional" as CardType,
+    tier: 1 as CardTier,
+    text: `${shadowName}: generate ${def.channels[i % def.channels.length]} channel but add 1 Stress until metabolized. (Effect provisional.)`,
+    provisional: true,
+  }));
+}
+
+export { provisionalMove };

--- a/mtgoa-game/src/data/npcs.ts
+++ b/mtgoa-game/src/data/npcs.ts
@@ -1,0 +1,565 @@
+/**
+ * NPC Roster — the eight pre-generated encounter characters.
+ *
+ * Canonical source: "MTGOA Game — NPC Test Suite". Each NPC was run through the
+ * Six Unpacking Questions and is a node in a network (also an ally to someone).
+ *
+ * Priya (NPC 008) is the hardest test case and the only NPC whose light/shadow
+ * decks are fully specified in the docs; her decks are encoded verbatim. The
+ * other seven carry full six-question profiles, milestones, and forest seeds;
+ * their decks are generated at encounter time from their channels + face (see
+ * engine/combat.ts) until canonical decks are authored.
+ */
+import type { Element } from "./channels";
+import type { SuperpowerName } from "./superpowers";
+import type { DomainName } from "./domains";
+
+/** Six Faces — NPC developmental altitudes (Core Architecture § The Six Faces). */
+export type Face =
+  | "Shaman"
+  | "Challenger"
+  | "Regent"
+  | "Architect"
+  | "Diplomat"
+  | "Sage";
+
+export const FACES: Record<Face, { coreQuestion: string }> = {
+  Shaman: { coreQuestion: "What matters?" },
+  Challenger: { coreQuestion: "Can I assert agency?" },
+  Regent: { coreQuestion: "Can I create order?" },
+  Architect: { coreQuestion: "Can I create effectiveness?" },
+  Diplomat: { coreQuestion: "Can we belong together?" },
+  Sage: { coreQuestion: "How does everything fit?" },
+};
+
+/** The six-question intake profile (Core Architecture § NPC Architecture). */
+export interface SixQuestions {
+  experience: string; // Q1 → milestone
+  satisfiedState: string; // Q2 → target channel
+  currentLife: string; // Q3 → stakes / forest pressure
+  howItFeels: string; // Q4 → stuck channel(s)
+  epiphany: string; // Q5 → root epiphany (hidden card)
+  reservations: string[]; // Q6 → forest seeds
+}
+
+/** Structured mechanical effect of an NPC shadow card (canonical for Priya). */
+export interface NpcShadowEffect {
+  /** Blocks the player's relational moves this round. */
+  blockRelational?: boolean;
+  /** No milestone progress is possible this round. */
+  skipProgress?: boolean;
+  /** Appears to progress but yields nothing real. */
+  falseProgress?: boolean;
+  /** Player loses N of the named channel. */
+  drainChannel?: { element: Element; amount: number };
+  /** Named card-type costs +N of the named channel to play this round. */
+  channelTax?: { element: Element; amount: number; affects: "action" };
+  /** Player gains N stress immediately. */
+  playerStress?: number;
+}
+
+export interface NpcShadowCard {
+  id: string;
+  name: string;
+  channel: Element;
+  text: string;
+  effect: NpcShadowEffect;
+  /** Name of the player move that metabolizes this shadow. */
+  counter: string;
+}
+
+/** Structured mechanical effect of an NPC light card (post-conversion). */
+export interface NpcLightEffect {
+  /** Player gains N of the named channel. */
+  playerChannel?: { element: Element; amount: number };
+  /** Player stress delta (negative = relief). */
+  playerStress?: number;
+  /** Reveals the epiphany card. */
+  revealEpiphany?: boolean;
+  /** Grants a Show Up BAR (victory point), optionally to both. */
+  showUpBar?: { both: boolean };
+  /** Advances the milestone by N. */
+  milestoneDelta?: number;
+}
+
+export interface NpcLightCard {
+  id: string;
+  name: string;
+  text: string;
+  effect: NpcLightEffect;
+}
+
+export interface Milestone {
+  title: string;
+  body: string;
+}
+
+export interface NpcProfile {
+  id: string; // e.g. "npc-008"
+  name: string;
+  age: string;
+  face: Face;
+  superpower: SuperpowerName;
+  /** One stuck element, or a compound (e.g. Priya = Water + Fire = betrayal). */
+  stuckChannels: Element[];
+  targetChannel: Element;
+  startingStress: number;
+  alsoAllyingWith: string;
+  note?: string;
+  sixQuestions: SixQuestions;
+  milestone: Milestone;
+  domainRelevance?: Partial<Record<DomainName, string>>;
+  forestSeeds: string[];
+  /** Fully authored only for Priya; empty arrays = generated at encounter time. */
+  shadowDeck: NpcShadowCard[];
+  lightDeck: NpcLightCard[];
+}
+
+// ---------------------------------------------------------------------------
+// NPC 001 — DARA
+// ---------------------------------------------------------------------------
+const DARA: NpcProfile = {
+  id: "npc-001",
+  name: "Dara",
+  age: "late 30s",
+  face: "Diplomat",
+  superpower: "Connector",
+  stuckChannels: ["Water"],
+  targetChannel: "Earth",
+  startingStress: 2,
+  alsoAllyingWith: "Someone in the coalition who feels unheard",
+  sixQuestions: {
+    experience:
+      "A space where people who disagree can still work together toward something real.",
+    satisfiedState: "Relief. Like the ground is solid again. Like I can breathe.",
+    currentLife:
+      "Every meeting ends in a smaller room than it started. People are choosing sides and I'm watching the thing I built fall apart.",
+    howItFeels:
+      "Exhausted and invisible. Like I'm holding something together that doesn't want to be held.",
+    epiphany: "What if belonging doesn't require agreement — only shared stakes?",
+    reservations: [
+      "If I name the conflict directly it will make things worse",
+      "I'm the wrong person to bridge this — I'm too close to one side",
+      "The people who are leaving have already decided",
+    ],
+  },
+  milestone: {
+    title: "Hold the coalition together",
+    body: "Your community organization is fracturing. People you've worked alongside for years are choosing sides. You're at the center of it — which means you're also the only one positioned to hold it.",
+  },
+  domainRelevance: {
+    "Gather Resources":
+      "Find the relational bandwidth to stay present with people who are pulling away",
+    "Raise Awareness":
+      "Understand what the conflict is actually about beneath the presenting issue",
+    "Direct Action": "Name what's happening and create a container for the harder conversation",
+    "Skillful Organizing":
+      "Build agreements that can hold disagreement without dissolving the coalition",
+  },
+  forestSeeds: [
+    "The conflict names itself before you're ready",
+    "A key member announces they're leaving",
+    "You lose your own center mid-facilitation",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 002 — MARCUS
+// ---------------------------------------------------------------------------
+const MARCUS: NpcProfile = {
+  id: "npc-002",
+  name: "Marcus",
+  age: "mid 40s",
+  face: "Regent",
+  superpower: "Strategist",
+  stuckChannels: ["Metal"],
+  targetChannel: "Fire",
+  startingStress: 3,
+  alsoAllyingWith: "The person who was harmed in that meeting",
+  sixQuestions: {
+    experience:
+      "To have addressed it in a way that creates safety rather than just covering myself.",
+    satisfiedState: "Integrity. Like my inside and outside match.",
+    currentLife: "I keep telling myself the moment passed. But it didn't pass — I let it pass.",
+    howItFeels: "Shame wearing the costume of pragmatism.",
+    epiphany: "The window didn't close — I closed it. And I can open it again.",
+    reservations: [
+      "Going back to it now will make it about me, not them",
+      "I don't know enough about what the affected person actually needs",
+      "Naming it publicly will embarrass the person who said it and create more conflict",
+    ],
+  },
+  milestone: {
+    title: "Go back to what you didn't address",
+    body: "Three weeks ago something harmful was said in a meeting you led. You said nothing. The moment didn't pass — you let it pass. You want to go back to it. You're not sure how.",
+  },
+  domainRelevance: {
+    "Gather Resources": "Build the clarity and courage to re-open something that feels closed",
+    "Raise Awareness":
+      "Understand what the person most affected actually needs — not what you assume",
+    "Direct Action": "Make contact. Name what happened. Create space for what comes next.",
+    "Skillful Organizing": "Establish new norms in your team so this has less room to happen again",
+  },
+  forestSeeds: [
+    "The affected person seems to have moved on",
+    "Your own guilt makes it about you",
+    "A colleague tells you to let it go",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 003 — YUKI
+// ---------------------------------------------------------------------------
+const YUKI: NpcProfile = {
+  id: "npc-003",
+  name: "Yuki",
+  age: "late 20s",
+  face: "Challenger",
+  superpower: "Disruptor",
+  stuckChannels: ["Fire"],
+  targetChannel: "Earth",
+  startingStress: 3,
+  alsoAllyingWith: "A colleague who privately agreed but publicly stayed silent",
+  sixQuestions: {
+    experience:
+      "To stay in this organization and keep telling the truth without it costing me everything.",
+    satisfiedState:
+      "Grounded. Like I can stand somewhere solid and not have to choose between integrity and survival.",
+    currentLife:
+      "I said the true thing and the room went cold. Now I'm technically included and functionally invisible.",
+    howItFeels: "Like I'm being slowly edited out of my own presence.",
+    epiphany:
+      "The organization didn't reject my truth — it revealed something about its relationship to truth.",
+    reservations: [
+      "Speaking up again will confirm I'm a problem",
+      "The people with power have already made their assessment",
+      "I don't have enough standing yet to push on this",
+    ],
+  },
+  milestone: {
+    title: "Stay true without disappearing",
+    body: "You spoke up early and paid a social price. Now you're navigating how to remain yourself inside a system that has quietly signaled it prefers a smaller version of you.",
+  },
+  domainRelevance: {
+    "Gather Resources": "Find the allies and inner resources to stay grounded in contested ground",
+    "Raise Awareness": "Understand the system you're in clearly enough to move skillfully within it",
+    "Direct Action": "Speak again — differently, strategically, without swallowing the truth",
+    "Skillful Organizing": "Build relationships that can hold your full presence over time",
+  },
+  forestSeeds: [
+    "A second truth gets dismissed",
+    "An ally goes quiet",
+    "You start self-censoring without noticing",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 004 — BEV
+// ---------------------------------------------------------------------------
+const BEV: NpcProfile = {
+  id: "npc-004",
+  name: "Bev",
+  age: "early 60s",
+  face: "Sage",
+  superpower: "Storyteller",
+  stuckChannels: ["Water"],
+  targetChannel: "Wood",
+  startingStress: 1,
+  alsoAllyingWith: "A community member who stopped coming to meetings",
+  sixQuestions: {
+    experience: "I want the organization to find its way back to the people it forgot.",
+    satisfiedState:
+      "Like the work means what it used to mean. Like I'm not the only one who notices.",
+    currentLife:
+      "Meetings are full of the right language and empty of the people that language is supposed to be about.",
+    howItFeels: "Grief. And a kind of tired loyalty I haven't figured out how to put down.",
+    epiphany: "Memory is an act of allyship when everyone else has moved on.",
+    reservations: [
+      "I've raised this before and nothing changed",
+      "The people making decisions now weren't here for what I'm describing",
+      "I might be romanticizing the past",
+    ],
+  },
+  milestone: {
+    title: "Bring the organization back to itself",
+    body: "You remember what this org was built for. The current leadership doesn't — or has forgotten. You want to close the gap between the mission on paper and the community being served.",
+  },
+  forestSeeds: [
+    "Leadership reframes your concern as nostalgia",
+    "A key community member stops showing up",
+    "Your own grief makes it hard to be strategic",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 005 — THEO
+// ---------------------------------------------------------------------------
+const THEO: NpcProfile = {
+  id: "npc-005",
+  name: "Theo",
+  age: "early 30s",
+  face: "Architect",
+  superpower: "Escape Artist",
+  stuckChannels: ["Metal"],
+  targetChannel: "Fire",
+  startingStress: 2,
+  alsoAllyingWith: "A user who is directly affected by the accessibility gap",
+  sixQuestions: {
+    experience:
+      "One real conversation where this gets treated as a structural issue, not a nice-to-have.",
+    satisfiedState: "Like I'm working somewhere that means what it says about inclusion.",
+    currentLife:
+      "Every workaround I build gets shipped as a feature. The underlying problem stays untouched.",
+    howItFeels: "Complicit. Like my competence is being used to paper over something I believe is wrong.",
+    epiphany: "The backlog isn't where good ideas go to wait. It's where accountability goes to die.",
+    reservations: [
+      "I don't have enough organizational capital to push on this",
+      "The right people will hear it as criticism rather than problem-solving",
+      "If I make it a values issue I'll be seen as difficult",
+    ],
+  },
+  milestone: {
+    title: "Make the invisible harm visible",
+    body: "You keep fixing symptoms of an accessibility problem that isn't getting fixed. You want one real conversation that treats this as a structural issue — not a feature request, not a backlog item.",
+  },
+  forestSeeds: [
+    "Your fix gets shipped without the conversation",
+    "A sympathetic leader gets reassigned",
+    "You get labeled as the accessibility person and quietly sidelined",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 006 — AMARA
+// ---------------------------------------------------------------------------
+const AMARA: NpcProfile = {
+  id: "npc-006",
+  name: "Amara",
+  age: "mid 30s",
+  face: "Shaman",
+  superpower: "Alchemist",
+  stuckChannels: ["Earth"],
+  targetChannel: "Water",
+  startingStress: 2,
+  alsoAllyingWith: "Her friend who is grieving",
+  sixQuestions: {
+    experience: "To be genuinely present for her without my own stuff getting in the way.",
+    satisfiedState:
+      "Clear. Like I'm actually with her instead of managing the distance between us.",
+    currentLife:
+      "I catch myself giving her interventions instead of presence. I'm being a therapist when she needs a friend.",
+    howItFeels: "Split. Professionally competent and personally unavailable.",
+    epiphany:
+      "The training that taught me to hold space taught me to hold distance. I need to unlearn enough of it to actually show up.",
+    reservations: [
+      "If I let myself feel my own grief I won't be able to hold hers",
+      "She doesn't know I'm struggling too — telling her would make it about me",
+      "I've been performing presence for so long I'm not sure I know what the real thing feels like",
+    ],
+  },
+  milestone: {
+    title: "Be a friend, not a therapist",
+    body: "Someone you love is grieving. You have every tool for holding pain — and they're getting in the way of actually being with her. You want to show up as yourself, not your training.",
+  },
+  forestSeeds: [
+    "Your friend asks for advice and you default to the clinical frame",
+    "Your own grief surfaces at the wrong moment",
+    "She notices the distance and names it",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 007 — JEROME (compound stuck: Metal + Water)
+// ---------------------------------------------------------------------------
+const JEROME: NpcProfile = {
+  id: "npc-007",
+  name: "Jerome",
+  age: "late 40s",
+  face: "Challenger",
+  superpower: "Connector",
+  stuckChannels: ["Metal", "Water"],
+  targetChannel: "Wood",
+  startingStress: 4,
+  alsoAllyingWith: "The family facing eviction",
+  note: "Jerome's stuck state is compound. The fear (Metal) of failure combines with the sadness (Water) of anticipated loss. His shadow deck draws from both channels.",
+  sixQuestions: {
+    experience:
+      "To get this family housed. And to do it in a way that doesn't burn out the people who keep showing up.",
+    satisfiedState: "Like the community I've been building actually works when it matters.",
+    currentLife: "I have a network. I have relationships. I keep not making the ask.",
+    howItFeels: "Like I'm standing in front of a door I built and can't open.",
+    epiphany:
+      "The ask feels like a burden because I haven't let myself believe the community wants to give.",
+    reservations: [
+      "People are tapped out — I've asked too recently",
+      "If this doesn't work it will prove something I don't want proved",
+      "Asking for someone else feels less legitimate than asking for a cause",
+    ],
+  },
+  milestone: {
+    title: "Make the ask before the 72 hours run out",
+    body: "A family needs housing in 72 hours. You have a network that could make this happen. The only thing between the resource and the need is you making the ask. You haven't made it yet.",
+  },
+  forestSeeds: [
+    "The first three asks come back as no",
+    "You second-guess the framing mid-send",
+    "Someone asks why you're doing this and not a formal org",
+  ],
+  shadowDeck: [],
+  lightDeck: [],
+};
+
+// ---------------------------------------------------------------------------
+// NPC 008 — PRIYA (compound stuck: Water + Fire = betrayal) — FULLY AUTHORED
+// ---------------------------------------------------------------------------
+const PRIYA: NpcProfile = {
+  id: "npc-008",
+  name: "Priya",
+  age: "early 40s",
+  face: "Diplomat",
+  superpower: "Storyteller",
+  stuckChannels: ["Water", "Fire"],
+  targetChannel: "Fire",
+  startingStress: 4,
+  alsoAllyingWith: "An employee whose advancement depended on the programs being cut",
+  note: "Priya is the hardest test case. Compound stuck emotions (betrayal = sadness + anger), high starting stress, Diplomat shadow patterns. If mechanics work for her they work for everyone.",
+  sixQuestions: {
+    experience:
+      "To protect what's actually working and find a way to keep doing the real work inside a hostile container.",
+    satisfiedState: "Purposeful. Like I'm still moving something that matters even when the ground shifts.",
+    currentLife:
+      "The announcement was made without me in the room. I'm being asked to communicate a decision I wasn't part of.",
+    howItFeels: "Betrayed. And unsure whether staying is integrity or complicity.",
+    epiphany:
+      "The institution was never the mission. The people are the mission. The question is whether I can still reach them from here.",
+    reservations: [
+      "Staying means being the face of something I didn't choose",
+      "Leaving means abandoning the people who have no one else",
+      "Whatever I say publicly will be used to legitimize the decision",
+    ],
+  },
+  milestone: {
+    title: "Find what's still possible inside the constraint",
+    body: "Your company rolled back the DEI programs you built. You weren't in the room. Now you're being asked to communicate the decision. You need to figure out what integrity looks like from inside this.",
+  },
+  forestSeeds: [
+    "A colleague you trust announces they're leaving",
+    "You're asked to present the rollback positively to employees",
+    "Someone you've supported publicly calls you out for staying",
+  ],
+  // Shadow Deck (Water + Fire compound) — verbatim from NPC Test Suite.
+  shadowDeck: [
+    {
+      id: "priya-s-performed-compliance",
+      name: "Performed Compliance",
+      channel: "Water",
+      text: "Says yes, does nothing. Blocks relational moves.",
+      effect: { blockRelational: true },
+      counter: "Bear Witness",
+    },
+    {
+      id: "priya-s-strategic-withdrawal",
+      name: "Strategic Withdrawal",
+      channel: "Water",
+      text: "Goes quiet. No progress this round.",
+      effect: { skipProgress: true },
+      counter: "Check In",
+    },
+    {
+      id: "priya-s-loyalty-performance",
+      name: "Loyalty Performance",
+      channel: "Water",
+      text: "Performs okayness. Looks like progress but isn't.",
+      effect: { falseProgress: true },
+      counter: "Name the Feeling",
+    },
+    {
+      id: "priya-s-managed-distance",
+      name: "Managed Distance",
+      channel: "Water",
+      text: "Stays but unavailable. Player loses 1 Water channel.",
+      effect: { drainChannel: { element: "Water", amount: 1 } },
+      counter: "Sit With It",
+    },
+    {
+      id: "priya-s-righteous-detachment",
+      name: "Righteous Detachment",
+      channel: "Fire",
+      text: "Makes it about principle. Action moves cost +1 Fire.",
+      effect: { channelTax: { element: "Fire", amount: 1, affects: "action" } },
+      counter: "Name the Pattern",
+    },
+    {
+      id: "priya-s-pre-emptive-exit",
+      name: "Pre-emptive Exit",
+      channel: "Fire",
+      text: "Starts looking for the door. Player +2 Stress.",
+      effect: { playerStress: 2 },
+      counter: "Speak Up",
+    },
+  ],
+  // Light Deck (post-conversion) — verbatim from NPC Test Suite.
+  lightDeck: [
+    {
+      id: "priya-l-names-it-first",
+      name: "She Names It First",
+      text: "Stops performing, names what happened. +1 Fire for player.",
+      effect: { playerChannel: { element: "Fire", amount: 1 } },
+    },
+    {
+      id: "priya-l-stays-in-the-room",
+      name: "She Stays in the Room",
+      text: "Her presence stabilizes. Player -1 Stress.",
+      effect: { playerStress: -1 },
+    },
+    {
+      id: "priya-l-shares-the-real-thing",
+      name: "She Shares the Real Thing",
+      text: "Says the true thing. Epiphany revealed.",
+      effect: { revealEpiphany: true },
+    },
+    {
+      id: "priya-l-makes-the-ask",
+      name: "She Makes the Ask",
+      text: "Requests what she needs. Show Up BAR for both.",
+      effect: { showUpBar: { both: true } },
+    },
+    {
+      id: "priya-l-chooses-to-stay",
+      name: "She Chooses to Stay",
+      text: "Decides to fight from inside. Milestone +2.",
+      effect: { milestoneDelta: 2 },
+    },
+  ],
+};
+
+export const NPCS: NpcProfile[] = [
+  DARA,
+  MARCUS,
+  YUKI,
+  BEV,
+  THEO,
+  AMARA,
+  JEROME,
+  PRIYA,
+];
+
+export const NPCS_BY_ID: Record<string, NpcProfile> = Object.fromEntries(
+  NPCS.map((n) => [n.id, n]),
+);
+
+export function getNpc(id: string): NpcProfile | undefined {
+  return NPCS_BY_ID[id];
+}

--- a/mtgoa-game/src/data/superpowers.ts
+++ b/mtgoa-game/src/data/superpowers.ts
@@ -1,0 +1,82 @@
+/**
+ * Superpower Archetypes — the player's identity and deck archetype.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § Superpower Archetypes.
+ * Each Superpower determines channel affinity, what the player perceives, their
+ * shadow patterns, and a synergy bonus triggered by 3 matching cards in one turn.
+ */
+import type { Element } from "./channels";
+
+export type SuperpowerName =
+  | "Strategist"
+  | "Connector"
+  | "Storyteller"
+  | "Alchemist"
+  | "Disruptor"
+  | "Escape Artist";
+
+export interface SuperpowerDef {
+  name: SuperpowerName;
+  /** Two-element channel affinity. */
+  channels: [Element, Element];
+  /** What this archetype perceives most readily. */
+  sees: string;
+  /** Characteristic shadow patterns (used to weight the starting shadow deck). */
+  shadows: string[];
+  /** Triggered when 3 matching-channel cards are played in one turn. */
+  synergyBonus: string;
+}
+
+export const SUPERPOWERS: Record<SuperpowerName, SuperpowerDef> = {
+  Strategist: {
+    name: "Strategist",
+    channels: ["Metal", "Earth"],
+    sees: "Leverage and structure",
+    shadows: ["Overcautious Analysis", "Detached Competence", "Analysis Paralysis"],
+    synergyBonus: "Reveal one face-down NPC shadow card",
+  },
+  Connector: {
+    name: "Connector",
+    channels: ["Water", "Wood"],
+    sees: "Relationships and belonging",
+    shadows: ["Conflict Avoidance", "Performed Warmth", "Loyalty Bind"],
+    synergyBonus: "+2 to all relational moves this round",
+  },
+  Storyteller: {
+    name: "Storyteller",
+    channels: ["Wood", "Fire"],
+    sees: "Narratives and meaning",
+    shadows: ["Narrative Takeover", "Performed Emotion", "Story Collapse"],
+    synergyBonus: "Next scenario card costs 1 less power to resolve",
+  },
+  Alchemist: {
+    name: "Alchemist",
+    channels: ["Water", "Earth"],
+    sees: "Transformations",
+    shadows: ["Spiritual Bypass", "Premature Resolution", "Holding Too Long"],
+    synergyBonus: "Metabolize one NPC shadow card for free",
+  },
+  Disruptor: {
+    name: "Disruptor",
+    channels: ["Fire", "Metal"],
+    sees: "Contradictions and what needs naming",
+    shadows: ["Righteous Detachment", "Bulldozing", "Confrontation for Its Own Sake"],
+    synergyBonus: "Counter any NPC shadow card regardless of type",
+  },
+  "Escape Artist": {
+    name: "Escape Artist",
+    channels: ["Wood", "Metal"],
+    sees: "Alternatives and exits",
+    shadows: ["Premature Pivot", "Avoidant Reframe", "Clever Deflection"],
+    synergyBonus: "Treat one exhausted domain as having 1 card remaining",
+  },
+};
+
+export const SUPERPOWER_NAMES: SuperpowerName[] = [
+  "Strategist",
+  "Connector",
+  "Storyteller",
+  "Alchemist",
+  "Disruptor",
+  "Escape Artist",
+];

--- a/mtgoa-game/src/engine/__tests__/completability.sim.test.ts
+++ b/mtgoa-game/src/engine/__tests__/completability.sim.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Completability simulation — does a REACHABLE win path exist?
+ *
+ * The existing engine.test.ts proves mechanics fire when *forced* (it hand-sets
+ * npcStress: 7, injects all six counters, and injects showUp: target). This sim
+ * instead plays the real reducer from a real starting deck under a reasonable
+ * greedy policy, for every superpower vs Priya, and reports the outcome it can
+ * actually reach. It asserts nothing about balance — it just surfaces the truth.
+ *
+ * Run: npm test -- completability
+ */
+import { describe, it } from "vitest";
+
+import { reducer, initialState, type GameState } from "../gameState";
+import { SUPERPOWER_NAMES, type SuperpowerName } from "@/data/superpowers";
+
+const TURN_CAP = 100;
+
+/** One greedy player phase, then END_TURN. Returns the next state. */
+function playerTurn(state: GameState): GameState {
+  let s = state;
+
+  // 1) Counter every active shadow we hold a counter for (free metabolize).
+  let acted = true;
+  while (acted) {
+    acted = false;
+    for (const shadow of s.activeShadows) {
+      const counter = s.hand.find(
+        (c) => c.state === "light" && c.name === shadow.counter,
+      );
+      if (counter) {
+        s = reducer(s, { type: "PLAY_MOVE", cardId: counter.id });
+        acted = true;
+        break;
+      }
+    }
+  }
+
+  // 2) If not yet converted and no shadow will surface next turn (npcStress < 3)
+  //    while shadows remain, play one hand shadow to push her stress up so the
+  //    next shadow activates and can be countered.
+  if (!s.converted) {
+    const shadowsLeft = (s.npcDecks?.shadow ?? []).filter(
+      (sh) => !s.metabolizedShadowIds.includes(sh.id),
+    );
+    const noneActiveSoon = s.npcStress < 3 && s.activeShadows.length === 0;
+    if (shadowsLeft.length > 0 && noneActiveSoon) {
+      const ownShadow = s.hand.find((c) => c.state === "shadow");
+      if (ownShadow) s = reducer(s, { type: "PLAY_MOVE", cardId: ownShadow.id });
+    }
+  }
+
+  return reducer(s, { type: "END_TURN" });
+}
+
+function runEncounter(superpower: SuperpowerName) {
+  let s = initialState();
+  s = reducer(s, { type: "SELECT_MODE", mode: "character-select" });
+  s = reducer(s, { type: "SELECT_SUPERPOWER", superpower });
+  s = reducer(s, { type: "SELECT_ENCOUNTER", npcId: "npc-008" });
+  s = reducer(s, { type: "ENTER_DOMAIN" });
+
+  const counters = s.hand.filter((c) => c.state === "light" && c.counters).length;
+
+  let guard = 0;
+  while (s.result === null && guard < TURN_CAP) {
+    s = playerTurn(s);
+    guard += 1;
+  }
+
+  return {
+    superpower,
+    counters,
+    result: s.result ?? "SOFTLOCK (no terminal state)",
+    turns: s.turn,
+    converted: s.converted,
+    metabolized: s.metabolizedShadowIds.length,
+    showUp: s.bars.showUp,
+    showUpTarget: s.showUpTarget,
+    playerStress: s.playerStress,
+    npcStress: s.npcStress,
+  };
+}
+
+describe("completability — every superpower vs Priya (real play)", () => {
+  it("reports the reachable outcome for each superpower", () => {
+    const rows = SUPERPOWER_NAMES.map(runEncounter);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      "\n=== Priya completability (real starting deck, greedy policy) ===",
+    );
+    for (const r of rows) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `${r.superpower.padEnd(13)} | counters:${r.counters} ` +
+          `| ${String(r.result).padEnd(28)} | turns:${String(r.turns).padStart(3)} ` +
+          `| converted:${r.converted ? "Y" : "n"} metab:${r.metabolized}/6 ` +
+          `| showUp:${r.showUp}/${r.showUpTarget} ` +
+          `| stress P${r.playerStress}/N${r.npcStress}`,
+      );
+    }
+    const wins = rows.filter((r) => r.result === "win").length;
+    // eslint-disable-next-line no-console
+    console.log(`\nWINNABLE PATHS FOUND: ${wins} / ${rows.length}\n`);
+  });
+});

--- a/mtgoa-game/src/engine/__tests__/engine.test.ts
+++ b/mtgoa-game/src/engine/__tests__/engine.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Engine smoke test — the Verification Quest for the migrated mechanics.
+ *
+ * Proves the canonical rules from the design docs actually run: the Wuxing
+ * generative cycle, Priya's authored decks, stress contagion, the
+ * metabolize → convert threshold, and the Show Up victory condition.
+ */
+import { describe, expect, it } from "vitest";
+
+import { generateChannel, metabolize, poolGet } from "../alchemy";
+import { activeShadowCount, resolveNpcDecks } from "../combat";
+import { reducer, initialState, type GameState } from "../gameState";
+import { COUNTER_MOVES } from "@/data/moves";
+import { getNpc } from "@/data/npcs";
+
+describe("alchemy — Wuxing generative cycle", () => {
+  it("generating a channel also yields +1 of the next element (Water → Wood)", () => {
+    const pool = generateChannel({}, "Water");
+    expect(poolGet(pool, "Water")).toBe(1);
+    expect(poolGet(pool, "Wood")).toBe(1); // downstream in the sheng cycle
+  });
+
+  it("metabolize fails without enough matching channel, succeeds with it", () => {
+    expect(metabolize({}, "Fire").ok).toBe(false);
+    const res = metabolize({ Fire: 2 }, "Fire");
+    expect(res.ok).toBe(true);
+    expect(poolGet(res.pool, "Fire")).toBe(1);
+  });
+});
+
+describe("combat — shadow activation + authored decks", () => {
+  it("activates shadows by NPC stress band (0/1/2/3)", () => {
+    expect(activeShadowCount(2)).toBe(0);
+    expect(activeShadowCount(3)).toBe(1);
+    expect(activeShadowCount(5)).toBe(2);
+    expect(activeShadowCount(7)).toBe(3);
+  });
+
+  it("Priya ships authored decks; other NPCs are generated", () => {
+    const priya = resolveNpcDecks(getNpc("npc-008")!);
+    expect(priya.generated).toBe(false);
+    expect(priya.shadow).toHaveLength(6);
+    expect(priya.light).toHaveLength(5);
+
+    const dara = resolveNpcDecks(getNpc("npc-001")!);
+    expect(dara.generated).toBe(true);
+    expect(dara.shadow).toHaveLength(6);
+  });
+});
+
+/** Drive the reducer from the menu into a live Priya encounter. */
+function enterPriyaDomain(): GameState {
+  let s = initialState();
+  s = reducer(s, { type: "SELECT_MODE", mode: "character-select" });
+  s = reducer(s, { type: "SELECT_SUPERPOWER", superpower: "Storyteller" });
+  s = reducer(s, { type: "SELECT_ENCOUNTER", npcId: "npc-008" });
+  s = reducer(s, { type: "ENTER_DOMAIN" });
+  return s;
+}
+
+describe("reducer — full Priya encounter", () => {
+  it("sets up Priya with her starting stress and authored decks", () => {
+    const s = enterPriyaDomain();
+    expect(s.phase).toBe("domain");
+    expect(s.npc?.name).toBe("Priya");
+    expect(s.npcStress).toBe(4); // canonical starting stress
+    expect(s.npcDecks?.generated).toBe(false);
+  });
+
+  it("NPC plays a shadow on END_TURN, raising player stress (contagion)", () => {
+    const s = enterPriyaDomain();
+    const next = reducer(s, { type: "END_TURN" });
+    expect(next.activeShadows.length).toBe(1);
+    expect(next.playerStress).toBe(s.playerStress + 1);
+  });
+
+  it("metabolizing 3 shadows with their counters converts Priya to an ally", () => {
+    // Give the player every canonical counter, and crank NPC stress so 3
+    // shadows are active per turn.
+    let s = enterPriyaDomain();
+    s = { ...s, npcStress: 7, hand: COUNTER_MOVES.map((c) => ({ ...c })) };
+
+    // Each cycle: NPC surfaces a shadow, player plays its counter.
+    for (let i = 0; i < 3 && !s.converted; i++) {
+      s = reducer(s, { type: "END_TURN" });
+      const shadow = s.activeShadows[s.activeShadows.length - 1];
+      expect(shadow).toBeDefined();
+      const counter = s.hand.find((c) => c.name === shadow.counter);
+      expect(counter, `counter for ${shadow.name}`).toBeDefined();
+      s = reducer(s, { type: "PLAY_MOVE", cardId: counter!.id });
+    }
+
+    expect(s.metabolizedShadowIds.length).toBeGreaterThanOrEqual(3);
+    expect(s.converted).toBe(true);
+    expect(s.bars.growUp).toBeGreaterThanOrEqual(1); // conversion grants a Grow Up BAR
+  });
+});
+
+describe("reducer — victory", () => {
+  it("declares a win once Show Up BARs hit the milestone target", () => {
+    let s = enterPriyaDomain();
+    s = { ...s, converted: true, bars: { ...s.bars, showUp: s.showUpTarget } };
+    s = reducer(s, { type: "END_TURN" }); // any action runs the end-evaluation
+    expect(s.result).toBe("win");
+    expect(s.phase).toBe("end");
+  });
+});

--- a/mtgoa-game/src/engine/alchemy.ts
+++ b/mtgoa-game/src/engine/alchemy.ts
@@ -1,0 +1,70 @@
+/**
+ * Emotional Alchemy — channel generation (Wuxing cycle), metabolize, exile.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § Emotional Alchemy.
+ *   - Generative cycle: generating a channel also yields +1 of the next element.
+ *   - Dual-state deck cost ladder: play (+stress) / metabolize (channel) / exile (higher channel).
+ */
+import type { ChannelPool, Element } from "@/data/channels";
+import { nextInCycle } from "@/data/channels";
+import { RULES } from "./rules";
+
+export function emptyPool(): ChannelPool {
+  return {};
+}
+
+export function poolGet(pool: ChannelPool, element: Element): number {
+  return pool[element] ?? 0;
+}
+
+export function addToPool(pool: ChannelPool, element: Element, amount: number): ChannelPool {
+  return { ...pool, [element]: poolGet(pool, element) + amount };
+}
+
+/**
+ * Generate channel energy. Per the Wuxing generative cycle, +1 of `element` also
+ * produces +1 of the next element downstream (Water → +Water +Wood).
+ */
+export function generateChannel(pool: ChannelPool, element: Element): ChannelPool {
+  const withPrimary = addToPool(pool, element, 1);
+  return addToPool(withPrimary, nextInCycle(element), 1);
+}
+
+/** Whether the player can afford to spend `amount` of `element`. */
+export function canSpend(pool: ChannelPool, element: Element, amount: number): boolean {
+  return poolGet(pool, element) >= amount;
+}
+
+export function spendChannel(pool: ChannelPool, element: Element, amount: number): ChannelPool {
+  return addToPool(pool, element, -amount);
+}
+
+export interface AlchemyResult {
+  ok: boolean;
+  pool: ChannelPool;
+  reason?: string;
+}
+
+/**
+ * Metabolize a shadow: pay the matching channel cost → it flips to light.
+ * Returns ok:false (unchanged pool) if the player can't pay.
+ */
+export function metabolize(pool: ChannelPool, channel: Element): AlchemyResult {
+  const cost = RULES.alchemy.metabolizeCost;
+  if (!canSpend(pool, channel, cost)) {
+    return { ok: false, pool, reason: `Need ${cost} ${channel} to metabolize` };
+  }
+  return { ok: true, pool: spendChannel(pool, channel, cost) };
+}
+
+/**
+ * Exile a shadow: pay the higher channel cost → removed from the deck permanently
+ * (the deck gets more efficient). Caller is responsible for removing the card.
+ */
+export function exile(pool: ChannelPool, channel: Element): AlchemyResult {
+  const cost = RULES.alchemy.exileCost;
+  if (!canSpend(pool, channel, cost)) {
+    return { ok: false, pool, reason: `Need ${cost} ${channel} to exile` };
+  }
+  return { ok: true, pool: spendChannel(pool, channel, cost) };
+}

--- a/mtgoa-game/src/engine/bars.ts
+++ b/mtgoa-game/src/engine/bars.ts
@@ -1,0 +1,36 @@
+/**
+ * BAR Economy.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § The BAR Economy.
+ *
+ *   Wake Up  → expand the map (unlock scenario tiers / ally types)
+ *   Clean Up → spendable energy, the primary currency (Dominion money model)
+ *   Grow Up  → gate permissions / tier unlocks
+ *   Show Up  → victory points (the score)
+ */
+
+export type BarType = "wakeUp" | "cleanUp" | "growUp" | "showUp";
+
+export type BarLedger = Record<BarType, number>;
+
+export const BAR_META: Record<BarType, { label: string; function: string }> = {
+  wakeUp: { label: "Wake Up", function: "Expand the map" },
+  cleanUp: { label: "Clean Up", function: "Spendable energy" },
+  growUp: { label: "Grow Up", function: "Gate permissions" },
+  showUp: { label: "Show Up", function: "Victory points" },
+};
+
+export const BAR_TYPES: BarType[] = ["wakeUp", "cleanUp", "growUp", "showUp"];
+
+export function emptyLedger(): BarLedger {
+  return { wakeUp: 0, cleanUp: 0, growUp: 0, showUp: 0 };
+}
+
+export function addBar(ledger: BarLedger, type: BarType, amount = 1): BarLedger {
+  return { ...ledger, [type]: ledger[type] + amount };
+}
+
+/** Win when Show Up BARs reach the milestone target (default 10). */
+export function hasReachedShowUpTarget(ledger: BarLedger, target: number): boolean {
+  return ledger.showUp >= target;
+}

--- a/mtgoa-game/src/engine/combat.ts
+++ b/mtgoa-game/src/engine/combat.ts
@@ -1,0 +1,145 @@
+/**
+ * Combat — NPC turn logic: shadow activation, conversion, card selection.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" (§ Stress System, § NPC
+ * Architecture, § NPC Conversion Threshold) and the Migration Brief (§ NPC
+ * Architecture). Priya ships with fully authored decks; the other seven NPCs get
+ * decks generated from their channels + face here (flagged provisional) until
+ * canonical decks are authored.
+ */
+import type { Element } from "@/data/channels";
+import type {
+  NpcLightCard,
+  NpcProfile,
+  NpcShadowCard,
+} from "@/data/npcs";
+import { RULES } from "./rules";
+
+/** How many of the NPC's shadow cards are active, by NPC stress. */
+export function activeShadowCount(npcStress: number): number {
+  const band = RULES.npcShadowActivation.find(
+    (b) => npcStress >= b.min && npcStress <= b.max,
+  );
+  return band?.active ?? 0;
+}
+
+/** Shadows reveal once NPC stress ≥ contagion threshold (Migration Brief). */
+export function shadowsRevealed(npcStress: number): boolean {
+  return npcStress >= RULES.stress.contagionThreshold;
+}
+
+/** NPC crosses to ally once enough shadows are metabolized (3 of 6). */
+export function isConverted(metabolizedShadowIds: string[]): boolean {
+  return metabolizedShadowIds.length >= RULES.conversion.shadowsToMetabolize;
+}
+
+// --- Deck generation for NPCs without authored decks (all but Priya) ---------
+
+function genShadowDeck(npc: NpcProfile): NpcShadowCard[] {
+  const channels = npc.stuckChannels;
+  // Spread six provisional shadows across the NPC's stuck channel(s).
+  return Array.from({ length: RULES.conversion.totalShadows }, (_, i) => {
+    const channel: Element = channels[i % channels.length];
+    return {
+      id: `${npc.id}-s-${i}`,
+      name: `${channel} Resistance ${i + 1}`,
+      channel,
+      text: `Provisional ${channel} shadow for ${npc.name}. Generate ${channel}; player +1 Stress.`,
+      effect: { playerStress: 1 },
+      counter: "—",
+    };
+  });
+}
+
+function genLightDeck(npc: NpcProfile): NpcLightCard[] {
+  const target = npc.targetChannel;
+  const cards: NpcLightCard[] = [
+    {
+      id: `${npc.id}-l-0`,
+      name: `${npc.name} Names It`,
+      text: `Provisional light move. +1 ${target} for player.`,
+      effect: { playerChannel: { element: target, amount: 1 } },
+    },
+    {
+      id: `${npc.id}-l-1`,
+      name: `${npc.name} Stays Present`,
+      text: "Provisional light move. Player -1 Stress.",
+      effect: { playerStress: -1 },
+    },
+    {
+      id: `${npc.id}-l-2`,
+      name: `${npc.name} Shares the Real Thing`,
+      text: "Provisional light move. Epiphany revealed.",
+      effect: { revealEpiphany: true },
+    },
+    {
+      id: `${npc.id}-l-3`,
+      name: `${npc.name} Makes the Ask`,
+      text: "Provisional light move. Show Up BAR for both.",
+      effect: { showUpBar: { both: true } },
+    },
+    {
+      id: `${npc.id}-l-4`,
+      name: `${npc.name} Commits`,
+      text: "Provisional light move. Milestone +2.",
+      effect: { milestoneDelta: 2 },
+    },
+  ];
+  return cards;
+}
+
+export interface NpcDecks {
+  shadow: NpcShadowCard[];
+  light: NpcLightCard[];
+  /** True when decks were generated (provisional), false for authored (Priya). */
+  generated: boolean;
+}
+
+/** Returns the NPC's decks, generating provisional ones when none are authored. */
+export function resolveNpcDecks(npc: NpcProfile): NpcDecks {
+  if (npc.shadowDeck.length > 0 && npc.lightDeck.length > 0) {
+    return { shadow: npc.shadowDeck, light: npc.lightDeck, generated: false };
+  }
+  return { shadow: genShadowDeck(npc), light: genLightDeck(npc), generated: true };
+}
+
+// --- NPC card selection ------------------------------------------------------
+
+export interface NpcTurnContext {
+  npc: NpcProfile;
+  decks: NpcDecks;
+  npcStress: number;
+  converted: boolean;
+  /** Shadow ids already metabolized (excluded from shadow selection). */
+  metabolizedShadowIds: string[];
+  /** Light card ids already played (so light moves don't repeat). */
+  playedLightIds: string[];
+}
+
+export type NpcPlay =
+  | { kind: "shadow"; card: NpcShadowCard }
+  | { kind: "light"; card: NpcLightCard }
+  | { kind: "none" };
+
+/**
+ * Decide the NPC's play for the turn.
+ *  - Post-conversion: play a light move if one remains, else a shadow.
+ *  - Pre-conversion: play the next active, un-metabolized shadow (if any active).
+ */
+export function npcChooseCard(ctx: NpcTurnContext): NpcPlay {
+  if (ctx.converted) {
+    const nextLight = ctx.decks.light.find((c) => !ctx.playedLightIds.includes(c.id));
+    if (nextLight) return { kind: "light", card: nextLight };
+  }
+
+  const activeCount = activeShadowCount(ctx.npcStress);
+  if (activeCount === 0) return { kind: "none" };
+
+  const available = ctx.decks.shadow.filter(
+    (c) => !ctx.metabolizedShadowIds.includes(c.id),
+  );
+  const active = available.slice(0, activeCount);
+  if (active.length === 0) return { kind: "none" };
+
+  return { kind: "shadow", card: active[active.length - 1] };
+}

--- a/mtgoa-game/src/engine/deckBuilder.ts
+++ b/mtgoa-game/src/engine/deckBuilder.ts
@@ -1,0 +1,65 @@
+/**
+ * Deck Builder — constructs the player's starting deck by Superpower.
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" § Card Acquisition / Deck
+ * Size (start: 12 cards = 5 light, 4 shadow, 3 alchemy-type free).
+ *
+ * Light cards are seeded from the canonical counter moves whose channel matches
+ * the archetype's affinity, then topped up with provisional channel cards. Shadow
+ * cards come from the archetype's documented shadow names. Provisional cards are
+ * flagged on the card (`provisional`) and are NOT canonical balance.
+ */
+import type { MoveCard } from "@/data/moves";
+import { COUNTER_MOVES, provisionalMove, shadowSeedsForSuperpower } from "@/data/moves";
+import type { SuperpowerName } from "@/data/superpowers";
+import { SUPERPOWERS } from "@/data/superpowers";
+import type { Element } from "@/data/channels";
+import { RULES } from "./rules";
+
+export interface PlayerDeck {
+  superpower: SuperpowerName;
+  cards: MoveCard[];
+}
+
+function pickLightCards(channels: [Element, Element], count: number): MoveCard[] {
+  // Prefer canonical counter moves in the archetype's channels.
+  const onAffinity = COUNTER_MOVES.filter((c) => channels.includes(c.channel));
+  const chosen: MoveCard[] = [...onAffinity].slice(0, count);
+
+  // Top up with provisional light cards alternating across the two channels.
+  let i = 0;
+  while (chosen.length < count) {
+    const channel = channels[i % channels.length];
+    const type = i % 2 === 0 ? "relational" : "cognitive";
+    chosen.push(provisionalMove(channel, type, "light", `${channel} Opening ${i + 1}`));
+    i += 1;
+  }
+  return chosen.map((c, idx) => ({ ...c, id: `${c.id}-d${idx}` }));
+}
+
+/** Three "alchemy-type" free cards (Earth/Water holding moves). Provisional. */
+function freeCards(count: number): MoveCard[] {
+  const elements: Element[] = ["Water", "Earth", "Water"];
+  return Array.from({ length: count }, (_, i) =>
+    provisionalMove(elements[i % elements.length], "emotional", "light", `Alchemy Free ${i + 1}`),
+  );
+}
+
+export function buildStartingDeck(superpower: SuperpowerName): PlayerDeck {
+  const def = SUPERPOWERS[superpower];
+  const { light, shadow, free } = RULES.startingDeck;
+
+  const lightCards = pickLightCards(def.channels, light);
+  const shadowCards = shadowSeedsForSuperpower(superpower).slice(0, shadow);
+  // Pad shadows if the archetype has fewer than `shadow` documented names.
+  while (shadowCards.length < shadow) {
+    const channel = def.channels[shadowCards.length % def.channels.length];
+    shadowCards.push(provisionalMove(channel, "emotional", "shadow", `${channel} Shadow ${shadowCards.length + 1}`));
+  }
+  const freeCardList = freeCards(free);
+
+  return {
+    superpower,
+    cards: [...lightCards, ...shadowCards, ...freeCardList],
+  };
+}

--- a/mtgoa-game/src/engine/gameState.ts
+++ b/mtgoa-game/src/engine/gameState.ts
@@ -1,0 +1,418 @@
+/**
+ * Game State Machine (useReducer).
+ *
+ * Canonical source: "MTGOA Game — Core Architecture" (stress, contagion, shadow
+ * activation, conversion, BAR economy, victory) and the Migration Brief
+ * (§ Core Mechanics Summary, § Priority build order #3 "useReducer with action
+ * types"). Pure reducer — no React, no I/O — so it is unit-testable in isolation.
+ *
+ * Where the docs leave a loop detail unstated, the choice is commented INTERP.
+ */
+import type { ChannelPool, Element } from "@/data/channels";
+import type { MoveCard } from "@/data/moves";
+import type { NpcLightCard, NpcProfile, NpcShadowCard } from "@/data/npcs";
+import type { SuperpowerName } from "@/data/superpowers";
+import { getNpc } from "@/data/npcs";
+
+import { RULES } from "./rules";
+import { emptyLedger, type BarLedger } from "./bars";
+import { buildStartingDeck, type PlayerDeck } from "./deckBuilder";
+import {
+  emptyPool,
+  generateChannel,
+  metabolize as metabolizeCost,
+  exile as exileCost,
+} from "./alchemy";
+import {
+  isConverted,
+  npcChooseCard,
+  resolveNpcDecks,
+  shadowsRevealed,
+  type NpcDecks,
+} from "./combat";
+
+export type GameMode = "character-select" | "applied";
+
+export type Phase =
+  | "mode-select"
+  | "superpower-select"
+  | "encounter"
+  | "domain"
+  | "end";
+
+export type GameResult = "win" | "loss-rupture" | "loss-exhaustion" | null;
+
+/** Round-scoped modifiers imposed by active NPC shadows (cleared each NPC turn). */
+export interface RoundModifiers {
+  blockRelational: boolean;
+  skipProgress: boolean;
+  /** Extra channel cost on a card type this round, e.g. action +1 Fire. */
+  actionTax: { element: Element; amount: number } | null;
+}
+
+export interface GameState {
+  mode: GameMode | null;
+  phase: Phase;
+  result: GameResult;
+
+  superpower: SuperpowerName | null;
+  deck: PlayerDeck | null;
+  /** Cards still in the player's usable hand (exiled/spent removed). */
+  hand: MoveCard[];
+
+  channels: ChannelPool;
+  bars: BarLedger;
+  playerStress: number;
+
+  npc: NpcProfile | null;
+  npcDecks: NpcDecks | null;
+  npcStress: number;
+  converted: boolean;
+  epiphanyRevealed: boolean;
+  milestoneProgress: number;
+  showUpTarget: number;
+
+  /** NPC shadow cards currently on the board awaiting a counter. */
+  activeShadows: NpcShadowCard[];
+  metabolizedShadowIds: string[];
+  exiledCardIds: string[];
+  playedLightIds: string[];
+
+  round: RoundModifiers;
+  turn: number;
+  log: string[];
+}
+
+export type Action =
+  | { type: "SELECT_MODE"; mode: GameMode }
+  | { type: "SELECT_SUPERPOWER"; superpower: SuperpowerName }
+  | { type: "SELECT_ENCOUNTER"; npcId: string }
+  | { type: "ENTER_DOMAIN" }
+  | { type: "PLAY_MOVE"; cardId: string }
+  | { type: "METABOLIZE_HAND_SHADOW"; cardId: string }
+  | { type: "EXILE_HAND_SHADOW"; cardId: string }
+  | { type: "END_TURN" }
+  | { type: "GOTO"; phase: Phase }
+  | { type: "RESET" };
+
+const clampStress = (n: number) =>
+  Math.max(RULES.stress.min, Math.min(RULES.stress.max, n));
+
+export function initialState(): GameState {
+  return {
+    mode: null,
+    phase: "mode-select",
+    result: null,
+    superpower: null,
+    deck: null,
+    hand: [],
+    channels: emptyPool(),
+    bars: emptyLedger(),
+    playerStress: 0,
+    npc: null,
+    npcDecks: null,
+    npcStress: 0,
+    converted: false,
+    epiphanyRevealed: false,
+    milestoneProgress: 0,
+    showUpTarget: RULES.victory.defaultShowUpTarget,
+    activeShadows: [],
+    metabolizedShadowIds: [],
+    exiledCardIds: [],
+    playedLightIds: [],
+    round: emptyRound(),
+    turn: 1,
+    log: [],
+  };
+}
+
+function emptyRound(): RoundModifiers {
+  return { blockRelational: false, skipProgress: false, actionTax: null };
+}
+
+function log(state: GameState, line: string): string[] {
+  return [...state.log, `T${state.turn}: ${line}`];
+}
+
+// --- Effect appliers ---------------------------------------------------------
+
+/** Apply an NPC light card's benefits to the player/board. */
+function applyNpcLight(state: GameState, card: NpcLightCard): GameState {
+  let next = { ...state };
+  const e = card.effect;
+  if (e.playerChannel) {
+    next.channels = { ...next.channels };
+    next.channels[e.playerChannel.element] =
+      (next.channels[e.playerChannel.element] ?? 0) + e.playerChannel.amount;
+  }
+  if (typeof e.playerStress === "number") {
+    next.playerStress = clampStress(next.playerStress + e.playerStress);
+  }
+  if (e.revealEpiphany) next.epiphanyRevealed = true;
+  if (e.showUpBar) next.bars = { ...next.bars, showUp: next.bars.showUp + 1 };
+  if (typeof e.milestoneDelta === "number") {
+    next.milestoneProgress += e.milestoneDelta;
+  }
+  // CANONICAL: NPC light move → player stress -1, milestone progress.
+  next.playerStress = clampStress(
+    next.playerStress + RULES.contagion.npcLightToPlayer,
+  );
+  next.milestoneProgress += 1;
+  next.playedLightIds = [...next.playedLightIds, card.id];
+  return next;
+}
+
+/** Put an NPC shadow on the board and apply its immediate contagion + effects. */
+function applyNpcShadow(state: GameState, card: NpcShadowCard): GameState {
+  let next = { ...state };
+  // CANONICAL: NPC shadow played → player stress +1.
+  next.playerStress = clampStress(
+    next.playerStress + RULES.contagion.npcShadowToPlayer,
+  );
+  const e = card.effect;
+  if (e.blockRelational) next.round = { ...next.round, blockRelational: true };
+  if (e.skipProgress) next.round = { ...next.round, skipProgress: true };
+  if (e.channelTax) {
+    next.round = {
+      ...next.round,
+      actionTax: { element: e.channelTax.element, amount: e.channelTax.amount },
+    };
+  }
+  if (e.drainChannel) {
+    next.channels = { ...next.channels };
+    next.channels[e.drainChannel.element] = Math.max(
+      0,
+      (next.channels[e.drainChannel.element] ?? 0) - e.drainChannel.amount,
+    );
+  }
+  if (typeof e.playerStress === "number") {
+    next.playerStress = clampStress(next.playerStress + e.playerStress);
+  }
+  next.activeShadows = [...next.activeShadows, card];
+  return next;
+}
+
+/** Win/loss evaluation (Core Architecture § Victory Structure). */
+function evaluateEnd(state: GameState): GameState {
+  if (state.bars.showUp >= state.showUpTarget) {
+    return { ...state, result: "win", phase: "end", log: log(state, "Milestone met — you win.") };
+  }
+  // INTERP: Rupture = collective stress overwhelms the table (both maxed).
+  if (
+    state.playerStress >= RULES.stress.max &&
+    state.npcStress >= RULES.stress.max
+  ) {
+    return {
+      ...state,
+      result: "loss-rupture",
+      phase: "end",
+      log: log(state, "Rupture — collective stress overwhelmed the table."),
+    };
+  }
+  // INTERP: Exhaustion = no shadows left, not converted, milestone unmet.
+  const shadowsLeft = state.npcDecks
+    ? state.npcDecks.shadow.filter((s) => !state.metabolizedShadowIds.includes(s.id))
+    : [];
+  if (
+    state.npcDecks &&
+    !state.converted &&
+    shadowsLeft.length === 0 &&
+    state.activeShadows.length === 0
+  ) {
+    return {
+      ...state,
+      result: "loss-exhaustion",
+      phase: "end",
+      log: log(state, "Exhaustion — the deck ran out before the milestone."),
+    };
+  }
+  return state;
+}
+
+// --- Reducer -----------------------------------------------------------------
+
+export function reducer(state: GameState, action: Action): GameState {
+  switch (action.type) {
+    case "SELECT_MODE":
+      return { ...state, mode: action.mode, phase: "superpower-select" };
+
+    case "SELECT_SUPERPOWER": {
+      const deck = buildStartingDeck(action.superpower);
+      return {
+        ...state,
+        superpower: action.superpower,
+        deck,
+        hand: deck.cards,
+        phase: "encounter",
+      };
+    }
+
+    case "SELECT_ENCOUNTER": {
+      // Empty id clears the current encounter (back-to-roster).
+      if (!action.npcId) {
+        return {
+          ...state,
+          npc: null,
+          npcDecks: null,
+          npcStress: 0,
+          activeShadows: [],
+          metabolizedShadowIds: [],
+          playedLightIds: [],
+          converted: false,
+          epiphanyRevealed: false,
+          milestoneProgress: 0,
+        };
+      }
+      const npc = getNpc(action.npcId);
+      if (!npc) return state;
+      const npcDecks = resolveNpcDecks(npc);
+      return {
+        ...state,
+        npc,
+        npcDecks,
+        npcStress: npc.startingStress,
+        showUpTarget: RULES.victory.defaultShowUpTarget,
+        log: log(state, `Encounter begins: ${npc.name} (${npc.face} · ${npc.superpower}).`),
+      };
+    }
+
+    case "ENTER_DOMAIN":
+      return { ...state, phase: "domain" };
+
+    case "PLAY_MOVE": {
+      if (!state.npc) return state;
+      const card = state.hand.find((c) => c.id === action.cardId);
+      if (!card) return state;
+
+      let next: GameState = { ...state };
+
+      if (card.state === "light") {
+        // Light move generates its channel (+ Wuxing downstream element).
+        next.channels = generateChannel(next.channels, card.channel);
+
+        // If it counters an active NPC shadow, metabolize that shadow.
+        const target = next.activeShadows.find((s) => s.counter === card.name);
+        if (target) {
+          // CANONICAL: metabolize NPC shadow → NPC stress -1, clear its round effect.
+          next.activeShadows = next.activeShadows.filter((s) => s.id !== target.id);
+          next.metabolizedShadowIds = [...next.metabolizedShadowIds, target.id];
+          next.npcStress = clampStress(
+            next.npcStress + RULES.contagion.metabolizeNpcShadow,
+          );
+          next.round = recomputeRound(next.activeShadows);
+          next.bars = { ...next.bars, cleanUp: next.bars.cleanUp + 1 };
+          next.log = log(next, `Played ${card.name} — metabolized ${target.name}.`);
+
+          if (!next.converted && isConverted(next.metabolizedShadowIds)) {
+            next.converted = true;
+            next.bars = { ...next.bars, growUp: next.bars.growUp + 1 };
+            next.log = log(next, `${state.npc.name} crosses the threshold — now an ally.`);
+          }
+        } else {
+          next.bars = { ...next.bars, wakeUp: next.bars.wakeUp + 1 };
+          next.log = log(next, `Played ${card.name} (+${card.channel}).`);
+        }
+      } else {
+        // Shadow played as-is: generate channel + add stress (cheap, costly).
+        next.channels = generateChannel(next.channels, card.channel);
+        next.playerStress = clampStress(
+          next.playerStress + RULES.alchemy.shadowPlayStress,
+        );
+        // CANONICAL: player shadow played → NPC stress +1.
+        next.npcStress = clampStress(
+          next.npcStress + RULES.contagion.playerShadowToNpc,
+        );
+        next.log = log(next, `Played shadow ${card.name} (+${card.channel}, +1 stress).`);
+      }
+
+      next.hand = next.hand.filter((c) => c.id !== card.id);
+      return evaluateEnd(next);
+    }
+
+    case "METABOLIZE_HAND_SHADOW": {
+      const card = state.hand.find((c) => c.id === action.cardId && c.state === "shadow");
+      if (!card) return state;
+      const res = metabolizeCost(state.channels, card.channel);
+      if (!res.ok) return { ...state, log: log(state, res.reason ?? "Cannot metabolize.") };
+      const flipped: MoveCard = { ...card, state: "light" };
+      return {
+        ...state,
+        channels: res.pool,
+        hand: state.hand.map((c) => (c.id === card.id ? flipped : c)),
+        bars: { ...state.bars, cleanUp: state.bars.cleanUp + 1 },
+        log: log(state, `Metabolized ${card.name} → light.`),
+      };
+    }
+
+    case "EXILE_HAND_SHADOW": {
+      const card = state.hand.find((c) => c.id === action.cardId && c.state === "shadow");
+      if (!card) return state;
+      const res = exileCost(state.channels, card.channel);
+      if (!res.ok) return { ...state, log: log(state, res.reason ?? "Cannot exile.") };
+      return {
+        ...state,
+        channels: res.pool,
+        hand: state.hand.filter((c) => c.id !== card.id),
+        exiledCardIds: [...state.exiledCardIds, card.id],
+        log: log(state, `Exiled ${card.name} — deck is leaner.`),
+      };
+    }
+
+    case "END_TURN": {
+      if (!state.npc || !state.npcDecks) return state;
+      // Clear round modifiers, then let the NPC act.
+      let next: GameState = { ...state, round: emptyRound() };
+
+      const play = npcChooseCard({
+        npc: next.npc!,
+        decks: next.npcDecks!,
+        npcStress: next.npcStress,
+        converted: next.converted,
+        metabolizedShadowIds: next.metabolizedShadowIds,
+        playedLightIds: next.playedLightIds,
+      });
+
+      if (play.kind === "shadow") {
+        next = applyNpcShadow(next, play.card);
+        next.log = log(next, `${next.npc!.name} plays ${play.card.name}.`);
+      } else if (play.kind === "light") {
+        next = applyNpcLight(next, play.card);
+        next.log = log(next, `${next.npc!.name} plays ${play.card.name}.`);
+      } else {
+        next.log = log(next, `${next.npc!.name} holds steady.`);
+      }
+
+      // Recompute round modifiers from whatever shadows remain on the board.
+      next.round = recomputeRound(next.activeShadows);
+      next.turn += 1;
+      return evaluateEnd(next);
+    }
+
+    case "GOTO":
+      return { ...state, phase: action.phase };
+
+    case "RESET":
+      return initialState();
+
+    default:
+      return state;
+  }
+}
+
+/** Recompute round-scoped modifiers from the shadows currently on the board. */
+function recomputeRound(active: NpcShadowCard[]): RoundModifiers {
+  const round = emptyRound();
+  for (const s of active) {
+    if (s.effect.blockRelational) round.blockRelational = true;
+    if (s.effect.skipProgress) round.skipProgress = true;
+    if (s.effect.channelTax) {
+      round.actionTax = { element: s.effect.channelTax.element, amount: s.effect.channelTax.amount };
+    }
+  }
+  return round;
+}
+
+/** Convenience selector: are the NPC's shadows currently revealed? */
+export function npcShadowsVisible(state: GameState): boolean {
+  return shadowsRevealed(state.npcStress);
+}

--- a/mtgoa-game/src/engine/rules.ts
+++ b/mtgoa-game/src/engine/rules.ts
@@ -1,0 +1,62 @@
+/**
+ * Tunable rules / constants.
+ *
+ * Values marked CANONICAL are stated explicitly in the design docs. Values marked
+ * PROVISIONAL are sensible defaults for numbers the docs leave to the designer
+ * (e.g. exact metabolize/exile channel costs); they live here so balancing never
+ * requires touching engine logic.
+ */
+
+export const RULES = {
+  // CANONICAL — Stress system (Core Architecture § The Stress System)
+  stress: {
+    min: 0,
+    max: 7,
+    contagionThreshold: 3, // player stress ≥ 3 dysregulates the NPC
+    sympatheticThreshold: 5, // can spend but cannot receive satisfaction
+    dysregulationThreshold: 7, // skip action phase until source resolved
+  },
+
+  // CANONICAL — NPC shadow activation by NPC stress (Core Architecture)
+  npcShadowActivation: [
+    { min: 0, max: 2, active: 0 },
+    { min: 3, max: 4, active: 1 },
+    { min: 5, max: 6, active: 2 },
+    { min: 7, max: 7, active: 3 },
+  ],
+
+  // CANONICAL — Conversion threshold (Core Architecture § NPC Conversion)
+  conversion: {
+    shadowsToMetabolize: 3, // of 6 → NPC crosses threshold → becomes ally
+    totalShadows: 6,
+  },
+
+  // CANONICAL — Starting deck composition (Core Architecture § Deck Size)
+  startingDeck: {
+    light: 5,
+    shadow: 4,
+    free: 3,
+    total: 12,
+  },
+
+  // CANONICAL — Victory (Core Architecture § Victory Structure)
+  victory: {
+    defaultShowUpTarget: 10,
+  },
+
+  // PROVISIONAL — Alchemy cost ladder. Docs specify "matching channel cost" to
+  // metabolize and "higher channel cost" to exile, without exact numbers.
+  alchemy: {
+    metabolizeCost: 1, // PROVISIONAL: pay 1 matching channel to flip shadow → light
+    exileCost: 2, // PROVISIONAL: pay 2 matching channel to remove permanently
+    shadowPlayStress: 1, // CANONICAL: playing a shadow as-is adds 1 stress
+  },
+
+  // CANONICAL — Stress contagion deltas (Core Architecture § Stress Contagion)
+  contagion: {
+    playerShadowToNpc: 1, // player shadow played → NPC stress +1
+    npcShadowToPlayer: 1, // NPC shadow played → player stress +1
+    metabolizeNpcShadow: -1, // player metabolizes NPC shadow → NPC stress -1
+    npcLightToPlayer: -1, // NPC light move → player stress -1
+  },
+} as const;

--- a/mtgoa-game/src/engine/trust/__tests__/trustCompletability.sim.test.ts
+++ b/mtgoa-game/src/engine/trust/__tests__/trustCompletability.sim.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Completability proof for the trust/attune rebuild.
+ *
+ * The channel-engine sim found 0/6 winnable paths (softlock). This one plays the
+ * real trust reducer for Level-1 Priya and proves a reachable win — under a smart
+ * policy AND under a safe-floor policy that only ever attunes + shows up honestly
+ * (the dead-end guarantee). It also proves the loss exists but is choice-driven.
+ *
+ * Run: npm test -- trustCompletability
+ */
+import { describe, expect, it } from "vitest";
+
+import { LEVEL1_PRIYA } from "../level1Priya";
+import { TRUST_RULES as R } from "../trustRules";
+import type { EncounterConfig } from "../trustTypes";
+import {
+  allDomainsTouched,
+  currentNeed,
+  initTrustEncounter,
+  trustReducer,
+  type TrustAction,
+  type TrustState,
+} from "../trustEngine";
+
+const TURN_CAP = 60;
+
+type Policy = (s: TrustState) => TrustAction | null;
+
+function run(config: EncounterConfig, policy: Policy) {
+  let s = initTrustEncounter(config);
+  let guard = 0;
+  while (s.result === null && guard < TURN_CAP) {
+    const action = policy(s);
+    if (!action) break;
+    s = trustReducer(s, action);
+    guard += 1;
+  }
+  return s;
+}
+
+/** Convert first (align → dissolve ×2), then engage all four domains, then capstone. */
+const smartPolicy: Policy = (s) => {
+  if (s.converted && allDomainsTouched(s)) return { type: "CAPSTONE" };
+  if (!s.needRevealed) return { type: "ATTUNE" };
+  if (!s.converted) {
+    if (s.trust >= R.shadow.dissolveCost && s.shadows.length > 0) {
+      return { type: "DISSOLVE", shadowId: s.shadows[0].id };
+    }
+    const need = currentNeed(s);
+    const aligner = s.config.deck.find((c) => c.kind === "align" && c.channel === need);
+    return aligner ? { type: "PLAY", cardId: aligner.id } : { type: "BASIC" };
+  }
+  const domain = s.config.deck.find(
+    (c) => c.kind === "domain" && c.domain && !s.domainsTouched.includes(c.domain),
+  );
+  return domain ? { type: "PLAY", cardId: domain.id } : null;
+};
+
+/** Never plays an align card — only attunes and "shows up honestly" to bank trust.
+ *  Proves the floor: even a player with no good cards still completes. */
+const safeFloorPolicy: Policy = (s) => {
+  if (s.converted && allDomainsTouched(s)) return { type: "CAPSTONE" };
+  if (!s.needRevealed) return { type: "ATTUNE" };
+  if (!s.converted) {
+    if (s.trust >= R.shadow.dissolveCost && s.shadows.length > 0) {
+      return { type: "DISSOLVE", shadowId: s.shadows[0].id };
+    }
+    return { type: "BASIC" };
+  }
+  const domain = s.config.deck.find(
+    (c) => c.kind === "domain" && c.domain && !s.domainsTouched.includes(c.domain),
+  );
+  return domain ? { type: "PLAY", cardId: domain.id } : null;
+};
+
+describe("trust engine — Level-1 Priya completability", () => {
+  it("smart play reaches a win", () => {
+    const s = run(LEVEL1_PRIYA, smartPolicy);
+    // eslint-disable-next-line no-console
+    console.log(`\n[smart]      result:${s.result} turns:${s.turn} converted:${s.converted} domains:${s.domainsTouched.length}/4`);
+    expect(s.result).toBe("win");
+  });
+
+  it("safe-floor play (attune + show up honestly only) still reaches a win — no dead end", () => {
+    const s = run(LEVEL1_PRIYA, safeFloorPolicy);
+    // eslint-disable-next-line no-console
+    console.log(`[safe-floor] result:${s.result} turns:${s.turn} converted:${s.converted} domains:${s.domainsTouched.length}/4`);
+    expect(s.result).toBe("win");
+  });
+
+  it("a careful reader never raises her stress (no forced rupture)", () => {
+    const s = run(LEVEL1_PRIYA, smartPolicy);
+    expect(s.npcStress).toBeLessThanOrEqual(LEVEL1_PRIYA.startingStress);
+  });
+
+  it("Direct Action is her-only — it will not engage before conversion", () => {
+    let s = initTrustEncounter(LEVEL1_PRIYA);
+    s = trustReducer(s, { type: "PLAY", cardId: "d-direct" });
+    expect(s.domainsTouched).not.toContain("Direct Action");
+    expect(s.converted).toBe(false);
+  });
+
+  it("the loss exists but is choice-driven: repeated misreads rupture", () => {
+    // A deck whose only card mismatches her Water need — forced misreads.
+    const reckless: EncounterConfig = {
+      ...LEVEL1_PRIYA,
+      deck: [{ id: "wrong", name: "Push the Agenda", channel: "Fire", kind: "align", text: "Wrong register." }],
+    };
+    let s = initTrustEncounter(reckless);
+    s = trustReducer(s, { type: "ATTUNE" });
+    let guard = 0;
+    while (s.result === null && guard < TURN_CAP) {
+      s = trustReducer(s, { type: "PLAY", cardId: "wrong" });
+      guard += 1;
+    }
+    expect(s.result).toBe("loss-rupture");
+  });
+});

--- a/mtgoa-game/src/engine/trust/level1Priya.ts
+++ b/mtgoa-game/src/engine/trust/level1Priya.ts
@@ -1,0 +1,40 @@
+/**
+ * Level-1 Priya — the tutorial-difficulty setting of the same machine, tuned so
+ * the matched starter deck can provably win it (the L1 principle: match the
+ * encounter to the deck). Full boss Priya is the identical loop at harder
+ * settings (alternating need, 6 shadows, more her-only components).
+ *
+ * Narrative source: NPC 008, milestone "Find what's still possible inside the
+ * constraint" (the DEI-rollback scenario) — see src/data/npcs.ts.
+ */
+import type { EncounterConfig } from "./trustTypes";
+
+export const LEVEL1_PRIYA: EncounterConfig = {
+  npcId: "npc-008",
+  npcName: "Priya",
+  level: 1,
+  // L1: a single, fixed, hidden need. Attune once to reveal it; it stays put.
+  needSequence: ["Water"],
+  startingStress: 2,
+  shadows: [
+    { id: "l1-performed-compliance", name: "Performed Compliance", channel: "Water", text: "Says yes, does nothing." },
+    { id: "l1-strategic-withdrawal", name: "Strategic Withdrawal", channel: "Water", text: "Goes quiet." },
+    { id: "l1-loyalty-performance", name: "Loyalty Performance", channel: "Water", text: "Performs okayness." },
+  ],
+  deck: [
+    // Inner track — match her Water need to build trust.
+    { id: "c-bear-witness", name: "Bear Witness", channel: "Water", kind: "align", text: "Stay present to what's real without fixing it." },
+    { id: "c-check-in", name: "Check In", channel: "Water", kind: "align", text: "Reach toward the person who went quiet." },
+    { id: "c-name-the-feeling", name: "Name the Feeling", channel: "Water", kind: "align", text: "Put words to what's underneath the performance." },
+    // Outer track — engage each domain to solve her problem.
+    { id: "d-gather", name: "Reach the People Still Inside", channel: "Water", kind: "domain", domain: "Gather Resources", text: "Find who's still reachable inside the building." },
+    { id: "d-aware", name: "See What the Rollback Protects", channel: "Metal", kind: "domain", domain: "Raise Awareness", text: "Understand what's actually at stake." },
+    { id: "d-organize", name: "Build the Container", channel: "Earth", kind: "domain", domain: "Skillful Organizing", text: "Make a space to keep doing the real work." },
+    // Her-only: the honest communication only lands once she's an ally.
+    { id: "d-direct", name: "Communicate It Honestly", channel: "Fire", kind: "domain", domain: "Direct Action", herOnly: true, text: "Say the true thing to the employees — together." },
+  ],
+  capstone: {
+    title: "Find what's still possible inside the constraint",
+    body: "With Priya as ally and every domain engaged, you name what integrity looks like from inside this.",
+  },
+};

--- a/mtgoa-game/src/engine/trust/trustEngine.ts
+++ b/mtgoa-game/src/engine/trust/trustEngine.ts
@@ -1,0 +1,178 @@
+/**
+ * Trust/Attune engine — a pure, testable reducer (no React, no I/O).
+ *
+ * One action per turn:
+ *   ATTUNE          reveal her live need (hidden until read)
+ *   PLAY align      match the need → +trust; mismatch → -trust, +stress (misread)
+ *   PLAY domain     engage a domain (outer work — not alignment-judged)
+ *   BASIC           "Show Up Honestly" — always available, +1 after attuning, never negative
+ *   DISSOLVE        spend trust to dissolve a shadow; threshold → conversion
+ *   CAPSTONE        win if converted AND all four domains engaged
+ *
+ * Completability guarantee: the only loss is rupture, and rupture only comes from
+ * misreads. A reader who attunes before acting never misreads → stress never
+ * rises → the table never ruptures → a win is always reachable. (Proven by
+ * trust/__tests__/trustCompletability.sim.test.ts.)
+ */
+import type { Element } from "@/data/channels";
+import { DOMAIN_NAMES, type DomainName } from "@/data/domains";
+import { TRUST_RULES as R } from "./trustRules";
+import type { EncounterConfig, TrustShadow } from "./trustTypes";
+
+export type TrustResult = "win" | "loss-rupture" | null;
+
+export interface TrustState {
+  phase: "encounter" | "end";
+  result: TrustResult;
+  trust: number;
+  npcStress: number;
+  needIndex: number;
+  needRevealed: boolean;
+  needTrail: Element[];
+  shadows: TrustShadow[];
+  dissolvedShadowIds: string[];
+  converted: boolean;
+  domainsTouched: DomainName[];
+  turn: number;
+  config: EncounterConfig;
+  log: string[];
+}
+
+export type TrustAction =
+  | { type: "ATTUNE" }
+  | { type: "PLAY"; cardId: string }
+  | { type: "BASIC" }
+  | { type: "DISSOLVE"; shadowId: string }
+  | { type: "CAPSTONE" }
+  | { type: "RESET" };
+
+export function currentNeed(state: TrustState): Element {
+  const seq = state.config.needSequence;
+  return seq[state.needIndex % seq.length];
+}
+
+export function allDomainsTouched(state: TrustState): boolean {
+  return DOMAIN_NAMES.every((d) => state.domainsTouched.includes(d));
+}
+
+export function initTrustEncounter(config: EncounterConfig): TrustState {
+  return {
+    phase: "encounter",
+    result: null,
+    trust: 0,
+    npcStress: config.startingStress,
+    needIndex: 0,
+    needRevealed: false,
+    needTrail: [],
+    shadows: [...config.shadows],
+    dissolvedShadowIds: [],
+    converted: false,
+    domainsTouched: [],
+    turn: 1,
+    config,
+    log: [],
+  };
+}
+
+const logLine = (s: TrustState, line: string): string[] => [...s.log, `T${s.turn}: ${line}`];
+
+/** Advance the turn. If the live need changes (alternating levels), it is hidden
+ *  again until re-attuned. A constant L1 need stays revealed. */
+function advanceTurn(s: TrustState): TrustState {
+  const prevNeed = currentNeed(s);
+  const next: TrustState = { ...s, needIndex: s.needIndex + 1, turn: s.turn + 1 };
+  if (currentNeed(next) !== prevNeed) next.needRevealed = false;
+  return next;
+}
+
+function checkRupture(s: TrustState): TrustState {
+  if (s.npcStress >= R.stress.ruptureAt) {
+    return { ...s, result: "loss-rupture", phase: "end", log: logLine(s, "Rupture — she walls off and leaves.") };
+  }
+  return s;
+}
+
+export function trustReducer(state: TrustState, action: TrustAction): TrustState {
+  if (action.type === "RESET") return initTrustEncounter(state.config);
+  if (state.phase === "end") return state;
+
+  switch (action.type) {
+    case "ATTUNE": {
+      const need = currentNeed(state);
+      const s: TrustState = {
+        ...state,
+        needRevealed: true,
+        needTrail: [...state.needTrail, need],
+        log: logLine(state, `Attuned — her live need is ${need}.`),
+      };
+      return advanceTurn(s);
+    }
+
+    case "PLAY": {
+      const card = state.config.deck.find((c) => c.id === action.cardId);
+      if (!card) return state;
+
+      if (card.kind === "align") {
+        const need = currentNeed(state);
+        if (card.channel === need) {
+          const trust = state.trust + R.trust.alignedGain;
+          return advanceTurn({ ...state, trust, log: logLine(state, `Played ${card.name} — aligned (+${R.trust.alignedGain} trust → ${trust}).`) });
+        }
+        const trust = Math.max(R.trust.floor, state.trust - R.trust.misreadLoss);
+        const npcStress = state.npcStress + R.stress.misreadGain;
+        const misread = checkRupture({ ...state, trust, npcStress, log: logLine(state, `Played ${card.name} — misread (-${R.trust.misreadLoss} trust, +${R.stress.misreadGain} stress).`) });
+        return misread.result ? misread : advanceTurn(misread);
+      }
+
+      // domain card — outer-track engagement (not alignment-judged)
+      if (card.herOnly && !state.converted) {
+        return { ...state, log: logLine(state, `${card.name} needs Priya as ally — convert her first.`) };
+      }
+      if (!card.domain || state.domainsTouched.includes(card.domain)) {
+        return { ...state, log: logLine(state, card.domain ? `${card.domain} already engaged.` : `${card.name} engages nothing.`) };
+      }
+      return advanceTurn({
+        ...state,
+        domainsTouched: [...state.domainsTouched, card.domain],
+        log: logLine(state, `Played ${card.name} — engaged ${card.domain}.`),
+      });
+    }
+
+    case "BASIC": {
+      const gain = state.needRevealed ? R.trust.basicGain : 0;
+      const trust = state.trust + gain;
+      const line = gain > 0 ? `Showed up honestly (+${gain} trust → ${trust}).` : `Showed up honestly — but you haven't read her yet (+0).`;
+      return advanceTurn({ ...state, trust, log: logLine(state, line) });
+    }
+
+    case "DISSOLVE": {
+      const shadow = state.shadows.find((sh) => sh.id === action.shadowId);
+      if (!shadow) return state;
+      if (state.trust < R.shadow.dissolveCost) {
+        return { ...state, log: logLine(state, `Not enough trust to dissolve ${shadow.name} (need ${R.shadow.dissolveCost}).`) };
+      }
+      let s: TrustState = {
+        ...state,
+        trust: state.trust - R.shadow.dissolveCost,
+        shadows: state.shadows.filter((sh) => sh.id !== shadow.id),
+        dissolvedShadowIds: [...state.dissolvedShadowIds, shadow.id],
+        npcStress: Math.max(R.stress.min, state.npcStress - R.stress.dissolveRelief),
+        log: logLine(state, `Dissolved ${shadow.name} (-${R.shadow.dissolveCost} trust).`),
+      };
+      if (!s.converted && s.dissolvedShadowIds.length >= R.shadow.convertThreshold) {
+        s = { ...s, converted: true, log: logLine(s, `${state.config.npcName} crosses the threshold — now she plays with you.`) };
+      }
+      return advanceTurn(s);
+    }
+
+    case "CAPSTONE": {
+      if (state.converted && allDomainsTouched(state)) {
+        return { ...state, result: "win", phase: "end", log: logLine(state, `Capstone: ${state.config.capstone.title} — you win.`) };
+      }
+      return { ...state, log: logLine(state, "Capstone not ready — need Priya as ally and all four domains engaged.") };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/mtgoa-game/src/engine/trust/trustRules.ts
+++ b/mtgoa-game/src/engine/trust/trustRules.ts
@@ -1,0 +1,23 @@
+/**
+ * Trust/Attune tunables. All numbers live here so balancing never touches engine
+ * logic. Level-1 starting balance (strawman from the design interview, 2026-06-12).
+ */
+export const TRUST_RULES = {
+  trust: {
+    floor: 0,
+    alignedGain: 3, // play a card matching her live need
+    misreadLoss: 1, // channel mismatch
+    basicGain: 1, // "Show Up Honestly" after attuning — always safe, never negative
+  },
+  stress: {
+    min: 0,
+    start: 2, // L1 starting defendedness (full Priya boss is higher)
+    misreadGain: 1, // a misread raises her walls
+    dissolveRelief: 1, // dissolving a shadow releases a defense
+    ruptureAt: 8, // she walls off and leaves (only reachable via repeated misreads)
+  },
+  shadow: {
+    dissolveCost: 2, // trust to dissolve one shadow
+    convertThreshold: 2, // shadows dissolved → she crosses to ally (L1: 2 of 3)
+  },
+} as const;

--- a/mtgoa-game/src/engine/trust/trustTypes.ts
+++ b/mtgoa-game/src/engine/trust/trustTypes.ts
@@ -1,0 +1,50 @@
+/**
+ * Trust/Attune encounter model — shared types.
+ *
+ * This is the redesigned encounter substrate (chosen 2026-06-12): instead of
+ * channel-metabolize + a 10-Show-Up victory (proven unwinnable — see
+ * engine/__tests__/completability.sim.test.ts), the loop runs on TRUST.
+ *
+ *   Inner track  — read her live need-channel (hidden until you ATTUNE), play a
+ *                  matching card to earn TRUST, spend trust to dissolve shadows,
+ *                  convert her at a threshold so she plays WITH you.
+ *   Outer track  — engage each of the four Domains; Direct Action is "her-only"
+ *                  and unlocks only after conversion. Touch all four + capstone.
+ *
+ * Win = convert + all four domains engaged + capstone. Reachable by construction.
+ */
+import type { Element } from "@/data/channels";
+import type { DomainName } from "@/data/domains";
+
+/** A player move. `align` cards build trust on the inner track; `domain` cards
+ *  engage a domain on the outer track (outer work is NOT alignment-judged). */
+export interface TrustCard {
+  id: string;
+  name: string;
+  channel: Element;
+  kind: "align" | "domain";
+  domain?: DomainName;
+  /** Domain that only resolves once the NPC is an ally (e.g. Direct Action). */
+  herOnly?: boolean;
+  text: string;
+}
+
+export interface TrustShadow {
+  id: string;
+  name: string;
+  channel: Element;
+  text: string;
+}
+
+export interface EncounterConfig {
+  npcId: string;
+  npcName: string;
+  /** Difficulty rung. L1 = single fixed need; higher levels alternate (rhythm). */
+  level: number;
+  /** The live need each turn. Length 1 = constant (L1). Longer = alternating. */
+  needSequence: Element[];
+  startingStress: number;
+  shadows: TrustShadow[];
+  deck: TrustCard[];
+  capstone: { title: string; body: string };
+}

--- a/mtgoa-game/src/hooks/useGame.ts
+++ b/mtgoa-game/src/hooks/useGame.ts
@@ -1,0 +1,13 @@
+/**
+ * useGame — binds the pure reducer (engine/gameState.ts) to React.
+ *
+ * The whole game runs through one reducer per the Migration Brief's priority #3
+ * ("useReducer with action types"), so the engine stays UI-free and testable.
+ */
+import { useReducer } from "react";
+import { initialState, reducer } from "@/engine/gameState";
+
+export function useGame() {
+  const [state, dispatch] = useReducer(reducer, undefined, initialState);
+  return { state, dispatch };
+}

--- a/mtgoa-game/src/index.css
+++ b/mtgoa-game/src/index.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: dark;
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    @apply bg-bg text-text antialiased;
+    font-family:
+      ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+      Arial, sans-serif;
+  }
+}
+
+@layer components {
+  /* Uppercase micro-label used on tags/meta. Mirrors tokens.typography.label. */
+  .ds-label {
+    @apply text-[10px] font-semibold uppercase tracking-label;
+  }
+}

--- a/mtgoa-game/src/lib/utils.ts
+++ b/mtgoa-game/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** shadcn/ui className helper: merge conditional + Tailwind classes safely. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/mtgoa-game/src/main.tsx
+++ b/mtgoa-game/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/mtgoa-game/src/screens/DomainScreen.tsx
+++ b/mtgoa-game/src/screens/DomainScreen.tsx
@@ -27,7 +27,8 @@ interface Props {
 export function DomainScreen({ state, dispatch }: Props) {
   if (!state.npc) return null;
   const dysregulated = state.playerStress >= RULES.stress.dysregulationThreshold;
-  const counterableNames = state.activeShadows.map((s) => s.counter);
+  // A card counters a board shadow when card.counters === that shadow's name.
+  const counterableNames = state.activeShadows.map((s) => s.name);
   const pendingShadows = activeShadowCount(state.npcStress);
 
   return (

--- a/mtgoa-game/src/screens/DomainScreen.tsx
+++ b/mtgoa-game/src/screens/DomainScreen.tsx
@@ -1,0 +1,155 @@
+/**
+ * DomainScreen — the core play loop. Player plays moves (generating Wuxing
+ * channel and countering NPC shadows), then ends the turn for the NPC to act.
+ * Surfaces the dual stress meters, BAR economy, active shadows, and event log.
+ */
+import type { Dispatch } from "react";
+import type { Action, GameState } from "@/engine/gameState";
+import { npcShadowsVisible } from "@/engine/gameState";
+import { activeShadowCount } from "@/engine/combat";
+import { RULES } from "@/engine/rules";
+import { DOMAIN_NAMES } from "@/data/domains";
+
+import { BARTracker } from "@/components/BARTracker";
+import { ChannelDisplay } from "@/components/ChannelDisplay";
+import { StressBar } from "@/components/StressBar";
+import { MoveCard } from "@/components/MoveCard";
+import { NPCShadowCard } from "@/components/NPCShadowCard";
+import { DomainCard } from "@/components/DomainCard";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+interface Props {
+  state: GameState;
+  dispatch: Dispatch<Action>;
+}
+
+export function DomainScreen({ state, dispatch }: Props) {
+  if (!state.npc) return null;
+  const dysregulated = state.playerStress >= RULES.stress.dysregulationThreshold;
+  const counterableNames = state.activeShadows.map((s) => s.counter);
+  const pendingShadows = activeShadowCount(state.npcStress);
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-4 p-6">
+      {/* Top status row */}
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-text">{state.npc.milestone.title}</h2>
+          <span className="text-xs text-muted">
+            Turn {state.turn} · vs {state.npc.name} ({state.npc.face} · {state.npc.superpower})
+            {state.converted && " · ALLY"}
+          </span>
+        </div>
+        <div className="w-full max-w-md">
+          <BARTracker bars={state.bars} showUpTarget={state.showUpTarget} />
+        </div>
+      </header>
+
+      {/* Resources + stress */}
+      <section className="grid gap-4 lg:grid-cols-[1fr_auto]">
+        <div className="flex flex-col gap-3 rounded-card border border-border bg-surf p-3">
+          <span className="ds-label text-muted">Your channels</span>
+          <ChannelDisplay pool={state.channels} />
+          <div className="flex flex-wrap gap-2 text-[11px] text-muted">
+            <span>Milestone progress: {state.milestoneProgress}</span>
+            {state.round.blockRelational && <Badge className="bg-fire/20 text-fire">Relational blocked</Badge>}
+            {state.round.skipProgress && <Badge className="bg-fire/20 text-fire">No progress this round</Badge>}
+            {state.round.actionTax && (
+              <Badge className="bg-fire/20 text-fire">
+                Action +{state.round.actionTax.amount} {state.round.actionTax.element}
+              </Badge>
+            )}
+          </div>
+        </div>
+        <div className="flex min-w-[220px] flex-col gap-3 rounded-card border border-border bg-surf p-3">
+          <StressBar label="Your" value={state.playerStress} showThresholds />
+          <StressBar label={state.npc.name} value={state.npcStress} showThresholds />
+          <span className="text-[10px] text-muted">
+            Metabolized {state.metabolizedShadowIds.length}/{RULES.conversion.shadowsToMetabolize} to
+            convert
+          </span>
+        </div>
+      </section>
+
+      {/* NPC board */}
+      <section className="flex flex-col gap-2 rounded-card border border-border bg-surf p-3">
+        <div className="flex items-center justify-between">
+          <span className="ds-label text-muted">
+            {state.converted ? `${state.npc.name} — ally` : `${state.npc.name} — resistance`}
+          </span>
+          <span className="text-[10px] text-muted">
+            {npcShadowsVisible(state)
+              ? `${pendingShadows} shadow${pendingShadows === 1 ? "" : "s"} active`
+              : "shadows hidden (stress < 3)"}
+          </span>
+        </div>
+        {state.epiphanyRevealed && (
+          <div className="rounded bg-accent/15 px-3 py-2 text-card-body text-accent">
+            Epiphany revealed: {state.npc.sixQuestions.epiphany}
+          </div>
+        )}
+        {state.activeShadows.length > 0 ? (
+          <div className="flex flex-wrap gap-3">
+            {state.activeShadows.map((s) => (
+              <NPCShadowCard key={s.id} card={s} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-card-body text-muted">
+            {state.converted
+              ? "No resistance on the board — keep building toward the milestone."
+              : "Nothing on the board yet. End your turn to let the NPC respond."}
+          </p>
+        )}
+      </section>
+
+      {/* Domains */}
+      <section className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        {DOMAIN_NAMES.map((d) => (
+          <DomainCard key={d} domain={d} relevance={state.npc?.domainRelevance?.[d]} />
+        ))}
+      </section>
+
+      {/* Hand */}
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="ds-label text-muted">Your hand ({state.hand.length})</span>
+          <Button onClick={() => dispatch({ type: "END_TURN" })} variant="subtle">
+            End turn — {state.npc.name} acts
+          </Button>
+        </div>
+        {dysregulated && (
+          <p className="text-card-body text-fire">
+            Dysregulated (stress {RULES.stress.max}). Action phase blocked — end your turn.
+          </p>
+        )}
+        <div className="flex flex-wrap gap-3">
+          {state.hand.map((card) => (
+            <MoveCard
+              key={card.id}
+              card={card}
+              counterableNames={counterableNames}
+              disabled={dysregulated}
+              onPlay={(id) => dispatch({ type: "PLAY_MOVE", cardId: id })}
+              onMetabolize={(id) => dispatch({ type: "METABOLIZE_HAND_SHADOW", cardId: id })}
+              onExile={(id) => dispatch({ type: "EXILE_HAND_SHADOW", cardId: id })}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Event log */}
+      <section className="rounded-card border border-border bg-surf p-3">
+        <span className="ds-label text-muted">Log</span>
+        <div className="mt-1 flex max-h-40 flex-col-reverse gap-0.5 overflow-y-auto">
+          {[...state.log].reverse().map((line, i) => (
+            <p key={state.log.length - i} className="text-[11px] text-dim">
+              {line}
+            </p>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/mtgoa-game/src/screens/EncounterScreen.tsx
+++ b/mtgoa-game/src/screens/EncounterScreen.tsx
@@ -1,0 +1,80 @@
+/**
+ * EncounterScreen — pick an encounter from the roster, then review the NPC's full
+ * six-question profile before entering the domain loop.
+ */
+import type { Dispatch } from "react";
+import type { Action, GameState } from "@/engine/gameState";
+import { NPCS } from "@/data/npcs";
+import { NPCProfile } from "@/components/NPCProfile";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CHANNELS } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  state: GameState;
+  dispatch: Dispatch<Action>;
+}
+
+export function EncounterScreen({ state, dispatch }: Props) {
+  if (!state.npc) {
+    return (
+      <div className="mx-auto flex max-w-5xl flex-col gap-5 p-8">
+        <header>
+          <h2 className="text-xl font-bold text-text">Choose an encounter</h2>
+          <p className="text-dim">
+            Eight pre-built characters, each a node in a network. Priya (008) is the hardest test.
+          </p>
+        </header>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {NPCS.map((npc) => (
+            <Card key={npc.id}>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>{npc.name}</CardTitle>
+                  <span className="text-[10px] text-muted">{npc.id.toUpperCase()}</span>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  <Badge className="bg-surf text-accent">{npc.face}</Badge>
+                  <Badge className="bg-surf text-dim">{npc.superpower}</Badge>
+                  {npc.stuckChannels.map((el) => (
+                    <Badge key={el} className={cn("bg-surf", channelClass[el].text)}>
+                      {CHANNELS[el].glyph}
+                    </Badge>
+                  ))}
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                <p className="text-[11px]">{npc.milestone.title}</p>
+                <Button size="sm" onClick={() => dispatch({ type: "SELECT_ENCOUNTER", npcId: npc.id })}>
+                  Face {npc.name}
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-5 p-8">
+      <header>
+        <h2 className="text-xl font-bold text-text">Encounter</h2>
+        <p className="text-dim">
+          Playing as <span className="text-accent">{state.superpower}</span>. Read the room, then
+          begin.
+        </p>
+      </header>
+      <NPCProfile npc={state.npc} expanded />
+      <div className="flex gap-2">
+        <Button onClick={() => dispatch({ type: "ENTER_DOMAIN" })}>Begin the encounter</Button>
+        <Button variant="ghost" onClick={() => dispatch({ type: "SELECT_ENCOUNTER", npcId: "" })}>
+          Back to roster
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/mtgoa-game/src/screens/EndScreen.tsx
+++ b/mtgoa-game/src/screens/EndScreen.tsx
@@ -1,0 +1,82 @@
+/**
+ * EndScreen — win/loss with the end-of-encounter reflection (Migration Brief
+ * priority #10/#11): what was metabolized, exiled, and what remains.
+ */
+import type { Dispatch } from "react";
+import type { Action, GameState } from "@/engine/gameState";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  state: GameState;
+  dispatch: Dispatch<Action>;
+}
+
+const OUTCOME: Record<NonNullable<GameState["result"]>, { title: string; tone: string; body: string }> = {
+  win: {
+    title: "Allyship occurred",
+    tone: "text-relational",
+    body: "You generated enough Show Up BARs before the domains exhausted. The milestone holds.",
+  },
+  "loss-rupture": {
+    title: "Rupture",
+    tone: "text-fire",
+    body: "Collective stress overwhelmed the table. The work isn't lost — it's a Roadblock Quest to metabolize.",
+  },
+  "loss-exhaustion": {
+    title: "Exhaustion",
+    tone: "text-earth",
+    body: "The deck ran out before the milestone was met. Speed comes from getting better at metabolizing blockers.",
+  },
+};
+
+export function EndScreen({ state, dispatch }: Props) {
+  const result = state.result ?? "loss-exhaustion";
+  const o = OUTCOME[result];
+  const metabolized = state.metabolizedShadowIds.length;
+  const exiled = state.exiledCardIds.length;
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-5 p-8">
+      <header>
+        <h1 className={`text-2xl font-bold ${o.tone}`}>{o.title}</h1>
+        <p className="mt-1 text-dim">{o.body}</p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Reflection</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Show Up" value={`${state.bars.showUp}/${state.showUpTarget}`} />
+          <Stat label="Metabolized" value={metabolized} />
+          <Stat label="Exiled" value={exiled} />
+          <Stat label="Turns" value={state.turn} />
+          <Stat label="Wake Up" value={state.bars.wakeUp} />
+          <Stat label="Clean Up" value={state.bars.cleanUp} />
+          <Stat label="Grow Up" value={state.bars.growUp} />
+          <Stat label="Converted" value={state.converted ? "Yes" : "No"} />
+        </CardContent>
+      </Card>
+
+      {state.npc && (
+        <p className="text-card-body text-muted">
+          {state.npc.name}'s epiphany — <span className="text-dim">{state.npc.sixQuestions.epiphany}</span>
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button onClick={() => dispatch({ type: "RESET" })}>Play again</Button>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col rounded-md border border-border bg-surf px-2 py-1.5">
+      <span className="ds-label text-muted">{label}</span>
+      <span className="text-lg font-bold text-text">{value}</span>
+    </div>
+  );
+}

--- a/mtgoa-game/src/screens/ModeSelect.tsx
+++ b/mtgoa-game/src/screens/ModeSelect.tsx
@@ -1,0 +1,63 @@
+/**
+ * ModeSelect — Character Select vs Applied Mode (Core Architecture § Two Game Modes).
+ * Applied Mode needs the AI intake backend; without it, it degrades to a note.
+ */
+import type { Dispatch } from "react";
+import type { Action } from "@/engine/gameState";
+import { aiEnabled } from "@/api/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  dispatch: Dispatch<Action>;
+}
+
+export function ModeSelect({ dispatch }: Props) {
+  const applied = aiEnabled();
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-8">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold text-text">Mastering the Game of Allyship</h1>
+        <p className="text-dim">
+          Increase the capacity for mutual satisfaction over time. Choose how you want to play.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Character Select</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <p>
+              Pick a Superpower and face one of the eight pre-built encounters. Recommended for
+              workshop and coaching contexts.
+            </p>
+            <Button onClick={() => dispatch({ type: "SELECT_MODE", mode: "character-select" })}>
+              Play Character Select
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className={applied ? "" : "opacity-60"}>
+          <CardHeader>
+            <CardTitle>Applied Mode</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <p>
+              Work a real situation. The intake guide maps your answers to the Six Unpacking
+              Questions and builds the encounter around you.
+            </p>
+            <Button
+              variant="subtle"
+              disabled={!applied}
+              onClick={() => dispatch({ type: "SELECT_MODE", mode: "applied" })}
+            >
+              {applied ? "Begin Intake" : "Requires AI backend"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/mtgoa-game/src/screens/SuperpowerSelect.tsx
+++ b/mtgoa-game/src/screens/SuperpowerSelect.tsx
@@ -1,0 +1,79 @@
+/**
+ * SuperpowerSelect — choose the player archetype (Core Architecture § Superpower
+ * Archetypes). Each card shows channel affinity, perception, shadows, and the
+ * 3-match synergy bonus.
+ */
+import type { Dispatch } from "react";
+import type { Action } from "@/engine/gameState";
+import { SUPERPOWERS, SUPERPOWER_NAMES, type SuperpowerName } from "@/data/superpowers";
+import { CHANNELS } from "@/data/channels";
+import { channelClass } from "../../design-system/theme";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  dispatch: Dispatch<Action>;
+}
+
+const accentByName: Record<SuperpowerName, string> = {
+  Strategist: "border-strategist",
+  Connector: "border-connector",
+  Storyteller: "border-storyteller",
+  Alchemist: "border-alchemist",
+  Disruptor: "border-disruptor",
+  "Escape Artist": "border-escape-artist",
+};
+
+export function SuperpowerSelect({ dispatch }: Props) {
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-5 p-8">
+      <header>
+        <h2 className="text-xl font-bold text-text">Choose your Superpower</h2>
+        <p className="text-dim">Your preferred method of creating mutual satisfaction.</p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {SUPERPOWER_NAMES.map((name) => {
+          const def = SUPERPOWERS[name];
+          return (
+            <Card key={name} className={cn("border-l-4", accentByName[name])}>
+              <CardHeader>
+                <CardTitle>{name}</CardTitle>
+                <div className="flex gap-1">
+                  {def.channels.map((el) => (
+                    <Badge key={el} className={cn("bg-surf", channelClass[el].text)}>
+                      {CHANNELS[el].glyph} {el}
+                    </Badge>
+                  ))}
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                <p>
+                  <span className="text-muted">Sees: </span>
+                  {def.sees}
+                </p>
+                <p className="text-[11px]">
+                  <span className="text-muted">Shadows: </span>
+                  {def.shadows.join(", ")}
+                </p>
+                <p className="text-[11px] text-relational">
+                  <span className="text-muted">Synergy (3 match): </span>
+                  {def.synergyBonus}
+                </p>
+                <Button
+                  className="mt-1"
+                  size="sm"
+                  onClick={() => dispatch({ type: "SELECT_SUPERPOWER", superpower: name })}
+                >
+                  Play as {name}
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/mtgoa-game/src/screens/TrustEncounterScreen.tsx
+++ b/mtgoa-game/src/screens/TrustEncounterScreen.tsx
@@ -1,0 +1,252 @@
+/**
+ * TrustEncounterScreen — the playable Level-1 Priya loop on the trust/attune
+ * engine (engine/trust). Self-contained: it owns its own reducer so it does not
+ * touch the channel-engine game state. Mounted from App via a prototype toggle.
+ *
+ * The loop on screen:
+ *   ATTUNE to reveal her live need → play a matching card for TRUST → spend trust
+ *   to DISSOLVE shadows → convert her → engage all four DOMAINS (Direct Action is
+ *   her-only) → CAPSTONE to win. "Show Up Honestly" is the always-safe basic move.
+ */
+import { useReducer } from "react";
+
+import { CHANNELS } from "@/data/channels";
+import { DOMAIN_NAMES } from "@/data/domains";
+import { channelClass } from "../../design-system/theme";
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+import { LEVEL1_PRIYA } from "@/engine/trust/level1Priya";
+import { TRUST_RULES as R } from "@/engine/trust/trustRules";
+import {
+  allDomainsTouched,
+  currentNeed,
+  initTrustEncounter,
+  trustReducer,
+} from "@/engine/trust/trustEngine";
+
+interface Props {
+  onExit: () => void;
+}
+
+/** A simple labelled value meter (trust has no fixed max; stress caps at rupture). */
+function Meter({ label, value, max, tone }: { label: string; value: number; max: number; tone: string }) {
+  const pct = Math.min(100, (value / max) * 100);
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between">
+        <span className="ds-label text-muted">{label}</span>
+        <span className="text-sm font-bold tabular-nums text-dim">{value}</span>
+      </div>
+      <div className="h-2.5 w-full overflow-hidden rounded-sm bg-border">
+        <div className={cn("h-full rounded-sm transition-all", tone)} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function TrustEncounterScreen({ onExit }: Props) {
+  const [state, dispatch] = useReducer(trustReducer, LEVEL1_PRIYA, initTrustEncounter);
+
+  const need = currentNeed(state);
+  const config = state.config;
+  const convertNeeded = R.shadow.convertThreshold;
+  const ready = state.converted && allDomainsTouched(state);
+
+  if (state.phase === "end") {
+    const won = state.result === "win";
+    return (
+      <div className="mx-auto flex max-w-xl flex-col gap-4 p-8">
+        <div className={cn("rounded-card border p-6", won ? "border-accent bg-accent/10" : "border-fire bg-fire/10")}>
+          <h2 className={cn("text-2xl font-bold", won ? "text-accent" : "text-fire")}>
+            {won ? "You found what's still possible." : "Rupture — she walled off and left."}
+          </h2>
+          <p className="mt-2 text-card-body text-dim">
+            {won
+              ? config.capstone.body
+              : "Too many misreads raised her defenses past the breaking point. Read her before you act."}
+          </p>
+          <p className="mt-3 text-xs text-muted">Resolved in {state.turn - 1} turns.</p>
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={() => dispatch({ type: "RESET" })}>Play again</Button>
+          <Button variant="ghost" onClick={onExit}>Exit prototype</Button>
+        </div>
+        <LogPanel log={state.log} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-4 p-6">
+      {/* Header */}
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-bold text-text">{config.capstone.title}</h2>
+            <Badge className="bg-surf text-accent">Level {config.level}</Badge>
+            {state.converted && <Badge className="bg-accent/20 text-accent">{config.npcName} · ALLY</Badge>}
+          </div>
+          <span className="text-xs text-muted">Turn {state.turn} · {config.npcName} (Diplomat)</span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onExit}>Exit prototype</Button>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-[1fr_minmax(220px,auto)]">
+        {/* Live need / inner track */}
+        <div className="flex flex-col gap-3 rounded-card border border-border bg-surf p-4">
+          <span className="ds-label text-muted">Her live need</span>
+          {state.needRevealed ? (
+            <div className="flex items-center gap-3">
+              <span className={cn("text-3xl", channelClass[need].text)}>{CHANNELS[need].glyph}</span>
+              <div>
+                <p className={cn("text-base font-bold", channelClass[need].text)}>{need}</p>
+                <p className="text-[11px] text-muted">Match this channel to build trust.</p>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <span className="text-3xl text-muted">?</span>
+              <div>
+                <p className="text-base font-bold text-dim">Unread</p>
+                <p className="text-[11px] text-muted">Attune to reveal what she needs.</p>
+              </div>
+            </div>
+          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="subtle" disabled={state.needRevealed} onClick={() => dispatch({ type: "ATTUNE" })}>
+              Attune
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => dispatch({ type: "BASIC" })}>
+              Show Up Honestly {state.needRevealed ? `(+${R.trust.basicGain})` : "(+0 until read)"}
+            </Button>
+            {state.needTrail.length > 0 && (
+              <span className="text-[10px] text-muted">trail: {state.needTrail.join(" · ")}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Meters */}
+        <div className="flex min-w-[220px] flex-col gap-3 rounded-card border border-border bg-surf p-4">
+          <Meter label="Trust" value={state.trust} max={Math.max(6, state.trust)} tone="bg-accent" />
+          <Meter label={`${config.npcName} stress`} value={state.npcStress} max={R.stress.ruptureAt} tone="bg-fire" />
+          <span className="text-[10px] text-muted">
+            Dissolved {state.dissolvedShadowIds.length}/{convertNeeded} to convert · dissolve costs {R.shadow.dissolveCost} trust
+          </span>
+        </div>
+      </section>
+
+      {/* Shadows */}
+      <section className="flex flex-col gap-2 rounded-card border border-border bg-surf p-3">
+        <span className="ds-label text-muted">
+          {state.converted ? `${config.npcName} — ally` : `${config.npcName} — defended`}
+        </span>
+        {state.shadows.length > 0 ? (
+          <div className="flex flex-wrap gap-3">
+            {state.shadows.map((s) => (
+              <div key={s.id} className={cn("flex w-52 flex-col gap-2 rounded-card border bg-card p-3", channelClass[s.channel].border)}>
+                <div className="flex items-center justify-between">
+                  <span className="text-card-title font-bold text-text">{s.name}</span>
+                  <span className={cn(channelClass[s.channel].text)}>{CHANNELS[s.channel].glyph}</span>
+                </div>
+                <p className="text-[11px] text-dim">{s.text}</p>
+                <Button
+                  size="sm"
+                  variant="subtle"
+                  disabled={state.trust < R.shadow.dissolveCost}
+                  onClick={() => dispatch({ type: "DISSOLVE", shadowId: s.id })}
+                >
+                  Dissolve (−{R.shadow.dissolveCost} trust)
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-card-body text-muted">Every defense released. She's with you now.</p>
+        )}
+      </section>
+
+      {/* Domain track */}
+      <section className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        {DOMAIN_NAMES.map((d) => {
+          const touched = state.domainsTouched.includes(d);
+          const card = config.deck.find((c) => c.kind === "domain" && c.domain === d);
+          const locked = !!card?.herOnly && !state.converted;
+          return (
+            <div
+              key={d}
+              className={cn(
+                "rounded-card border p-3",
+                touched ? "border-accent bg-accent/10" : locked ? "border-border bg-card opacity-60" : "border-border bg-card",
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-card-title font-bold text-text">{d}</span>
+                {touched ? <Badge className="bg-accent/20 text-accent">engaged</Badge> : locked ? <Badge className="bg-surf text-muted">her-only</Badge> : null}
+              </div>
+              <p className="mt-1 text-[11px] text-muted">{card?.text}</p>
+            </div>
+          );
+        })}
+      </section>
+
+      {/* Hand */}
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="ds-label text-muted">Your hand</span>
+          <Button disabled={!ready} onClick={() => dispatch({ type: "CAPSTONE" })}>
+            {ready ? "Capstone — solve it" : "Capstone (convert + all four domains)"}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          {config.deck.map((card) => {
+            const isAlign = card.kind === "align";
+            const aligned = isAlign && state.needRevealed && card.channel === need;
+            const touched = !isAlign && !!card.domain && state.domainsTouched.includes(card.domain);
+            const locked = !!card.herOnly && !state.converted;
+            return (
+              <button
+                key={card.id}
+                disabled={touched || locked}
+                onClick={() => dispatch({ type: "PLAY", cardId: card.id })}
+                className={cn(
+                  "flex w-44 flex-col gap-1 rounded-card border bg-card p-3 text-left transition-colors hover:bg-surf disabled:opacity-40 disabled:hover:bg-card",
+                  channelClass[card.channel].border,
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-card-title font-bold text-text">{card.name}</span>
+                  <span className={cn(channelClass[card.channel].text)}>{CHANNELS[card.channel].glyph}</span>
+                </div>
+                <p className="text-[11px] text-dim">{card.text}</p>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  <Badge className="bg-surf text-muted">{isAlign ? "inner · align" : `outer · ${card.domain}`}</Badge>
+                  {aligned && <Badge className="bg-accent/20 text-accent">matches need</Badge>}
+                  {touched && <Badge className="bg-accent/20 text-accent">engaged</Badge>}
+                  {locked && <Badge className="bg-surf text-muted">her-only</Badge>}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <LogPanel log={state.log} />
+    </div>
+  );
+}
+
+function LogPanel({ log }: { log: string[] }) {
+  return (
+    <section className="rounded-card border border-border bg-surf p-3">
+      <span className="ds-label text-muted">Log</span>
+      <div className="mt-1 flex max-h-40 flex-col-reverse gap-0.5 overflow-y-auto">
+        {[...log].reverse().map((line, i) => (
+          <p key={log.length - i} className="text-[11px] text-dim">{line}</p>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/mtgoa-game/src/vite-env.d.ts
+++ b/mtgoa-game/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_AI_ENDPOINT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/mtgoa-game/tailwind.config.ts
+++ b/mtgoa-game/tailwind.config.ts
@@ -1,0 +1,54 @@
+import type { Config } from "tailwindcss";
+import { colors } from "./design-system/tokens";
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        // Surfaces
+        bg: colors.bg,
+        surf: colors.surf,
+        card: colors.card,
+        border: colors.border,
+        accent: colors.accent,
+        text: colors.text,
+        dim: colors.dim,
+        muted: colors.muted,
+        // Channels (Wuxing)
+        wood: colors.wood,
+        fire: colors.fire,
+        earth: colors.earth,
+        metal: colors.metal,
+        water: colors.water,
+        // Card types
+        emotional: colors.emotional,
+        relational: colors.relational,
+        cognitive: colors.cognitive,
+        action: colors.action,
+        // Superpowers
+        strategist: colors.Strategist,
+        connector: colors.Connector,
+        storyteller: colors.Storyteller,
+        alchemist: colors.Alchemist,
+        disruptor: colors.Disruptor,
+        "escape-artist": colors["Escape Artist"],
+      },
+      borderRadius: {
+        card: "10px",
+      },
+      fontSize: {
+        "card-title": ["13px", { lineHeight: "1.3", fontWeight: "700" }],
+        "card-body": ["12px", { lineHeight: "1.6" }],
+        "card-meta": ["10px", { fontWeight: "600" }],
+      },
+      letterSpacing: {
+        label: "0.8px",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/mtgoa-game/tsconfig.json
+++ b/mtgoa-game/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/mtgoa-game/vite.config.ts
+++ b/mtgoa-game/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
     "scripts",
     "src/scripts",
     "chatgpt_repo_snapshot_*",
-    "vitest.config.ts"
+    "vitest.config.ts",
+    "mtgoa-game"
   ]
 }


### PR DESCRIPTION
## Summary

Migrates **Mastering the Game of Allyship (MTGOA)** from the ~900-line Claude.ai artifact into a standalone **Vite + React 18 + TypeScript + Tailwind** app under `mtgoa-game/`, with a fully separated data layer and a `useReducer` state machine. Adds a **provably-completable** Level-1 Priya encounter built on a trust/attune substrate.

## What's here

- **Scaffold** — Vite + React + TS project, shadcn/ui-style base components, design tokens → Tailwind (no inline styles), engine/data/UI separation.
- **Completability diagnosis** — a new sim (`completability.sim.test.ts`) proves the original channel-metabolize combat engine is unwinnable: `0/6` superpowers can beat Priya (4 can't reach the 3-shadow conversion; the 2 that convert softlock at ~1 Show Up against a target of 10).
- **Trust/attune rebuild** (additive — the channel engine and its tests are untouched):
  - `engine/trust/` — a pure, testable reducer. ATTUNE to read her hidden live-need, play a matching card for TRUST, spend trust to DISSOLVE shadows, convert her, engage all four Domains, then CAPSTONE. Win is reachable by construction.
  - Level-1 Priya tuned to a starter deck so the basic loop is winnable now; the full boss is the same loop at harder settings.
  - `trustCompletability.sim.test.ts` — smart play wins in 10 turns, safe-floor play in 12; loss exists but is choice-driven.
  - `TrustEncounterScreen` + App toggle — playable in-app via the prototype button or `#l1-priya`.

## Verification

- ✅ `tsc --noEmit` — clean
- ✅ `vitest run` — 14/14 pass
- ✅ `vite build` — succeeds

## Follow-ups (not in this PR)

- Full boss Priya (same loop, harder settings)
- Applied Mode intake / `IntakeConversation` (Migration Brief priority #8)

https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS)_