### PR TITLE
Fix P3009: reconstruct idempotent friendcard/vibeulon migration

### DIFF
--- a/prisma/migrations/20260530000000_add_friendcard_vibeulon_schema/migration.sql
+++ b/prisma/migrations/20260530000000_add_friendcard_vibeulon_schema/migration.sql
@@ -1,0 +1,59 @@
+-- Reconcile migration for the Vibeulon Ledger / Instance Participation schema
+-- (models added to prisma/schema.prisma in a8270e0 without a migration).
+--
+-- The original migration ran directly against production on 2026-06-09, created
+-- "vibeulon_ledger", then failed partway — leaving a P3009 failed-migration marker
+-- that blocks every subsequent deploy. The file itself was never committed.
+--
+-- This reconstruction is deliberately IDEMPOTENT (IF NOT EXISTS / duplicate-safe
+-- FK guards) so it can be safely re-applied over the partially-migrated production
+-- database after the failed marker is cleared with:
+--   npx prisma migrate resolve --rolled-back 20260530000000_add_friendcard_vibeulon_schema
+-- It only creates objects that are missing and never drops or rewrites existing data.
+
+-- AlterTable
+ALTER TABLE "custom_bars" ADD COLUMN IF NOT EXISTS "maxAssignments" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "vibeulon_ledger" (
+    "id" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "sourceInstanceId" TEXT,
+    "targetInstanceId" TEXT,
+    "amount" INTEGER NOT NULL,
+    "type" TEXT NOT NULL,
+    "metadata" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "vibeulon_ledger_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "instance_participation" (
+    "id" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "instanceId" TEXT NOT NULL,
+    "localBalance" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "instance_participation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "instance_participation_playerId_instanceId_key" ON "instance_participation"("playerId", "instanceId");
+
+-- AddForeignKey
+DO $$ BEGIN
+    ALTER TABLE "vibeulon_ledger" ADD CONSTRAINT "vibeulon_ledger_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- AddForeignKey
+DO $$ BEGIN
+    ALTER TABLE "instance_participation" ADD CONSTRAINT "instance_participation_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "instances"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- AddForeignKey
+DO $$ BEGIN
+    ALTER TABLE "instance_participation" ADD CONSTRAINT "instance_participation_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;


### PR DESCRIPTION
## Context

Production deploys were aborting with **`Error: P3009`** at the `prisma migrate deploy` build step:

> The `20260530000000_add_friendcard_vibeulon_schema` migration started at 2026-06-09 … failed

### Root cause — schema/migration drift

- Commit `a8270e0` added the `VibeulonLedger` and `InstanceParticipation` models to `prisma/schema.prisma` **with no accompanying migration**.
- A migration named `20260530000000_add_friendcard_vibeulon_schema` was later run **directly against production**, created `vibeulon_ledger`, then **failed partway** — leaving a `failed` row in `_prisma_migrations` that blocks every subsequent deploy (P3009).
- That migration file was **never committed to any branch**, so `main` describes tables that no migration creates.

## This change

Reconstructs the lost migration from the exact schema delta, faithfully and **idempotently**:

- `ALTER TABLE … ADD COLUMN IF NOT EXISTS "maxAssignments"`
- `CREATE TABLE IF NOT EXISTS "vibeulon_ledger"` / `"instance_participation"`
- `CREATE UNIQUE INDEX IF NOT EXISTS` + duplicate-safe (`DO $$ … EXCEPTION WHEN duplicate_object`) foreign keys

Because production had only *partially* applied the original migration (`vibeulon_ledger` existed; `instance_participation` / `custom_bars.maxAssignments` state unknown), the idempotent form safely creates **only what is missing** and never drops or rewrites data. It also makes a fresh database reproduce `schema.prisma` exactly.

## Production remediation (already performed)

Per `docs/ENV_AND_VERCEL.md` P3009 guidance, run against the prod `DATABASE_URL`:

```bash
npx prisma migrate resolve --rolled-back 20260530000000_add_friendcard_vibeulon_schema
npx prisma migrate deploy
```

This was already executed against production, clearing the failed marker and reconciling the schema. Merging this PR lands the migration in `main` so future deploys and fresh databases stay consistent.

## Verification

- Reconstructed SQL maps 1:1 to the three objects in the `a8270e0` schema delta (verified against current `prisma/schema.prisma`).
- Idempotent guards make re-application over the partially-migrated prod DB safe.

> Split from the combined branch per review request. The OpenGSD Phase 1 work is in a separate PR.

https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS)_