### PR TITLE
Adopt OpenGSD (Phase 1): GSD Browser provisioning + migration decision

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/setup-gsd-browser.sh --check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ chatgpt_repo_snapshot_*/
 /specify_specs_tree.txt
 /possible_backlog_files.txt
 /schema.prisma.copy.txt
+
+# GSD Browser visual-verification artifacts (commit curated baselines deliberately)
+.gsd-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,10 @@ yarn-error.log*
 
 # embedded repos (avoid accidental add)
 LibreSprite/
-.claude/
+# Keep Claude config local, but share the project SessionStart hook + settings.
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 
 # typescript
 *.tsbuildinfo

--- a/.specify/specs/opengsd-workflow-migration/plan.md
+++ b/.specify/specs/opengsd-workflow-migration/plan.md
@@ -1,0 +1,52 @@
+# Plan: OpenGSD Workflow Migration
+
+## Strategy
+
+Incremental, lowest-risk-first, compost-as-you-go. Add the **net-new** capability
+(GSD Browser) before touching anything that works; pilot **GSD Pi** in parallel
+with the bespoke stack; cut over and compost only after parity is demonstrated.
+No big-bang. Each phase is independently revertable.
+
+## Sequencing rationale
+
+1. **GSD Browser first** — purely additive (we have no visual verification today),
+   so it can land with zero risk to existing flows and immediately serves
+   `UI_COVENANT` work on both the MTGOA app and the Next.js app.
+2. **GSD Pi pilot second** — runs alongside Ouroboros/Spec-Kit; proves
+   context-fidelity and autonomy on one real kit before any removal.
+3. **Cutover + compost last** — Strands→worktrees, `.specify/`→`.gsd/`, retire
+   bespoke commands, update docs.
+
+## Architecture / file impacts
+
+| Area | Change | Phase |
+|------|--------|-------|
+| Setup hook (`.claude/` session-start / CI) | Provision headless Chromium for GSD Browser | 1 |
+| `package.json` | `verify:ui` script (boot app + gsd-browser capture); optionally vendor gsd-browser | 1 |
+| `mtgoa-game/` | Baseline screenshots + a11y tree for Level-1 Priya | 1 |
+| Repo root | `.gsd/` directory (GSD Pi state) appears once Pi is initialized | 2 |
+| `.specify/specs/*` | One kit translated to GSD Pi; rest untouched until Phase 3 | 2→3 |
+| BARS Strand skills | Map fork-space boundaries to GSD worktrees | 3 |
+| `.agent/context/*`, `BACKLOG.md` | Migrate into `.gsd/` context | 3 |
+| `CLAUDE.md`, `docs/` | Re-point workflow guidance from `ooo`/Strands to GSD | 3 |
+
+## Prerequisites / risks
+
+- **Chromium provisioning** is the gating dependency for Phase 1 (spike confirmed
+  the sandbox has no browser; CDP daemon won't start without one).
+- **GSD Pi is local-first + LLM-driven** — confirm provider, the "latest Claude"
+  default, and cost controls before piloting (Phase 2).
+- **Young dependency (v0.1.x)** — keep `.specify/` archived (not deleted) through
+  Phase 3 so rollback is cheap.
+- **Community optics** — preserve dual-track/non-AI legibility; consider framing
+  the migration as an in-game artifact.
+
+## Verification
+
+- Phase 1: GSD Browser captures an MTGOA baseline and flags a visual diff on an
+  intentional color/border change.
+- Phase 2: one feature delivered end-to-end via GSD Pi without bespoke fallback.
+- Phase 3: existing specs still build; non-AI flows unaffected; docs point at GSD.
+
+> Not a persistence/UI feature change — no Prisma migration and no Twine
+> Verification Quest required (those apply to user-facing product features).

--- a/.specify/specs/opengsd-workflow-migration/spec.md
+++ b/.specify/specs/opengsd-workflow-migration/spec.md
@@ -1,0 +1,122 @@
+# Spec: OpenGSD Workflow Migration
+
+## Purpose
+
+Adopt **OpenGSD** ("Git. Ship. Done.") as the standard AI-assisted development
+workflow for bars-engine, and incrementally migrate the project's bespoke
+agent-orchestration stack (Ouroboros, Spec-Kit tooling, BARS Strand System) onto
+it — composting the in-house infrastructure as GSD equivalents take over.
+
+**Problem**: bars-engine maintains a sophisticated but **sole-maintained** stack
+of spec-driven / context-engineering / work-isolation tooling. The functionality
+is largely *replicated* by OpenGSD, which is more mature and backed by an active
+developer community. Sole-maintaining bespoke developer infrastructure is a
+standing tax; an externally maintained ecosystem lowers long-term cost — and
+GSD Browser adds a capability (automated visual verification) we do not have.
+
+**Practice**: Deftness Development — compost obsolete paths over maintaining them
+(generative dependencies); incremental, non-breaking migration; deterministic
+verification before cutover.
+
+## Decision
+
+**Adopt OpenGSD; migrate the bespoke stack onto it incrementally.** This is a
+ratified direction (owner decision, 2026-06-12), recorded here for legibility.
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Adopt vs. keep bespoke | **Adopt OpenGSD** | Functionality replicated, but GSD is more mature and community-maintained; ends sole-maintainership of bespoke infra. |
+| GSD Pi (spec-driven agent) | **Replace** Ouroboros + Spec-Kit tooling over time | Same model (milestones/slices/tasks, context engineering, long autonomous runs) with upstream maintenance. |
+| BARS Strand System | **Map onto** GSD Pi git-worktree isolation | GSD isolates work in worktrees natively; Strands' fork-space boundaries map directly. |
+| GSD Browser | **Add (net-new)** | No current automated visual verification; directly serves `UI_COVENANT` (element=color, altitude=border, stage=density) for MTGOA + Next.js UI. |
+| Migration style | **Incremental, compost-as-you-go** | Do not break in-flight specs; retire bespoke paths only as GSD equivalents are proven. |
+| Community optics | **Preserve dual-track / non-AI legibility** | Portland AI-allergy: GSD adoption must not degrade the first-class non-AI delivery mode or make process illegible. |
+
+## Conceptual Model (what maps to what)
+
+| bars-engine (today) | OpenGSD (target) | Migration note |
+|---------------------|------------------|----------------|
+| Ouroboros `ooo` (interview→seed→execute→evaluate) | GSD Pi (plan→implement→verify→ship) | Meta-prompting + evolutionary loop ≈ GSD Pi autonomous sessions. |
+| Spec-Kit `.specify/specs/*` (spec/plan/tasks) | GSD Pi milestones / slices / tasks in `.gsd/` | Translate existing kits; keep `.specify/` until parity proven. |
+| `.agent/context/*`, BACKLOG | GSD Pi context engineering (`.gsd/`) | Context state + validation evidence. |
+| BARS Strand System (fork-space, work isolation) | GSD Pi git worktrees | Strand boundaries → worktree branches. |
+| *(none)* | **GSD Browser** | New: screenshots, accessibility tree, visual diffing, test generation. |
+
+## Environment Spike — Findings (2026-06-12)
+
+A feasibility smoke-test of GSD Browser in the web/remote sandbox:
+
+- ✅ `@opengsd/gsd-browser@0.1.29` installs from npm (registry reachable).
+- ✅ CLI runs (`gsd-browser --version` / `--help`); rich CDP command set
+  (navigate, click, type, screenshot, accessibility-tree, visual diff, etc.).
+- ❌ **Daemon fails to start — no Chromium binary present** in the sandbox
+  (`daemon exited during startup`). CDP requires a Chrome/Chromium install.
+
+**Implication**: Any environment that runs GSD Browser (local dev, CI, web
+sessions) must **provision a headless Chromium** (e.g. a setup-hook /
+`session-start-hook`, or a CI step). This is the gating prerequisite for the
+verification track.
+
+## User Stories
+
+### P1: Maintainer ends bespoke-stack tax
+**As the project maintainer**, I want spec-driven work to run on a
+community-maintained engine, so I stop sole-maintaining Ouroboros/Strand
+internals and inherit upstream improvements.
+**Acceptance**: One real feature is delivered end-to-end through GSD Pi
+(plan→ship) without falling back to the bespoke `ooo` commands.
+
+### P2: UI work gains automated visual verification
+**As a developer doing UI work**, I want screenshot + visual-diff checks against
+`UI_COVENANT` encodings, so card aesthetics are verified without manual review.
+**Acceptance**: GSD Browser captures a baseline of the MTGOA Level-1 Priya screen
+and flags a visual diff on an intentional color/border change.
+
+### P3: No regression to in-flight work or non-AI mode
+**As a contributor**, I want existing `.specify/` specs and the non-AI delivery
+path to keep working during migration, so nothing breaks mid-cutover.
+**Acceptance**: Existing specs remain buildable; non-AI flows unaffected; bespoke
+paths retired only after GSD parity is demonstrated.
+
+## Functional Requirements
+
+### Phase 0: Decision & feasibility (this spec)
+- **FR0.1**: Record the adopt-and-migrate decision (this document).
+- **FR0.2**: Spike GSD Browser install/run in the sandbox; document the Chromium
+  prerequisite. *(done — see Findings)*
+
+### Phase 1: GSD Browser (net-new, lowest risk, highest additive value)
+- **FR1.1**: Provision headless Chromium for dev/CI/web sessions (setup hook).
+- **FR1.2**: Add a `verify:ui` path that boots the MTGOA app and captures a
+  baseline screenshot + accessibility tree of the Level-1 Priya screen.
+- **FR1.3**: Wire visual-diff into the verification loop for `UI_COVENANT` work.
+
+### Phase 2: GSD Pi pilot (parallel to bespoke; no removal yet)
+- **FR2.1**: `npx @opengsd/gsd-pi@latest` setup; choose LLM provider (default to
+  the latest Claude per project guidance).
+- **FR2.2**: Translate **one** existing `.specify/` kit into GSD Pi
+  milestones/slices/tasks and deliver it through GSD.
+- **FR2.3**: Compare context-fidelity and autonomy vs. Ouroboros on that pilot.
+
+### Phase 3: Cutover & compost (only after parity)
+- **FR3.1**: Map BARS Strand fork-space boundaries to GSD worktrees.
+- **FR3.2**: Migrate backlog/context (`.specify/`, `.agent/context/`) into `.gsd/`.
+- **FR3.3**: Compost retired bespoke commands; update CLAUDE.md + docs to point at GSD.
+
+## Non-Functional Requirements
+
+- **Non-breaking**: in-flight specs and current deploys unaffected during migration.
+- **Dual-track**: non-AI delivery mode remains first-class and legible.
+- **Reversibility**: each phase independently revertable; no big-bang cutover.
+- **Lock-in awareness**: GSD is young (v0.1.x); keep `.specify/` archived until
+  Phase 3 parity is proven, so rollback stays cheap.
+- **Secrets/cost**: GSD Pi LLM provider keys documented in `docs/ENV_AND_VERCEL.md`;
+  model override + caching honored.
+
+## Open Questions
+
+- Provider/runtime: which LLM does GSD Pi drive, and does it honor the project's
+  "latest Claude" default and cost controls?
+- CI surface: provision Chromium in CI now, or gate GSD Browser to local/web only?
+- Optics: how do we frame GSD adoption for the AI-allergic Portland community —
+  is the migration itself an in-game artifact ("the game creates the game")?

--- a/.specify/specs/opengsd-workflow-migration/tasks.md
+++ b/.specify/specs/opengsd-workflow-migration/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: OpenGSD Workflow Migration
+
+Phased, revertable. Do not start a phase's removal steps until the prior phase's
+parity is verified. `[x]` = done.
+
+## Phase 0 — Decision & feasibility
+- [x] Record adopt-and-migrate decision (`spec.md`).
+- [x] Spike GSD Browser in sandbox: installs + runs; **Chromium binary missing**
+      blocks the CDP daemon. (`gsd-browser 0.1.29`, `daemon exited during startup`.)
+- [ ] Owner confirms scope/sequencing of this spec.
+
+## Phase 1 — GSD Browser (net-new, no risk to existing flows)
+- [ ] Provision headless Chromium for the runtime(s) that will run it:
+      `npx playwright install --with-deps chromium` (or distro chromium), wired
+      into a session-start / CI setup step.
+- [ ] `GSD_BROWSER_DEBUG=1 gsd-browser navigate https://example.com` — confirm the
+      daemon starts once Chromium is present.
+- [ ] Boot the MTGOA app (`cd mtgoa-game && npm run dev`) and capture a baseline:
+      `gsd-browser navigate http://localhost:5173/#l1-priya`
+      `gsd-browser screenshot --out .gsd-artifacts/priya-baseline.png`
+      `gsd-browser accessibility-tree --out .gsd-artifacts/priya-a11y.json`
+- [ ] Add `verify:ui` npm script (boot app → capture → diff).
+- [ ] Wire visual-diff into the `UI_COVENANT` loop (element=color, altitude=border,
+      stage=density); demo: an intentional color change must surface a diff.
+
+## Phase 2 — GSD Pi pilot (parallel to bespoke; no removals)
+- [ ] `npx @opengsd/gsd-pi@latest`; complete setup; select LLM provider (default to
+      latest Claude per project guidance); document keys in `docs/ENV_AND_VERCEL.md`.
+- [ ] Pick one existing `.specify/specs/*` kit; translate to GSD Pi
+      milestones/slices/tasks; deliver it end-to-end via `/gsd`.
+- [ ] Compare vs. Ouroboros: context fidelity, autonomy length, output quality.
+      Record findings back in `spec.md` (Open Questions → resolved).
+
+## Phase 3 — Cutover & compost (only after Phase 2 parity)
+- [ ] Map BARS Strand fork-space boundaries → GSD git worktrees.
+- [ ] Migrate `.agent/context/*` + `BACKLOG.md` into `.gsd/`.
+- [ ] Translate remaining `.specify/` kits (or archive completed ones).
+- [ ] Retire bespoke commands (`ooo *`, strand skills); **archive, don't delete**,
+      `.specify/` until rollback window closes.
+- [ ] Update `CLAUDE.md` + `docs/` to point workflow guidance at GSD.
+- [ ] Preserve dual-track: verify non-AI delivery mode still first-class.
+
+## Verification gates
+- [ ] Phase 1: MTGOA baseline captured; intentional UI change flagged by visual diff.
+- [ ] Phase 2: one feature shipped via GSD Pi with no bespoke fallback.
+- [ ] Phase 3: existing specs still build (`npm run check`); non-AI flows unaffected.

--- a/.specify/specs/opengsd-workflow-migration/tasks.md
+++ b/.specify/specs/opengsd-workflow-migration/tasks.md
@@ -10,18 +10,27 @@ parity is verified. `[x]` = done.
 - [ ] Owner confirms scope/sequencing of this spec.
 
 ## Phase 1 — GSD Browser (net-new, no risk to existing flows)
-- [ ] Provision headless Chromium for the runtime(s) that will run it:
-      `npx playwright install --with-deps chromium` (or distro chromium), wired
-      into a session-start / CI setup step.
-- [ ] `GSD_BROWSER_DEBUG=1 gsd-browser navigate https://example.com` — confirm the
-      daemon starts once Chromium is present.
-- [ ] Boot the MTGOA app (`cd mtgoa-game && npm run dev`) and capture a baseline:
-      `gsd-browser navigate http://localhost:5173/#l1-priya`
-      `gsd-browser screenshot --out .gsd-artifacts/priya-baseline.png`
-      `gsd-browser accessibility-tree --out .gsd-artifacts/priya-a11y.json`
-- [ ] Add `verify:ui` npm script (boot app → capture → diff).
+- [x] Provisioning script + browser resolution: `scripts/setup-gsd-browser.sh`
+      (`resolve` / `--install` / `--check`); resolves macOS Chrome, real Linux
+      binaries, or Playwright Chromium; `GSD_CHROME_PATH` override.
+- [x] SessionStart hook (`.claude/settings.json`) runs `--check` — fast, non-fatal
+      browser-readiness status on every web/CLI session.
+- [x] Generic capture script: `scripts/gsd-ui-verify.sh <url> [out] [name]`
+      (navigate → full-page PNG → accessibility-tree JSON).
+- [ ] **BLOCKED in sandbox — egress policy.** Chromium cannot be installed here:
+      `cdn.playwright.dev`, `dl.google.com`, `storage.googleapis.com` all return
+      `host_not_allowed`; Ubuntu Noble `chromium-browser` is a snap shim (won't run
+      headless). **To unblock:** allowlist `cdn.playwright.dev` in the env's network
+      egress (then `scripts/setup-gsd-browser.sh --install`), OR run the capture on a
+      machine with Chrome (e.g. macOS) where `setup-gsd-browser.sh` auto-resolves it.
+- [ ] Capture the MTGOA baseline (run where Chrome is available):
+      `cd mtgoa-game && npm run dev` then
+      `scripts/gsd-ui-verify.sh http://localhost:5173/#l1-priya .gsd-artifacts priya-baseline`
+      → produces `priya-baseline.png` + `priya-baseline.a11y.json`.
 - [ ] Wire visual-diff into the `UI_COVENANT` loop (element=color, altitude=border,
       stage=density); demo: an intentional color change must surface a diff.
+- [ ] Add the MTGOA `verify:ui` npm script to the game package (lives on PR #91 /
+      `claude/sweet-hopper-hs4pw2`) so it ships with the app.
 
 ## Phase 2 — GSD Pi pilot (parallel to bespoke; no removals)
 - [ ] `npx @opengsd/gsd-pi@latest`; complete setup; select LLM provider (default to

--- a/scripts/gsd-ui-verify.sh
+++ b/scripts/gsd-ui-verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# gsd-ui-verify.sh — capture a GSD Browser visual baseline for a running URL.
+#
+# Produces, for a given page: a full-page PNG screenshot and an accessibility
+# tree (JSON). Use it to baseline UI_COVENANT surfaces (element=color,
+# altitude=border, stage=density) and to diff against on later changes.
+#
+# Usage:
+#   scripts/gsd-ui-verify.sh <url> [out-dir] [name]
+#
+# Examples:
+#   # MTGOA Level-1 Priya trust loop (start the app first: cd mtgoa-game && npm run dev)
+#   scripts/gsd-ui-verify.sh http://localhost:5173/#l1-priya .gsd-artifacts priya-baseline
+#
+#   # Next.js page
+#   scripts/gsd-ui-verify.sh http://localhost:3000/market .gsd-artifacts market-baseline
+#
+# Requires a Chrome binary (resolved by setup-gsd-browser.sh). Override with
+# GSD_CHROME_PATH. The browser is found automatically on macOS (system Chrome).
+#
+set -euo pipefail
+
+URL="${1:?usage: gsd-ui-verify.sh <url> [out-dir] [name]}"
+OUT="${2:-.gsd-artifacts}"
+NAME="${3:-baseline}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GSD_VERSION="0.1.29"
+GSD=(npx -y "@opengsd/gsd-browser@${GSD_VERSION}")
+
+CHROME="$("${SCRIPT_DIR}/setup-gsd-browser.sh" resolve)"
+echo "Browser : ${CHROME}"
+echo "Target  : ${URL}"
+mkdir -p "${OUT}"
+
+# The daemon persists between commands, so navigate then capture in sequence.
+"${GSD[@]}" navigate "${URL}" --browser-path "${CHROME}"
+"${GSD[@]}" screenshot --browser-path "${CHROME}" --format png --full-page \
+  --output "${OUT}/${NAME}.png"
+"${GSD[@]}" accessibility-tree --browser-path "${CHROME}" --json \
+  > "${OUT}/${NAME}.a11y.json"
+
+echo "Wrote   : ${OUT}/${NAME}.png"
+echo "Wrote   : ${OUT}/${NAME}.a11y.json"
+echo "Re-run after a change and diff the PNG / a11y JSON to verify the surface."

--- a/scripts/setup-gsd-browser.sh
+++ b/scripts/setup-gsd-browser.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# setup-gsd-browser.sh — resolve (or install) a Chrome/Chromium binary for GSD Browser.
+#
+# GSD Browser (@opengsd/gsd-browser) drives Chrome over the DevTools Protocol and
+# does NOT bundle a browser — it needs a real Chrome/Chromium binary on disk.
+# This script finds one (or installs Playwright's Chromium) and prints its path.
+#
+# Modes:
+#   (default)   Resolve an existing browser. Print path to stdout, exit 0.
+#               If none found, print guidance to stderr, exit 1.
+#   --install   As above, but download Playwright Chromium if none is found.
+#   --check     Never fail (exit 0 always). For SessionStart hooks: prints a
+#               one-line status to stderr; does not download anything.
+#
+# Resolution order:
+#   1. $GSD_CHROME_PATH                (explicit override — set this in CI/web)
+#   2. macOS system Google Chrome
+#   3. A real Linux google-chrome / chromium binary (NOT the Ubuntu snap shim)
+#   4. Playwright-managed Chromium under ~/.cache/ms-playwright
+#
+# NETWORK NOTE: installing Chromium downloads from cdn.playwright.dev. In
+# restrictive egress environments (e.g. Claude Code web with a strict network
+# policy) that host must be allowlisted, OR set $GSD_CHROME_PATH to a
+# pre-installed browser. Hosts confirmed BLOCKED in our sandbox (2026-06-12):
+# cdn.playwright.dev, dl.google.com, storage.googleapis.com. The Ubuntu Noble
+# `chromium-browser` apt package is only a snap shim and will not run headless.
+#
+set -euo pipefail
+
+MODE="${1:-resolve}"
+
+is_script() { head -c2 "$1" 2>/dev/null | grep -q '#!'; }   # detect snap/shell shims
+
+find_chrome() {
+  # 1. explicit override
+  if [[ -n "${GSD_CHROME_PATH:-}" && -x "${GSD_CHROME_PATH}" ]]; then
+    echo "${GSD_CHROME_PATH}"; return 0
+  fi
+  # 2. macOS
+  local mac="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  [[ -x "$mac" ]] && { echo "$mac"; return 0; }
+  local mac_canary="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
+  [[ -x "$mac_canary" ]] && { echo "$mac_canary"; return 0; }
+  # 3. real Linux binaries (skip the snap shim, which is a shell script)
+  local c p
+  for c in google-chrome google-chrome-stable chromium chromium-browser; do
+    p="$(command -v "$c" 2>/dev/null || true)"
+    if [[ -n "$p" ]] && ! is_script "$p"; then echo "$p"; return 0; fi
+  done
+  # 4. Playwright-managed chromium
+  p="$(ls -d "${HOME}/.cache/ms-playwright"/chromium-*/chrome-linux/chrome 2>/dev/null | sort | tail -1 || true)"
+  [[ -n "$p" && -x "$p" ]] && { echo "$p"; return 0; }
+  return 1
+}
+
+GUIDANCE="No Chrome/Chromium found for GSD Browser.
+  • Local dev: install Google Chrome, or run: scripts/setup-gsd-browser.sh --install
+  • Restricted egress (web/CI): allowlist cdn.playwright.dev then --install,
+    or set GSD_CHROME_PATH=/path/to/chrome"
+
+case "$MODE" in
+  --check)
+    if path="$(find_chrome)"; then
+      echo "✓ GSD Browser: using $path" >&2
+    else
+      echo "ℹ GSD Browser: no Chrome yet. ${GUIDANCE}" >&2
+    fi
+    exit 0
+    ;;
+  --install)
+    if path="$(find_chrome)"; then echo "$path"; exit 0; fi
+    echo "No Chrome found — installing Playwright Chromium…" >&2
+    npx -y playwright@latest install chromium >&2
+    path="$(ls -d "${HOME}/.cache/ms-playwright"/chromium-*/chrome-linux/chrome 2>/dev/null | sort | tail -1 || true)"
+    if [[ -z "$path" || ! -x "$path" ]]; then
+      echo "ERROR: Chromium install failed (egress?). ${GUIDANCE}" >&2
+      exit 1
+    fi
+    echo "$path"
+    ;;
+  resolve|*)
+    if path="$(find_chrome)"; then echo "$path"; exit 0; fi
+    echo "${GUIDANCE}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Phase 1 of adopting **OpenGSD** ("Git. Ship. Done.") as the project's AI-assisted development workflow, plus the decision record for migrating bars-engine's bespoke stack (Ouroboros, Spec-Kit tooling, BARS Strand System) onto it.

This PR is **net-new and non-breaking** — it adds tooling and docs, touches no existing app/spec behavior.

## What's here

**Decision record** — `.specify/specs/opengsd-workflow-migration/` (spec.md / plan.md / tasks.md):
- Ratified decision to adopt OpenGSD and incrementally migrate the bespoke stack (functionality is replicated, but GSD is more mature and community-maintained — ends sole-maintainership).
- Mapping table: Ouroboros→GSD Pi, Spec-Kit→Pi milestones/`.gsd/`, Strands→git worktrees, and **GSD Browser as net-new** visual verification for `UI_COVENANT`.
- Phased, revertable plan: GSD Browser first → GSD Pi pilot in parallel → cutover + compost only after parity. Guardrails for dual-track/non-AI legibility and young-dependency lock-in.

**GSD Browser provisioning + verification (Phase 1):**
- `scripts/setup-gsd-browser.sh` — resolve-or-install a Chrome/Chromium binary for GSD Browser (CDP). Resolves macOS Chrome, real Linux binaries (skips the Ubuntu snap shim), or Playwright Chromium; honors `GSD_CHROME_PATH`. Modes: `resolve` / `--install` / `--check`.
- `scripts/gsd-ui-verify.sh` — capture a baseline (full-page PNG + accessibility tree) for any running URL; ready for the MTGOA Level-1 Priya screen.
- `.claude/settings.json` — SessionStart hook runs `--check` (fast, non-fatal browser-readiness report). `.gitignore` un-ignores **only** this file so the hook is shared without committing private Claude config.
- `.gitignore` — ignore `.gsd-artifacts/`.

## Environment finding

The web/remote sandbox's egress allowlist blocks every browser-binary CDN (`cdn.playwright.dev`, `dl.google.com`, `storage.googleapis.com` → `host_not_allowed`; the Ubuntu Noble `chromium-browser` apt package is a non-runnable snap shim). So the **live baseline capture must run where Chrome is reachable** (e.g. macOS, where the scripts auto-resolve system Chrome) or after allowlisting `cdn.playwright.dev`. Recorded in the spec's `tasks.md`.

## Follow-ups (tracked in tasks.md)

- Capture the MTGOA baseline + wire visual-diff into the `UI_COVENANT` loop.
- Add a `verify:ui` npm script to the MTGOA game package (PR #91 / `claude/sweet-hopper-hs4pw2`).
- Phase 2 GSD Pi pilot; Phase 3 cutover + compost.

> Split from the combined branch per review request. The P3009 migration fix is in a separate PR.

https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS)_