### PR TITLE
Add /handbook digital reader route (front-of-book slice)

### DIFF
--- a/public/handbook/front-of-book.json
+++ b/public/handbook/front-of-book.json
@@ -1,0 +1,63 @@
+{
+  "id": "front-of-book",
+  "kicker": "Mastering the Game of Allyship",
+  "title": "Prologue · The Call to Play",
+  "blocks": [
+    {
+      "type": "hero",
+      "art": "pyrakanth-bold-heart.png",
+      "kicker": "A SCHOOL-SHIP RPG",
+      "title": "Mastering the\nGame of Allyship",
+      "sub": "Become useful under pressure."
+    },
+    {
+      "type": "prose",
+      "kicker": "Prologue · The City With the Dry River",
+      "lead": "The first thing you notice is the silence.",
+      "paras": [
+        "Not the absence of sound. The square is full of it: banners snapping in dry wind, a councilor's amplified welcome ringing too bright against the old buildings.",
+        "But the people are silent where it matters. No one says the river is gone. No one says the council locked the water before the ship arrived.",
+        "Above the square, hidden by cloud and old agreements, the school-ship holds position. The Headmaster watches the ceremony through rain-glass windows."
+      ]
+    },
+    {
+      "type": "pullquote",
+      "text": "“They are grateful too early,” she says. “You will want to fix this. That is not yet the same as helping.”"
+    },
+    {
+      "type": "letter",
+      "kicker": "From the Headmaster",
+      "lead": "You were not chosen because you were ready. No one arrives ready.",
+      "paras": [
+        "Readiness is not the price of admission. **Willingness is.** You will be tempted to arrive as the answer. Do not. A clean intention can still bruise. This is not a reason to do nothing — it is a reason to train.",
+        "Welcome aboard. The ship is moving. The lesson will begin before you feel prepared."
+      ],
+      "signature": "the Headmaster",
+      "signatureNote": "— signed, but not named,",
+      "seal": "護"
+    },
+    {
+      "type": "prose",
+      "kicker": "What this game is",
+      "lead": "Each mission asks the same impossible question — **what does help require here?**",
+      "paras": [
+        "You play students of a hidden traveling academy that answers crises ordinary institutions cannot or will not resolve. This is not a game about proving your character is good. It is about what happens when your help meets reality."
+      ]
+    },
+    { "type": "moves" },
+    { "type": "houses" },
+    {
+      "type": "roll",
+      "scene": "The council keeps thanking the ship — but no one looks at the child holding the empty cup. You stop watching the stage and read the crowd. *Who tenses? Who looks away?*",
+      "move": "WAKE UP",
+      "stat": "+SENSE · Body"
+    },
+    {
+      "type": "barPrompt",
+      "kicker": "Your first move · write a BAR",
+      "prompt": "What signal brought you here — and the one move you are willing to make right now?"
+    },
+    { "type": "nations" },
+    { "type": "footer", "nextLabel": "Continue to Chapter One ›" }
+  ]
+}

--- a/src/actions/campaign-domain-preference.ts
+++ b/src/actions/campaign-domain-preference.ts
@@ -3,6 +3,9 @@
 import { db } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 import { getCurrentPlayer } from '@/lib/auth'
+import { parseCampaignDomainPreference } from '@/lib/allyship-domains'
+
+const VALID_DOMAIN_KEYS = ['GATHERING_RESOURCES', 'DIRECT_ACTION', 'RAISE_AWARENESS', 'SKILLFUL_ORGANIZING']
 
 /**
  * Update the player's campaign domain preference (multi-select).
@@ -12,14 +15,44 @@ export async function updateCampaignDomainPreference(domains: string[]) {
   const player = await getCurrentPlayer()
   if (!player) return { error: 'Not logged in' }
 
-  const validKeys = ['GATHERING_RESOURCES', 'DIRECT_ACTION', 'RAISE_AWARENESS', 'SKILLFUL_ORGANIZING']
-  const filtered = domains.filter((d) => validKeys.includes(d))
+  const filtered = domains.filter((d) => VALID_DOMAIN_KEYS.includes(d))
 
   const value = filtered.length > 0 ? JSON.stringify(filtered) : null
 
   await db.player.update({
     where: { id: player.id },
     data: { campaignDomainPreference: value },
+  })
+
+  revalidatePath('/bars/available')
+  revalidatePath('/')
+  return { success: true }
+}
+
+/**
+ * Add a single allyship domain to the player's preference without removing any
+ * existing ones (non-destructive). Used by the Handbook reader's House select
+ * (HOOK A): tapping a House records that the player works in that domain.
+ *
+ * Returns { pending: true } for logged-out readers so the client can keep using
+ * its localStorage fallback (mirrors createOnboardingBar / createHandbookBar).
+ */
+export async function addCampaignDomainPreference(
+  domain: string
+): Promise<{ success: true } | { pending: true } | { error: string }> {
+  if (!VALID_DOMAIN_KEYS.includes(domain)) return { error: 'Unknown allyship domain' }
+
+  const player = await getCurrentPlayer()
+  if (!player) return { pending: true }
+
+  const current = parseCampaignDomainPreference(player.campaignDomainPreference ?? null)
+  if (current.includes(domain)) return { success: true } // already recorded
+
+  const merged = Array.from(new Set([...current, domain])).filter((d) => VALID_DOMAIN_KEYS.includes(d))
+
+  await db.player.update({
+    where: { id: player.id },
+    data: { campaignDomainPreference: JSON.stringify(merged) },
   })
 
   revalidatePath('/bars/available')

--- a/src/actions/handbook-bar.ts
+++ b/src/actions/handbook-bar.ts
@@ -1,0 +1,88 @@
+'use server'
+
+import { db } from '@/lib/db'
+import { cookies } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+
+/**
+ * HOOK B — "Plant this seed" from the Handbook reader.
+ *
+ * Creates a private `player_response` BAR from a Handbook prompt + the reader's
+ * answer, so it lands in the player's hand like any other BAR. Mirrors the shape
+ * `data/chapters/mtgoa/chapter-1.ts` defines for its `barCreationMoments`
+ * ("Name the Call"): { promptText, response, defaultMoveType, barTypeHint }.
+ *
+ * Follows `createOnboardingBar`'s contract: when the reader is not authenticated
+ * it returns `{ pending: true }` so the client can fall back to localStorage.
+ */
+export interface HandbookBarPayload {
+  promptText: string
+  response: string
+  defaultMoveType?: string
+  barTypeHint?: string
+}
+
+export async function createHandbookBar(
+  payload: HandbookBarPayload
+): Promise<
+  | { success: true; barId: string }
+  | { pending: true }
+  | { error: string }
+> {
+  const response = (payload.response || '').trim()
+  if (response.length < 3) {
+    return { error: 'Write at least a few words before planting this seed.' }
+  }
+
+  const cookieStore = await cookies()
+  const playerId = cookieStore.get('bars_player_id')?.value
+  if (!playerId) {
+    // Logged-out readers persist locally; client handles the fallback.
+    return { pending: true }
+  }
+
+  const firstLine = response.split(/\r?\n/)[0] || ''
+  const title = (firstLine.length <= 80 ? firstLine : firstLine.slice(0, 77) + '...') || 'Name the Call'
+
+  const completionEffects = JSON.stringify({
+    source: 'handbook',
+    promptText: payload.promptText,
+    barTypeHint: payload.barTypeHint || 'player_response',
+  })
+
+  try {
+    const bar = await db.customBar.create({
+      data: {
+        creatorId: playerId,
+        title,
+        description: response,
+        type: 'bar',
+        reward: 0,
+        inputs: JSON.stringify([
+          { key: 'response', label: 'Response', type: 'text', placeholder: '' },
+        ]),
+        visibility: 'private',
+        status: 'active',
+        moveType: payload.defaultMoveType || 'wakeUp',
+        storyPath: 'collective',
+        storyContent: payload.promptText || null,
+        completionEffects,
+        rootId: 'temp',
+      },
+    })
+
+    await db.customBar.update({
+      where: { id: bar.id },
+      data: { rootId: bar.id },
+    })
+
+    revalidatePath('/bars')
+    revalidatePath('/hand')
+    revalidatePath('/')
+    return { success: true, barId: bar.id }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Unknown error'
+    console.error('[HANDBOOK] BAR create failed:', message)
+    return { error: 'Could not plant this seed. Please try again.' }
+  }
+}

--- a/src/app/handbook/layout.tsx
+++ b/src/app/handbook/layout.tsx
@@ -1,0 +1,18 @@
+// Full-screen reader shell, mirroring the Oracle route's layout. Loads the six
+// book fonts here (the rest of the app uses Geist; these are scoped additions).
+export default function HandbookLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+      {/* eslint-disable-next-line @next/next/no-page-custom-font -- App Router has no _document; book fonts are scoped to this route */}
+      <link
+        href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Caveat:wght@400;600;700&family=Spline+Sans+Mono:wght@400;500;600&family=Marcellus&family=Ma+Shan+Zheng&display=swap"
+        rel="stylesheet"
+      />
+      <div className="fixed inset-0 z-[60]" style={{ background: "#0a0a0c" }}>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/app/handbook/page.tsx
+++ b/src/app/handbook/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { HandbookReader } from "@/components/handbook/HandbookReader";
+
+export const metadata: Metadata = {
+  title: "The Handbook — Mastering the Game of Allyship",
+  description: "A phone-first digital reader for the front of the book.",
+};
+
+export default function HandbookPage() {
+  return <HandbookReader chapterId="front-of-book" />;
+}

--- a/src/components/handbook/HandbookReader.tsx
+++ b/src/components/handbook/HandbookReader.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { SEAL, SPREAD_ART } from "@/lib/handbook/assets";
+import type { Block, Chapter } from "@/lib/handbook/content";
+import { createHandbookBar } from "@/actions/handbook-bar";
+import { HeroBlock } from "@/components/handbook/blocks/HeroBlock";
+import { ProseBlock } from "@/components/handbook/blocks/ProseBlock";
+import { PullquoteBlock } from "@/components/handbook/blocks/PullquoteBlock";
+import { LetterBlock } from "@/components/handbook/blocks/LetterBlock";
+import { MovesBlock } from "@/components/handbook/blocks/MovesBlock";
+import { HandlesBlock } from "@/components/handbook/blocks/HandlesBlock";
+import { HousesBlock } from "@/components/handbook/blocks/HousesBlock";
+import { RollBlock, type DiceResult } from "@/components/handbook/blocks/RollBlock";
+import { BarPromptBlock } from "@/components/handbook/blocks/BarPromptBlock";
+import { NationsBlock } from "@/components/handbook/blocks/NationsBlock";
+import { FooterBlock } from "@/components/handbook/blocks/FooterBlock";
+
+// localStorage fallbacks (namespace mtgoa_handbook_) — used until server
+// persistence is wired. See handoff HOOK A / HOOK B.
+const LS_HOUSE = "mtgoa_handbook_house";
+const LS_BAR = "mtgoa_handbook_bar";
+const LS_POS = "mtgoa_handbook_pos";
+
+type View = "read" | "spread";
+
+export function HandbookReader({ chapterId }: { chapterId: string }) {
+  const [chapter, setChapter] = useState<Chapter | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Interaction state
+  const [dice, setDice] = useState<DiceResult | null>(null);
+  const [house, setHouse] = useState<string | null>(null);
+  const [view, setView] = useState<View>("read");
+
+  // BAR (HOOK B) state
+  const [barDraft, setBarDraft] = useState("");
+  const [barText, setBarText] = useState("");
+  const [barSaved, setBarSaved] = useState(false);
+  const [barSaving, setBarSaving] = useState(false);
+  const [barError, setBarError] = useState<string | null>(null);
+
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const progRef = useRef<HTMLDivElement>(null);
+
+  // Load chapter content (data-driven, like OracleReader loads the deck).
+  useEffect(() => {
+    fetch(`/handbook/${chapterId}.json`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Could not load chapter.");
+        return r.json() as Promise<Chapter>;
+      })
+      .then(setChapter)
+      .catch(() => setError("This chapter could not be loaded."));
+  }, [chapterId]);
+
+  // Restore persisted state from localStorage fallbacks.
+  useEffect(() => {
+    try {
+      const h = localStorage.getItem(LS_HOUSE);
+      if (h) setHouse(h);
+      const b = localStorage.getItem(LS_BAR);
+      if (b) {
+        setBarText(b);
+        setBarSaved(true);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Scroll progress + resume. (Oracle has no resume; added here per handoff.)
+  useEffect(() => {
+    if (!chapter) return;
+    const body = bodyRef.current;
+    if (!body) return;
+
+    try {
+      const saved = parseInt(localStorage.getItem(LS_POS) || "0", 10);
+      if (saved) body.scrollTop = saved;
+    } catch {
+      /* ignore */
+    }
+
+    const onScroll = () => {
+      const max = body.scrollHeight - body.clientHeight;
+      const p = max > 0 ? Math.min(100, (body.scrollTop / max) * 100) : 0;
+      if (progRef.current) progRef.current.style.width = `${p}%`;
+      try {
+        localStorage.setItem(LS_POS, String(Math.round(body.scrollTop)));
+      } catch {
+        /* ignore */
+      }
+    };
+    body.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => body.removeEventListener("scroll", onScroll);
+  }, [chapter]);
+
+  // HOOK A — House select. Persists to the player's identity once available;
+  // localStorage is the fallback for logged-out readers (and until a House
+  // field exists on the player record).
+  const pickHouse = useCallback((name: string) => {
+    setHouse(name);
+    try {
+      localStorage.setItem(LS_HOUSE, name);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Dice — pure client. 2d6 + 1.
+  const rollDice = useCallback(() => {
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    const total = d1 + d2 + 1;
+    let tier: string;
+    let txt: string;
+    if (total >= 10) {
+      tier = "10+ · strong hit";
+      txt = "Your read lands cleanly. Ask three questions; choose two benefits.";
+    } else if (total >= 7) {
+      tier = "7–9 · mixed hit";
+      txt = "You see it — and you are seen. Ask one question; the Guide adds a cost.";
+    } else {
+      tier = "6– · a truth";
+      txt = "The answer implicates you. Gain 1 Adversity; mark Growth if you name your impact.";
+    }
+    setDice({ d1, d2, total, tier, txt });
+  }, []);
+
+  // HOOK B — BAR creation. Calls the server action; falls back to localStorage
+  // when the reader is logged out (action returns { pending: true }).
+  const saveBar = useCallback(
+    async (prompt: string) => {
+      const value = barDraft.trim();
+      if (!value) {
+        setBarError("Write the call before you plant it.");
+        return;
+      }
+      setBarSaving(true);
+      setBarError(null);
+      try {
+        const result = await createHandbookBar({
+          promptText: prompt,
+          response: value,
+          defaultMoveType: "wakeUp",
+          barTypeHint: "player_response",
+        });
+        if ("error" in result) {
+          setBarError(result.error);
+          return;
+        }
+        // success or pending — persist locally and show the planted state.
+        try {
+          localStorage.setItem(LS_BAR, value);
+        } catch {
+          /* ignore */
+        }
+        setBarText(value);
+        setBarSaved(true);
+      } catch {
+        setBarError("Could not plant this seed. Please try again.");
+      } finally {
+        setBarSaving(false);
+      }
+    },
+    [barDraft]
+  );
+
+  const editBar = useCallback(() => {
+    setBarDraft(barText);
+    setBarSaved(false);
+    try {
+      localStorage.removeItem(LS_BAR);
+    } catch {
+      /* ignore */
+    }
+  }, [barText]);
+
+  const renderBlock = (block: Block, i: number) => {
+    switch (block.type) {
+      case "hero":
+        return <HeroBlock key={i} {...block} />;
+      case "prose":
+        return <ProseBlock key={i} kicker={block.kicker} lead={block.lead} paras={block.paras} />;
+      case "pullquote":
+        return <PullquoteBlock key={i} text={block.text} />;
+      case "letter":
+        return <LetterBlock key={i} {...block} />;
+      case "moves":
+        return <MovesBlock key={i} />;
+      case "handles":
+        return <HandlesBlock key={i} />;
+      case "houses":
+        return <HousesBlock key={i} selected={house} onSelect={pickHouse} />;
+      case "roll":
+        return <RollBlock key={i} {...block} dice={dice} onRoll={rollDice} />;
+      case "barPrompt":
+        return (
+          <BarPromptBlock
+            key={i}
+            kicker={block.kicker}
+            prompt={block.prompt}
+            saved={barSaved}
+            savedText={barText}
+            draft={barDraft}
+            onDraftChange={setBarDraft}
+            onSave={() => saveBar(block.prompt)}
+            onEdit={editBar}
+            saving={barSaving}
+            error={barError}
+          />
+        );
+      case "nations":
+        return <NationsBlock key={i} />;
+      case "footer":
+        return <FooterBlock key={i} nextLabel={block.nextLabel} />;
+      default:
+        return null;
+    }
+  };
+
+  if (error) {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          background: COLOR.paper,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: FONT.body,
+          color: COLOR.body,
+          padding: 24,
+          textAlign: "center",
+        }}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        flexDirection: "column",
+        background: COLOR.paper,
+        overflow: "hidden",
+      }}
+    >
+      {/* Keyframes + hide the reader's scrollbar. */}
+      <style>{`
+        @keyframes handbookFadeUp { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+        .handbook-rdr::-webkit-scrollbar { width: 0; background: transparent; }
+        .handbook-rdr { scrollbar-width: none; }
+        @media print {
+          .handbook-chrome, .handbook-status { display: none !important; }
+        }
+      `}</style>
+
+      {/* status bar */}
+      <div
+        className="handbook-status"
+        style={{
+          height: 34,
+          flex: "0 0 auto",
+          background: COLOR.midnight,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 22px",
+          color: "#e7ddc9",
+        }}
+      >
+        <span style={{ fontFamily: FONT.mono, fontSize: 11, letterSpacing: "0.04em" }}>The Handbook</span>
+        <span style={{ fontFamily: FONT.mono, fontSize: 10, letterSpacing: "0.06em", opacity: 0.85 }}>
+          phone-first
+        </span>
+      </div>
+
+      {/* app header */}
+      <div
+        className="handbook-chrome"
+        style={{
+          flex: "0 0 auto",
+          background: COLOR.midnight,
+          color: "#e7ddc9",
+          padding: "6px 16px 11px",
+          borderBottom: "1px solid #2a3047",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            aria-label="Back"
+            style={{ background: "transparent", border: "none", fontFamily: FONT.mono, fontSize: 16, color: COLOR.gold, lineHeight: 1, cursor: "pointer", padding: 0 }}
+          >
+            ‹
+          </button>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: FONT.mono, fontSize: 8.5, letterSpacing: "0.18em", color: COLOR.steel, textTransform: "uppercase" }}>
+              {chapter?.kicker ?? " "}
+            </div>
+            <div style={{ fontFamily: FONT.display, fontWeight: 600, fontSize: 17, color: "#f1ead9", lineHeight: 1.05 }}>
+              {chapter?.title ?? " "}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setView("spread")}
+            style={{ display: "flex", alignItems: "center", gap: 5, border: "1px solid #4a5168", borderRadius: 14, padding: "4px 9px", cursor: "pointer", background: "transparent" }}
+          >
+            <span style={{ fontFamily: FONT.mono, fontSize: 9, letterSpacing: "0.06em", color: COLOR.gold }}>PRINT</span>
+            <div style={{ width: 13, height: 11, border: `1px solid ${COLOR.gold}`, borderRadius: 1 }} />
+          </button>
+        </div>
+        <div style={{ height: 2, background: "#2a3047", borderRadius: 2, marginTop: 9, overflow: "hidden" }}>
+          <div
+            ref={progRef}
+            style={{ height: "100%", width: "0%", background: `linear-gradient(90deg, ${COLOR.cinnabar}, ${COLOR.gold})`, transition: "width .15s ease" }}
+          />
+        </div>
+      </div>
+
+      {/* reader body (reflow) */}
+      <div
+        ref={bodyRef}
+        className="handbook-rdr"
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: "auto",
+          background: COLOR.paper,
+          backgroundImage: `radial-gradient(130% 60% at 50% 0%, ${COLOR.paperHi} 0%, ${COLOR.paper} 60%)`,
+        }}
+      >
+        {chapter?.blocks.map(renderBlock)}
+        <div style={{ height: 40 }} />
+      </div>
+
+      {/* print / spread overlay — same content, fixed spread ("author once, render twice") */}
+      {view === "spread" && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 20,
+            background: "rgba(10,11,16,.92)",
+            backdropFilter: "blur(3px)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 22,
+          }}
+        >
+          <div style={{ fontFamily: FONT.mono, fontSize: 9, letterSpacing: "0.18em", color: COLOR.gold, textTransform: "uppercase", marginBottom: 10, textAlign: "center" }}>
+            Print layout · what your book designer receives
+          </div>
+          <div style={{ width: 340, height: 220, boxShadow: "0 20px 50px rgba(0,0,0,.5)", display: "flex", overflow: "hidden", background: COLOR.paper }}>
+            <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={SPREAD_ART} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+              <div style={{ position: "absolute", inset: 0, background: "linear-gradient(180deg,transparent 55%,rgba(8,10,18,.8))" }} />
+              <div style={{ position: "absolute", left: 9, bottom: 8, fontFamily: FONT.display, fontWeight: 600, fontSize: 12, color: COLOR.goldLt }}>
+                An Invitation
+              </div>
+            </div>
+            <div style={{ flex: 1, background: COLOR.paper, padding: 13, display: "flex", flexDirection: "column", justifyContent: "center" }}>
+              <div style={{ fontFamily: FONT.mono, fontSize: 6, letterSpacing: "0.18em", color: COLOR.lanternbearers }}>FROM THE HEADMASTER</div>
+              <div style={{ fontFamily: FONT.display, fontStyle: "italic", fontSize: 11, color: "#1d1a15", lineHeight: 1.25, margin: "6px 0" }}>
+                You were not chosen because you were ready.
+              </div>
+              <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginTop: 6 }}>
+                <div style={{ fontFamily: FONT.hand, fontWeight: 700, fontSize: 15, color: "#1d1a15", lineHeight: 0.9 }}>the Headmaster</div>
+                <div style={{ width: 26, height: 26, background: COLOR.cinnabar, borderRadius: 2, display: "grid", placeItems: "center" }}>
+                  <span style={{ fontFamily: FONT.seal, fontSize: 16, color: "#f6ece0" }}>{SEAL}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style={{ fontFamily: FONT.mono, fontSize: 10, color: "#9aa3b6", marginTop: 12, textAlign: "center", maxWidth: 300, lineHeight: 1.5 }}>
+            Same content, same skin — poured into the fixed 8.5×11 spread. The reader on your phone and the printer&apos;s
+            page come from one source.
+          </div>
+          <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+            <button
+              type="button"
+              onClick={() => setView("read")}
+              style={{ border: `1px solid ${COLOR.gold}`, borderRadius: 5, padding: "8px 16px", fontFamily: FONT.mono, fontSize: 11, color: COLOR.gold, cursor: "pointer", background: "transparent" }}
+            >
+              ‹ Back to reading
+            </button>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              style={{ background: COLOR.gold, border: "none", borderRadius: 5, padding: "8px 16px", fontFamily: FONT.mono, fontSize: 11, color: COLOR.midnight, fontWeight: 600, cursor: "pointer" }}
+            >
+              Export PDF ⤓
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/handbook/HandbookReader.tsx
+++ b/src/components/handbook/HandbookReader.tsx
@@ -5,13 +5,14 @@ import { COLOR, FONT } from "@/lib/handbook/tokens";
 import { SEAL, SPREAD_ART } from "@/lib/handbook/assets";
 import type { Block, Chapter } from "@/lib/handbook/content";
 import { createHandbookBar } from "@/actions/handbook-bar";
+import { addCampaignDomainPreference } from "@/actions/campaign-domain-preference";
 import { HeroBlock } from "@/components/handbook/blocks/HeroBlock";
 import { ProseBlock } from "@/components/handbook/blocks/ProseBlock";
 import { PullquoteBlock } from "@/components/handbook/blocks/PullquoteBlock";
 import { LetterBlock } from "@/components/handbook/blocks/LetterBlock";
 import { MovesBlock } from "@/components/handbook/blocks/MovesBlock";
 import { HandlesBlock } from "@/components/handbook/blocks/HandlesBlock";
-import { HousesBlock } from "@/components/handbook/blocks/HousesBlock";
+import { HousesBlock, HOUSES } from "@/components/handbook/blocks/HousesBlock";
 import { RollBlock, type DiceResult } from "@/components/handbook/blocks/RollBlock";
 import { BarPromptBlock } from "@/components/handbook/blocks/BarPromptBlock";
 import { NationsBlock } from "@/components/handbook/blocks/NationsBlock";
@@ -98,15 +99,23 @@ export function HandbookReader({ chapterId }: { chapterId: string }) {
     return () => body.removeEventListener("scroll", onScroll);
   }, [chapter]);
 
-  // HOOK A — House select. Persists to the player's identity once available;
-  // localStorage is the fallback for logged-out readers (and until a House
-  // field exists on the player record).
+  // HOOK A — House select. Records the player's allyship domain on their
+  // identity (campaignDomainPreference), added non-destructively so it doesn't
+  // clobber any domains they curated in the Market. localStorage mirrors the
+  // reader's own choice and is the fallback for logged-out readers.
   const pickHouse = useCallback((name: string) => {
     setHouse(name);
     try {
       localStorage.setItem(LS_HOUSE, name);
     } catch {
       /* ignore */
+    }
+    const domainKey = HOUSES.find((h) => h.name === name)?.domainKey;
+    if (domainKey) {
+      // Fire-and-forget: the localStorage write above already reflects the UI.
+      void addCampaignDomainPreference(domainKey).catch(() => {
+        /* logged-out / transient — localStorage fallback stands */
+      });
     }
   }, []);
 

--- a/src/components/handbook/blocks/BarPromptBlock.tsx
+++ b/src/components/handbook/blocks/BarPromptBlock.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+export function BarPromptBlock({
+  kicker,
+  prompt,
+  saved,
+  savedText,
+  draft,
+  onDraftChange,
+  onSave,
+  onEdit,
+  saving,
+  error,
+}: {
+  kicker: string;
+  prompt: string;
+  saved: boolean;
+  savedText: string;
+  draft: string;
+  onDraftChange: (v: string) => void;
+  onSave: () => void;
+  onEdit: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  return (
+    <div style={{ marginTop: 24, padding: "26px 24px", background: COLOR.midnight }}>
+      <div style={{ fontFamily: FONT.mono, fontSize: 9.5, letterSpacing: "0.22em", color: "#caa978", textTransform: "uppercase" }}>
+        {kicker}
+      </div>
+      <p
+        style={{
+          fontFamily: FONT.display,
+          fontStyle: "italic",
+          fontWeight: 500,
+          fontSize: 20,
+          lineHeight: 1.32,
+          color: COLOR.goldLt,
+          margin: "12px 0 14px",
+        }}
+      >
+        {prompt}
+      </p>
+
+      {!saved ? (
+        <div>
+          <textarea
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            placeholder="Name the call…"
+            style={{
+              width: "100%",
+              minHeight: 84,
+              background: "#0c1018",
+              border: "1px solid #2a3047",
+              borderRadius: 8,
+              color: "#e7ddc9",
+              fontFamily: FONT.body,
+              fontSize: 16,
+              lineHeight: 1.5,
+              padding: 12,
+              resize: "none",
+              outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+          {error && (
+            <div style={{ fontFamily: FONT.mono, fontSize: 11, color: COLOR.cinnabar, marginTop: 8 }}>{error}</div>
+          )}
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            style={{
+              width: "100%",
+              marginTop: 11,
+              background: COLOR.gold,
+              border: "none",
+              borderRadius: 8,
+              padding: 12,
+              textAlign: "center",
+              cursor: saving ? "default" : "pointer",
+              opacity: saving ? 0.7 : 1,
+            }}
+          >
+            <span style={{ fontFamily: FONT.label, fontSize: 15, color: COLOR.midnight, letterSpacing: "0.03em" }}>
+              {saving ? "Planting…" : "Plant this seed ⟶"}
+            </span>
+          </button>
+        </div>
+      ) : (
+        <div
+          style={{
+            border: `1px solid ${COLOR.gold}`,
+            borderRadius: 8,
+            padding: 14,
+            background: "rgba(200,163,90,.08)",
+            animation: "handbookFadeUp .3s ease",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+            <span style={{ fontFamily: FONT.seal, fontSize: 18, color: COLOR.gold }}>種</span>
+            <span style={{ fontFamily: FONT.mono, fontSize: 9.5, letterSpacing: "0.14em", color: COLOR.gold }}>
+              SEED PLANTED · SAVED AS A BAR
+            </span>
+          </div>
+          <div style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 16, lineHeight: 1.5, color: "#ece6d6" }}>
+            “{savedText}”
+          </div>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 11 }}>
+            <span style={{ fontFamily: FONT.body, fontSize: 13, color: COLOR.steel }}>In the app, this lands in your hand.</span>
+            <button
+              type="button"
+              onClick={onEdit}
+              style={{
+                background: "transparent",
+                border: "none",
+                fontFamily: FONT.mono,
+                fontSize: 11,
+                color: COLOR.gold,
+                cursor: "pointer",
+                textDecoration: "underline",
+              }}
+            >
+              edit
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/FooterBlock.tsx
+++ b/src/components/handbook/blocks/FooterBlock.tsx
@@ -1,0 +1,19 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+export function FooterBlock({ nextLabel }: { nextLabel: string }) {
+  return (
+    <div style={{ marginTop: 20, padding: 24, textAlign: "center", borderTop: "1px solid #d5c8aa" }}>
+      <div style={{ fontFamily: FONT.mono, fontSize: 9, letterSpacing: "0.18em", color: "#9a8d72" }}>
+        — THE OPENING ENDS HERE —
+      </div>
+      <div style={{ marginTop: 14, display: "inline-block", border: `1px solid ${COLOR.cinnabar}`, borderRadius: 8, padding: "11px 20px", cursor: "pointer" }}>
+        <span style={{ fontFamily: FONT.label, fontSize: 15, color: COLOR.cinnabar }}>{nextLabel}</span>
+      </div>
+      <div style={{ fontFamily: FONT.mono, fontSize: 9, color: "#b3a583", marginTop: 16, lineHeight: 1.6 }}>
+        PROTOTYPE · front-of-book vertical slice
+        <br />
+        content + skin shared with the print export
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/HandlesBlock.tsx
+++ b/src/components/handbook/blocks/HandlesBlock.tsx
@@ -1,0 +1,34 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { Kicker } from "@/components/handbook/blocks/shared";
+
+/**
+ * Static reference of the six character handles. Canonical copy lives here.
+ * Not used by `front-of-book` yet, but defined so the reader's `switch` stays
+ * exhaustive and later chapters can drop in `{ "type": "handles" }`.
+ */
+const HANDLES: { name: string; gloss: string }[] = [
+  { name: "House", gloss: "your practice lineage — how you tend to help" },
+  { name: "School", gloss: "the discipline your Nation trains into you" },
+  { name: "Offer", gloss: "what you bring to the table" },
+  { name: "Cost", gloss: "what your help asks of you" },
+  { name: "Line", gloss: "the boundary you will not cross" },
+  { name: "Bond", gloss: "who you are accountable to" },
+];
+
+export function HandlesBlock() {
+  return (
+    <div style={{ padding: "24px 24px 6px" }}>
+      <Kicker>Your handles · what the sheet tracks</Kicker>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10, marginTop: 14 }}>
+        {HANDLES.map((h) => (
+          <div key={h.name} style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+            <span style={{ fontFamily: FONT.label, fontSize: 16, color: COLOR.ink, flex: "0 0 88px" }}>{h.name}</span>
+            <span style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 15, color: COLOR.muteInk, lineHeight: 1.4 }}>
+              {h.gloss}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/HeroBlock.tsx
+++ b/src/components/handbook/blocks/HeroBlock.tsx
@@ -1,0 +1,51 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { artSrc } from "@/lib/handbook/assets";
+
+export function HeroBlock({
+  art,
+  kicker,
+  title,
+  sub,
+}: {
+  art: string;
+  kicker: string;
+  title: string;
+  sub: string;
+}) {
+  return (
+    <div style={{ position: "relative", height: 300, overflow: "hidden", background: COLOR.lacquer }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={artSrc(art)}
+        alt=""
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover", opacity: 0.82 }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background:
+            "linear-gradient(180deg, rgba(8,10,18,.25), transparent 40%, rgba(8,10,18,.9))",
+        }}
+      />
+      <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, padding: "22px 22px 24px", textAlign: "center" }}>
+        <div style={{ fontFamily: FONT.mono, fontSize: 9, letterSpacing: "0.24em", color: "#e3b98c" }}>{kicker}</div>
+        <div
+          style={{
+            fontFamily: FONT.display,
+            fontWeight: 600,
+            fontSize: 33,
+            lineHeight: 1.04,
+            color: "#f4ecda",
+            margin: "8px 0 6px",
+            whiteSpace: "pre-line",
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ width: 40, height: 1, background: COLOR.gold, margin: "0 auto 8px" }} />
+        <div style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 13, color: "#cbd2dc" }}>{sub}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/HousesBlock.tsx
+++ b/src/components/handbook/blocks/HousesBlock.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+// Canonical House copy — static block; the only data is the player's choice.
+export const HOUSES: { name: string; domain: string; question: string; accent: string; domainColor: string }[] = [
+  { name: "Provisioners", domain: "GATHER RESOURCES", question: "“What is actually depleted?”", accent: COLOR.provisioners, domainColor: "#c08a5a" },
+  { name: "Weavers", domain: "SKILLFUL ORGANIZING", question: "“What structure lets work continue?”", accent: COLOR.weavers, domainColor: "#c8975a" },
+  { name: "Linekeepers", domain: "DIRECT ACTION", question: "“What line must be drawn?”", accent: COLOR.linekeepers, domainColor: "#d06a52" },
+  { name: "Lanternbearers", domain: "RAISE AWARENESS", question: "“What truth must become visible?”", accent: COLOR.lanternbearers, domainColor: COLOR.gold },
+];
+
+export function HousesBlock({
+  selected,
+  onSelect,
+}: {
+  selected: string | null;
+  onSelect: (name: string) => void;
+}) {
+  return (
+    <div style={{ marginTop: 24, padding: "24px 24px 8px", background: COLOR.midnight }}>
+      <div style={{ fontFamily: FONT.mono, fontSize: 9.5, letterSpacing: "0.22em", color: "#caa978", textTransform: "uppercase" }}>
+        Which House would you be in?
+      </div>
+      <p style={{ fontFamily: FONT.body, fontSize: 15.5, lineHeight: 1.5, color: COLOR.steelLt, margin: "9px 0 14px" }}>
+        Tap to choose your practice lineage. It saves to your character — and the app remembers.
+      </p>
+
+      {selected && (
+        <div
+          style={{
+            background: "rgba(200,163,90,.12)",
+            border: `1px solid ${COLOR.gold}`,
+            borderRadius: 8,
+            padding: "9px 12px",
+            marginBottom: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 9,
+          }}
+        >
+          <span style={{ color: COLOR.gold, fontSize: 15 }}>✦</span>
+          <span style={{ fontFamily: FONT.body, fontSize: 15, color: "#e7ddc9" }}>
+            You joined the <b style={{ color: COLOR.goldLt }}>{selected}</b> — saved to your record.
+          </span>
+        </div>
+      )}
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+        {HOUSES.map((h) => {
+          const isSelected = selected === h.name;
+          return (
+            <button
+              key={h.name}
+              type="button"
+              onClick={() => onSelect(h.name)}
+              style={{
+                textAlign: "left",
+                background: COLOR.card,
+                border: `1px solid #2a3047`,
+                borderTop: `3px solid ${h.accent}`,
+                borderRadius: 7,
+                padding: "12px 13px",
+                cursor: "pointer",
+                position: "relative",
+              }}
+            >
+              <div style={{ fontFamily: FONT.display, fontWeight: 700, fontSize: 18, color: "#f1ead9", lineHeight: 1 }}>
+                {h.name}
+              </div>
+              <div style={{ fontFamily: FONT.mono, fontSize: 7.5, color: h.domainColor, letterSpacing: "0.05em", margin: "3px 0 6px" }}>
+                {h.domain}
+              </div>
+              <div style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 12.5, color: COLOR.steelLt, lineHeight: 1.3 }}>
+                {h.question}
+              </div>
+              {isSelected && (
+                <div style={{ position: "absolute", top: 8, right: 9, color: COLOR.gold, fontSize: 13 }}>✓</div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/HousesBlock.tsx
+++ b/src/components/handbook/blocks/HousesBlock.tsx
@@ -1,13 +1,22 @@
 "use client";
 
 import { COLOR, FONT } from "@/lib/handbook/tokens";
+import type { AllyshipDomainKey } from "@/lib/allyship-domains";
 
 // Canonical House copy — static block; the only data is the player's choice.
-export const HOUSES: { name: string; domain: string; question: string; accent: string; domainColor: string }[] = [
-  { name: "Provisioners", domain: "GATHER RESOURCES", question: "“What is actually depleted?”", accent: COLOR.provisioners, domainColor: "#c08a5a" },
-  { name: "Weavers", domain: "SKILLFUL ORGANIZING", question: "“What structure lets work continue?”", accent: COLOR.weavers, domainColor: "#c8975a" },
-  { name: "Linekeepers", domain: "DIRECT ACTION", question: "“What line must be drawn?”", accent: COLOR.linekeepers, domainColor: "#d06a52" },
-  { name: "Lanternbearers", domain: "RAISE AWARENESS", question: "“What truth must become visible?”", accent: COLOR.lanternbearers, domainColor: COLOR.gold },
+// Each House maps 1:1 onto an allyship domain (the domain caption is its label).
+export const HOUSES: {
+  name: string;
+  domain: string;
+  domainKey: AllyshipDomainKey;
+  question: string;
+  accent: string;
+  domainColor: string;
+}[] = [
+  { name: "Provisioners", domain: "GATHER RESOURCES", domainKey: "GATHERING_RESOURCES", question: "“What is actually depleted?”", accent: COLOR.provisioners, domainColor: "#c08a5a" },
+  { name: "Weavers", domain: "SKILLFUL ORGANIZING", domainKey: "SKILLFUL_ORGANIZING", question: "“What structure lets work continue?”", accent: COLOR.weavers, domainColor: "#c8975a" },
+  { name: "Linekeepers", domain: "DIRECT ACTION", domainKey: "DIRECT_ACTION", question: "“What line must be drawn?”", accent: COLOR.linekeepers, domainColor: "#d06a52" },
+  { name: "Lanternbearers", domain: "RAISE AWARENESS", domainKey: "RAISE_AWARENESS", question: "“What truth must become visible?”", accent: COLOR.lanternbearers, domainColor: COLOR.gold },
 ];
 
 export function HousesBlock({

--- a/src/components/handbook/blocks/LetterBlock.tsx
+++ b/src/components/handbook/blocks/LetterBlock.tsx
@@ -1,0 +1,79 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { renderInline } from "@/components/handbook/blocks/shared";
+
+export function LetterBlock({
+  kicker,
+  lead,
+  paras,
+  signature,
+  signatureNote,
+  seal,
+}: {
+  kicker: string;
+  lead: string;
+  paras: string[];
+  signature: string;
+  signatureNote: string;
+  seal: string;
+}) {
+  return (
+    <div style={{ margin: "18px 0", padding: "26px 24px", background: COLOR.midnight, color: "#ece6d6", position: "relative" }}>
+      <div style={{ fontFamily: FONT.mono, fontSize: 9.5, letterSpacing: "0.22em", color: "#caa978", textTransform: "uppercase" }}>
+        {kicker}
+      </div>
+      <p
+        style={{
+          fontFamily: FONT.display,
+          fontStyle: "italic",
+          fontWeight: 500,
+          fontSize: 23,
+          lineHeight: 1.3,
+          color: COLOR.goldLt,
+          margin: "13px 0 14px",
+        }}
+      >
+        {lead}
+      </p>
+      {paras.map((p, i) => (
+        <p
+          key={i}
+          style={{
+            fontFamily: FONT.body,
+            fontSize: 16.5,
+            lineHeight: 1.6,
+            color: COLOR.parchOnDark,
+            margin: i === paras.length - 1 ? "0 0 18px" : "0 0 12px",
+          }}
+        >
+          {renderInline(p)}
+        </p>
+      ))}
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16 }}>
+        <div>
+          <div style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 13, color: COLOR.steel }}>{signatureNote}</div>
+          <div style={{ fontFamily: FONT.hand, fontWeight: 700, fontSize: 31, color: "#f1ead9", lineHeight: 0.9 }}>
+            {signature}
+          </div>
+          <div
+            style={{
+              width: 140,
+              height: 0,
+              borderBottom: `2px solid ${COLOR.cinnabar}`,
+              marginTop: 5,
+              transform: "rotate(-1.5deg)",
+              transformOrigin: "left",
+              opacity: 0.85,
+            }}
+          />
+        </div>
+        <div style={{ position: "relative", width: 62, height: 62, flex: "0 0 auto", transform: "rotate(-6deg)" }}>
+          <div style={{ position: "absolute", inset: 0, background: COLOR.cinnabar, borderRadius: 4 }} />
+          <div style={{ position: "absolute", inset: 5, border: "1.5px solid rgba(247,236,224,.78)", borderRadius: 2 }} />
+          <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
+            <span style={{ fontFamily: FONT.seal, fontSize: 36, color: "#f6ece0" }}>{seal}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/MovesBlock.tsx
+++ b/src/components/handbook/blocks/MovesBlock.tsx
@@ -1,0 +1,50 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { MOVE_ICONS } from "@/lib/handbook/assets";
+import { Kicker } from "@/components/handbook/blocks/shared";
+
+// Canonical copy lives here — static block, no JSON data.
+const MOVES: { icon: string; name: string; gloss: string }[] = [
+  { icon: MOVE_ICONS.wakeUp, name: "Wake Up", gloss: "understand what's really happening" },
+  { icon: MOVE_ICONS.cleanUp, name: "Clean Up", gloss: "repair harm, restore integrity" },
+  { icon: MOVE_ICONS.growUp, name: "Grow Up", gloss: "build capacity under pressure" },
+  { icon: MOVE_ICONS.showUp, name: "Show Up", gloss: "act to change the situation" },
+];
+
+export function MovesBlock() {
+  return (
+    <div style={{ padding: "24px 24px 6px" }}>
+      <Kicker>How you play · the four moves</Kicker>
+      <p style={{ fontFamily: FONT.body, fontSize: 17, lineHeight: 1.55, color: COLOR.body, margin: "11px 0 16px" }}>
+        Every risky moment enters through one of four moves. Roll <b>2d6 + a School stat</b> and read what your move
+        does to the field.
+      </p>
+      <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+        {MOVES.map((m) => (
+          <div key={m.name} style={{ display: "flex", alignItems: "center", gap: 13 }}>
+            <div
+              style={{
+                width: 42,
+                height: 42,
+                borderRadius: "50%",
+                background: COLOR.chip,
+                border: "1.5px solid #c2ad84",
+                display: "grid",
+                placeItems: "center",
+                flex: "0 0 auto",
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={m.icon} alt="" style={{ width: 24, height: 24, objectFit: "contain" }} />
+            </div>
+            <div>
+              <div style={{ fontFamily: FONT.label, fontSize: 17, color: "#211d18", lineHeight: 1 }}>{m.name}</div>
+              <div style={{ fontFamily: FONT.body, fontStyle: "italic", fontSize: 14, color: COLOR.muteInk }}>
+                {m.gloss}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/NationsBlock.tsx
+++ b/src/components/handbook/blocks/NationsBlock.tsx
@@ -1,0 +1,41 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { artSrc } from "@/lib/handbook/assets";
+import { Kicker } from "@/components/handbook/blocks/shared";
+
+// Canonical Nation tiles — static block, no JSON data.
+const NATIONS: { name: string; art: string; element: string; color: string }[] = [
+  { name: "Pyrakanth", art: "pyrakanth-bold-heart.png", element: "FIRE", color: COLOR.fire },
+  { name: "Lamenth", art: "lamenth-truth-seer.png", element: "WATER", color: COLOR.water },
+  { name: "Virelune", art: "virelune-joyful-connector.png", element: "WOOD", color: COLOR.wood },
+  { name: "Argyra", art: "argyra-still-point.png", element: "METAL", color: COLOR.metal },
+  { name: "Meridia", art: "meridia-devoted-guardian.png", element: "EARTH", color: COLOR.earth },
+];
+
+export function NationsBlock() {
+  return (
+    <div style={{ padding: "26px 24px 8px" }}>
+      <Kicker>Where you&apos;re from · what trains you</Kicker>
+      <p style={{ fontFamily: FONT.body, fontSize: 16.5, lineHeight: 1.55, color: COLOR.body, margin: "11px 0 14px" }}>
+        The ship is a worldship. Your <b>Nation</b> is the element you were raised inside; your <b>School</b> is the
+        discipline it trains into you.
+      </p>
+      <div style={{ display: "flex", gap: 6, marginBottom: 16 }}>
+        {NATIONS.map((n) => (
+          <div key={n.name} style={{ flex: 1 }}>
+            <div style={{ aspectRatio: "3 / 4", overflow: "hidden", borderRadius: 4, border: "1px solid #c2ad84" }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={artSrc(n.art)} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+            </div>
+            <div style={{ fontFamily: FONT.display, fontWeight: 700, fontSize: 11, color: "#211d18", textAlign: "center", marginTop: 3, lineHeight: 1 }}>
+              {n.name}
+            </div>
+            <div style={{ fontFamily: FONT.mono, fontSize: 6, color: n.color, textAlign: "center" }}>{n.element}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontFamily: FONT.hand, fontSize: 19, color: COLOR.cinnabar, lineHeight: 1.1 }}>
+        Heritage is where you begin. Discipline is who you become.
+      </div>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/ProseBlock.tsx
+++ b/src/components/handbook/blocks/ProseBlock.tsx
@@ -1,0 +1,48 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { Kicker, renderInline } from "@/components/handbook/blocks/shared";
+
+export function ProseBlock({
+  kicker,
+  lead,
+  paras,
+}: {
+  kicker?: string;
+  lead?: string;
+  paras: string[];
+}) {
+  return (
+    <div style={{ padding: "30px 24px 8px" }}>
+      {kicker && <Kicker>{kicker}</Kicker>}
+      <div style={{ width: 46, height: 2, background: COLOR.cinnabar, margin: "13px 0 16px" }} />
+      {lead && (
+        <p
+          style={{
+            fontFamily: FONT.display,
+            fontWeight: 500,
+            fontSize: 30,
+            lineHeight: 1.08,
+            color: "#1d1a15",
+            margin: "0 0 16px",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {renderInline(lead)}
+        </p>
+      )}
+      {paras.map((p, i) => (
+        <p
+          key={i}
+          style={{
+            fontFamily: FONT.body,
+            fontSize: 18,
+            lineHeight: 1.62,
+            color: COLOR.body,
+            margin: "0 0 14px",
+          }}
+        >
+          {renderInline(p)}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/PullquoteBlock.tsx
+++ b/src/components/handbook/blocks/PullquoteBlock.tsx
@@ -1,0 +1,21 @@
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+export function PullquoteBlock({ text }: { text: string }) {
+  return (
+    <div style={{ padding: "0 24px 8px" }}>
+      <p
+        style={{
+          fontFamily: FONT.display,
+          fontStyle: "italic",
+          fontWeight: 500,
+          fontSize: 21,
+          lineHeight: 1.36,
+          color: COLOR.cinnabar,
+          margin: "18px 0 4px",
+        }}
+      >
+        {text}
+      </p>
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/RollBlock.tsx
+++ b/src/components/handbook/blocks/RollBlock.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+import { Kicker, renderInline } from "@/components/handbook/blocks/shared";
+
+export interface DiceResult {
+  d1: number;
+  d2: number;
+  total: number;
+  tier: string;
+  txt: string;
+}
+
+export function RollBlock({
+  scene,
+  move,
+  stat,
+  dice,
+  onRoll,
+}: {
+  scene: string;
+  move: string;
+  stat: string;
+  dice: DiceResult | null;
+  onRoll: () => void;
+}) {
+  return (
+    <div style={{ padding: "26px 24px 8px" }}>
+      <Kicker>A move at the table · try it</Kicker>
+      <p style={{ fontFamily: FONT.body, fontSize: 17, lineHeight: 1.58, color: COLOR.body, margin: "11px 0 12px" }}>
+        {renderInline(scene)}
+      </p>
+      <div style={{ display: "flex", gap: 7, marginBottom: 14 }}>
+        <span style={{ fontFamily: FONT.mono, fontSize: 10, background: COLOR.pine, color: "#e7efe2", padding: "4px 9px", borderRadius: 3 }}>
+          {move}
+        </span>
+        <span style={{ fontFamily: FONT.mono, fontSize: 10, background: COLOR.midnight, color: COLOR.gold, padding: "4px 9px", borderRadius: 3 }}>
+          {stat}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onRoll}
+        style={{
+          width: "100%",
+          background: COLOR.cinnabar,
+          border: "none",
+          borderRadius: 8,
+          padding: 13,
+          textAlign: "center",
+          cursor: "pointer",
+          boxShadow: "0 4px 14px rgba(168,64,46,.3)",
+        }}
+      >
+        <span style={{ fontFamily: FONT.label, fontSize: 16, color: "#f6ece0", letterSpacing: "0.03em" }}>
+          ⚄ Roll 2d6 + Sense
+        </span>
+      </button>
+
+      {dice && (
+        <div
+          style={{
+            marginTop: 14,
+            border: "1.5px solid #211d18",
+            background: COLOR.chip,
+            borderRadius: 8,
+            padding: 14,
+            animation: "handbookFadeUp .3s ease",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 9 }}>
+            {[dice.d1, dice.d2].map((d, i) => (
+              <div
+                key={i}
+                style={{
+                  width: 38,
+                  height: 38,
+                  border: "2px solid #211d18",
+                  borderRadius: 7,
+                  display: "grid",
+                  placeItems: "center",
+                  fontFamily: FONT.mono,
+                  fontSize: 18,
+                  fontWeight: 600,
+                  background: "#fff",
+                }}
+              >
+                {d}
+              </div>
+            ))}
+            <span style={{ fontFamily: FONT.mono, fontSize: 13, color: "#5c5236" }}>+1 Sense</span>
+            <span style={{ fontFamily: FONT.display, fontWeight: 700, fontSize: 26, color: COLOR.provisioners, marginLeft: "auto" }}>
+              = {dice.total}
+            </span>
+          </div>
+          <div style={{ fontFamily: FONT.mono, fontSize: 10, letterSpacing: "0.1em", color: COLOR.provisioners, textTransform: "uppercase", marginBottom: 5 }}>
+            {dice.tier}
+          </div>
+          <div style={{ fontFamily: FONT.body, fontSize: 15.5, lineHeight: 1.5, color: COLOR.body }}>{dice.txt}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/handbook/blocks/shared.tsx
+++ b/src/components/handbook/blocks/shared.tsx
@@ -1,0 +1,53 @@
+import { Fragment, type ReactNode } from "react";
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+/**
+ * Lightweight inline markup for prose authored in the JSON:
+ *   **text** → cinnabar emphasis span
+ *   *text*   → italic
+ * Everything else renders verbatim. Keep the writers' surface tiny on purpose.
+ */
+export function renderInline(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  // Split on **…** (group 1) or *…* (group 2), keeping the captured inner text.
+  const re = /\*\*([^*]+)\*\*|\*([^*]+)\*/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) out.push(<Fragment key={key++}>{text.slice(last, m.index)}</Fragment>);
+    if (m[1] !== undefined) {
+      out.push(
+        <span key={key++} style={{ color: COLOR.cinnabar }}>
+          {m[1]}
+        </span>
+      );
+    } else if (m[2] !== undefined) {
+      out.push(
+        <i key={key++} style={{ fontStyle: "italic" }}>
+          {m[2]}
+        </i>
+      );
+    }
+    last = re.lastIndex;
+  }
+  if (last < text.length) out.push(<Fragment key={key++}>{text.slice(last)}</Fragment>);
+  return out;
+}
+
+/** The small uppercase mono kicker used above most sections. */
+export function Kicker({ children, dark = false }: { children: ReactNode; dark?: boolean }) {
+  return (
+    <div
+      style={{
+        fontFamily: FONT.mono,
+        fontSize: 9.5,
+        letterSpacing: "0.22em",
+        color: dark ? "#caa978" : COLOR.lanternbearers,
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/lib/handbook/assets.ts
+++ b/src/lib/handbook/assets.ts
@@ -1,0 +1,30 @@
+/**
+ * Handbook asset paths + constants. Mirrors `src/lib/oracle/assets.ts`.
+ * All paths are root-relative (served from `public/`), like the Oracle deck.
+ */
+
+/** The chapter content as data — fetched by HandbookReader, like Oracle's DECK_URL. */
+export const CONTENT_URL = "/handbook/front-of-book.json";
+
+/** The four Move icons, reused verbatim from the Oracle suits. */
+export const MOVE_ICONS = {
+  wakeUp: "/oracle/icons/wake-up.svg",
+  cleanUp: "/oracle/icons/clean-up.svg",
+  growUp: "/oracle/icons/grow-up.svg",
+  showUp: "/oracle/icons/show-up.svg",
+} as const;
+
+/** The Headmaster's chop glyph (rendered in the `Ma Shan Zheng` web font, no image). */
+export const SEAL = "護";
+
+/** Print-preview spread art. */
+export const SPREAD_ART = "/oracle/images/wu-a.png";
+
+/**
+ * Resolve cover / Nation tile art. Card art lives at `/card-art/*` in the repo.
+ * Accepts either a bare filename ("pyrakanth-bold-heart.png") or a full path.
+ */
+export function artSrc(file: string): string {
+  if (file.startsWith("/")) return file;
+  return `/card-art/${file}`;
+}

--- a/src/lib/handbook/content.ts
+++ b/src/lib/handbook/content.ts
@@ -1,0 +1,39 @@
+/**
+ * Handbook content schema — a chapter is data the reader renders with a
+ * `switch` over `block.type`. Add block types as chapters need them.
+ *
+ * Static blocks (`moves`, `handles`, `houses`, `nations`) carry no copy here
+ * because their content is canonical — it lives in the block component. All
+ * prose lives in the JSON so writers edit text without touching code.
+ *
+ * Mirrors how the Oracle feature shapes `deck.json` (data-first, dumb renderers).
+ */
+
+export type Block =
+  | { type: "hero"; art: string; kicker: string; title: string; sub: string }
+  // `lead` = oversized opening line. `**emphasis**` in any line renders cinnabar.
+  | { type: "prose"; kicker?: string; lead?: string; paras: string[] }
+  | { type: "pullquote"; text: string } // cinnabar italic Cormorant
+  | {
+      type: "letter";
+      kicker: string;
+      lead: string;
+      paras: string[];
+      signature: string;
+      signatureNote: string;
+      seal: string; // '護'
+    }
+  | { type: "moves" } // static: the 4 Basic Moves + icons
+  | { type: "handles" } // static: House/School/Offer/Cost/Line/Bond
+  | { type: "houses" } // INTERACTIVE (app hook A)
+  | { type: "roll"; scene: string; move: string; stat: string } // INTERACTIVE: 2d6 + stat
+  | { type: "barPrompt"; kicker: string; prompt: string } // INTERACTIVE (app hook B)
+  | { type: "nations" } // static: 5 Nation tiles
+  | { type: "footer"; nextLabel: string };
+
+export interface Chapter {
+  id: string;
+  kicker: string;
+  title: string;
+  blocks: Block[];
+}

--- a/src/lib/handbook/tokens.ts
+++ b/src/lib/handbook/tokens.ts
@@ -1,0 +1,44 @@
+/**
+ * Handbook design tokens — exact values from the Digital Reader handoff.
+ * Mirrors the Oracle feature's `cardLayout.ts` (exported color/type constants).
+ * The reader and the print export both read from here ("author once, render twice").
+ */
+
+export const COLOR = {
+  paper: "#efe7d6",
+  paperHi: "#f4eee0",
+  chip: "#efe6d2",
+  ink: "#211d17",
+  body: "#33302a",
+  muteInk: "#6a5e44",
+  cinnabar: "#a8402e",
+  gold: "#c8a35a",
+  goldLt: "#e7c98a",
+  lacquer: "#0a0d14",
+  midnight: "#11162a",
+  card: "#0e1320",
+  steel: "#8a93a6",
+  steelLt: "#aab2c2",
+  parchOnDark: "#cdd4dc",
+  // House accents
+  provisioners: "#8f3b2d",
+  weavers: "#a9743f",
+  linekeepers: "#a8402e",
+  lanternbearers: "#9a7b3f",
+  // Element / Nation
+  fire: "#c2502e",
+  water: "#2b8ca0",
+  wood: "#5a9e4f",
+  metal: "#9aa4b2",
+  earth: "#b0863f",
+  pine: "#33463b",
+} as const;
+
+export const FONT = {
+  display: "'Cormorant Garamond', Georgia, serif", // headings / titles (600)
+  body: "'EB Garamond', Georgia, serif", // body copy
+  label: "'Marcellus', Georgia, serif", // buttons, move names, plate labels
+  hand: "'Caveat', cursive", // signature, asides
+  mono: "'Spline Sans Mono', ui-monospace, monospace", // kickers, tags, folios
+  seal: "'Ma Shan Zheng', serif", // 護 chop
+} as const;


### PR DESCRIPTION
## Summary

Recreates the **Digital Reader** prototype inside bars-engine as a phone-first route at `/handbook`, mirroring the Oracle feature's conventions: data-driven JSON content + dumb, inline-styled React renderers. The architecture is built so every later chapter is just more data.

## What's here

**Lib layer**
- `src/lib/handbook/tokens.ts` — exact COLOR/FONT design tokens from the handoff
- `src/lib/handbook/content.ts` — `Block` tagged union + `Chapter` schema
- `src/lib/handbook/assets.ts` — `CONTENT_URL`, `artSrc()`, `MOVE_ICONS`, `SEAL`, `SPREAD_ART` (mirrors `src/lib/oracle/assets.ts`)

**Content**
- `public/handbook/front-of-book.json` — chapter copy as data. Static blocks (`moves`/`houses`/`nations`/`handles`) keep their canonical copy in the components; all prose lives in the JSON.

**Components** — one renderer per block type in `src/components/handbook/blocks/*`, switched over by `HandbookReader.tsx`, which owns the shell (status bar, header, cinnabar→gold scroll progress, print overlay), scroll resume, and the three interactions:
- **Dice** — pure client 2d6+1 with strong / mixed / truth tiers
- **HOOK A (House select)** — see below
- **HOOK B (Plant a BAR)** — `src/actions/handbook-bar.ts`, creating a private `player_response` BAR; returns `{ pending }` for logged-out readers so the client falls back to localStorage (mirrors `createOnboardingBar`)

**Route** — `src/app/handbook/{layout,page}.tsx`, full-screen, loading the six book fonts, rendering `<HandbookReader chapterId="front-of-book" />`.

## HOOK A → real player identity

The four Houses map 1:1 onto the four allyship domains, recorded on `Player.campaignDomainPreference` (the field character creation already uses):

| House | `AllyshipDomainKey` |
|---|---|
| Provisioners | `GATHERING_RESOURCES` |
| Weavers | `SKILLFUL_ORGANIZING` |
| Linekeepers | `DIRECT_ACTION` |
| Lanternbearers | `RAISE_AWARENESS` |

`addCampaignDomainPreference(domain)` is a new **non-destructive** server action — it merges the House's domain into the player's existing preference rather than overwriting domains they curated in the Market. `localStorage` mirrors the reader's own selection and is the logged-out fallback.

## Notes / known scope

- **House banner reflects localStorage, not server state.** Writing House→domain is real player identity; *displaying* which House you're in still reflects your last tap in this reader. With the additive multi-domain model there's no unambiguous single House to reverse-derive on load. Could be surfaced later as a "domains you're active in" line.
- **Print** is the in-app spread overlay (faithful to the prototype) with `window.print()` for Export PDF; the optional separate `/handbook/print` route was skipped.
- No schema migration — `campaignDomainPreference` already exists.

## Verification

- `tsc --noEmit` — clean
- `eslint` — clean on handbook files
- `validate-manifest` — passes
- Full precommit `check` passed (0 errors)

https://claude.ai/code/session_0154uNkLDmgAnNxsCDHKPvyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0154uNkLDmgAnNxsCDHKPvyQ)_