### PR TITLE
Add MTGOA verify:ui script for GSD Browser visual baselines

### DIFF
--- a/.specify/specs/opengsd-workflow-migration/tasks.md
+++ b/.specify/specs/opengsd-workflow-migration/tasks.md
@@ -29,8 +29,10 @@ parity is verified. `[x]` = done.
       → produces `priya-baseline.png` + `priya-baseline.a11y.json`.
 - [ ] Wire visual-diff into the `UI_COVENANT` loop (element=color, altitude=border,
       stage=density); demo: an intentional color change must surface a diff.
-- [ ] Add the MTGOA `verify:ui` npm script to the game package (lives on PR #91 /
-      `claude/sweet-hopper-hs4pw2`) so it ships with the app.
+- [x] Add the MTGOA `verify:ui` npm script to the game package
+      (`mtgoa-game/scripts/verify-ui.sh`: build → `vite preview` → GSD Browser
+      capture → teardown) so it ships with the app. *(awaits a Chrome-reachable
+      run to produce the first committed baseline.)*
 
 ## Phase 2 — GSD Pi pilot (parallel to bespoke; no removals)
 - [ ] `npx @opengsd/gsd-pi@latest`; complete setup; select LLM provider (default to

--- a/mtgoa-game/package.json
+++ b/mtgoa-game/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "verify:ui": "bash scripts/verify-ui.sh"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/mtgoa-game/scripts/verify-ui.sh
+++ b/mtgoa-game/scripts/verify-ui.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# verify-ui.sh — capture a GSD Browser visual baseline of an MTGOA screen.
+#
+# Builds the app, serves the production build with `vite preview`, captures a
+# full-page screenshot + accessibility tree via the repo-root GSD Browser
+# helper, then tears the server down. Use it to baseline UI_COVENANT surfaces
+# (element=color, altitude=border, stage=density) and diff later changes.
+#
+# Usage:
+#   npm run verify:ui                      # defaults to the Level-1 Priya trust loop
+#   bash scripts/verify-ui.sh '#l1-priya' priya-baseline
+#   bash scripts/verify-ui.sh '' home-baseline
+#
+# Requires a Chrome binary (auto-resolved by ../scripts/setup-gsd-browser.sh —
+# finds system Chrome on macOS; set GSD_CHROME_PATH otherwise). In restricted
+# egress environments the browser CDN must be allowlisted; see that script.
+#
+set -euo pipefail
+
+ROUTE="${1:-#l1-priya}"
+NAME="${2:-priya-baseline}"
+PORT="${PORT:-5173}"
+
+GAME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${GAME_DIR}/.." && pwd)"
+cd "${GAME_DIR}"
+
+echo "▶ Building MTGOA…"
+npm run build
+
+echo "▶ Serving production build on :${PORT}…"
+npx vite preview --port "${PORT}" --strictPort >/dev/null 2>&1 &
+SERVER_PID=$!
+trap 'kill "${SERVER_PID}" 2>/dev/null || true' EXIT
+
+echo "▶ Waiting for the server…"
+for _ in $(seq 1 30); do
+  curl -sf "http://localhost:${PORT}/" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+"${REPO_ROOT}/scripts/gsd-ui-verify.sh" \
+  "http://localhost:${PORT}/${ROUTE}" "${GAME_DIR}/.gsd-artifacts" "${NAME}"


### PR DESCRIPTION
## Summary

Completes the OpenGSD Phase 1 follow-up to ship **visual verification with the MTGOA game**. Adds a `verify:ui` script so the game can produce GSD Browser baselines of its screens (screenshot + accessibility tree) for `UI_COVENANT` work (element=color, altitude=border, stage=density).

Now that the MTGOA app lives on `main` (via #91), this script belongs with the game package.

## What's here

- **`mtgoa-game/scripts/verify-ui.sh`** — builds the app, serves the production build with `vite preview`, captures a full-page PNG + accessibility tree via the repo-root helper (`scripts/gsd-ui-verify.sh`, from #94), then tears the server down. Defaults to the Level-1 Priya trust loop (`#l1-priya`).
- **`mtgoa-game/package.json`** — `"verify:ui": "bash scripts/verify-ui.sh"`.

```bash
cd mtgoa-game && npm install
npm run verify:ui                       # → .gsd-artifacts/priya-baseline.{png,a11y.json}
npm run verify:ui -- '#l1-priya' priya-baseline   # explicit route + name
```

## Notes

- Depends on `scripts/setup-gsd-browser.sh` (merged in #94) to resolve a Chrome binary — auto-found on macOS; set `GSD_CHROME_PATH` otherwise.
- **No committed baseline yet:** the web sandbox's egress blocks every browser CDN, so the first `priya-baseline.png` must be generated on a Chrome-reachable machine (e.g. macOS) and committed in a follow-up. Script syntax + `package.json` JSON validated; the capture itself is untested here for that reason.

Tracked task in `.specify/specs/opengsd-workflow-migration/tasks.md` is ticked.

https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDA2aEif6QEwoMtJ2zVpS)_