### PR TITLE
Add full-difficulty Boss Priya to trust/attune engine

### DIFF
--- a/mtgoa-game/src/App.tsx
+++ b/mtgoa-game/src/App.tsx
@@ -15,19 +15,28 @@ import { EncounterScreen } from "@/screens/EncounterScreen";
 import { DomainScreen } from "@/screens/DomainScreen";
 import { EndScreen } from "@/screens/EndScreen";
 import { TrustEncounterScreen } from "@/screens/TrustEncounterScreen";
+import { LEVEL1_PRIYA } from "@/engine/trust/level1Priya";
+import { BOSS_PRIYA } from "@/engine/trust/bossPriya";
 
 export default function App() {
   const { state, dispatch } = useGame();
-  // Trust/attune rebuild: a self-contained, provably-completable Level-1 Priya
-  // loop, reachable via a prototype toggle without disturbing the channel engine.
-  const [trustProto, setTrustProto] = useState(
-    typeof window !== "undefined" && window.location.hash === "#l1-priya",
-  );
+  // Trust/attune rebuild: self-contained, provably-completable Priya encounters,
+  // reachable via a prototype toggle without disturbing the channel engine.
+  // null = not in the prototype; otherwise the encounter to run.
+  const initialProto =
+    typeof window !== "undefined"
+      ? window.location.hash === "#boss-priya"
+        ? BOSS_PRIYA
+        : window.location.hash === "#l1-priya"
+          ? LEVEL1_PRIYA
+          : null
+      : null;
+  const [trustProto, setTrustProto] = useState(initialProto);
 
   if (trustProto) {
     return (
       <div className="min-h-screen bg-bg text-text">
-        <TrustEncounterScreen onExit={() => setTrustProto(false)} />
+        <TrustEncounterScreen encounter={trustProto} onExit={() => setTrustProto(null)} />
       </div>
     );
   }
@@ -40,12 +49,20 @@ export default function App() {
       {state.phase === "domain" && <DomainScreen state={state} dispatch={dispatch} />}
       {state.phase === "end" && <EndScreen state={state} dispatch={dispatch} />}
 
-      <button
-        onClick={() => setTrustProto(true)}
-        className="fixed bottom-3 right-3 rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-semibold text-accent hover:bg-accent/20"
-      >
-        ▶ Play Level-1 Priya (trust prototype)
-      </button>
+      <div className="fixed bottom-3 right-3 flex flex-col items-end gap-2">
+        <button
+          onClick={() => setTrustProto(LEVEL1_PRIYA)}
+          className="rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-semibold text-accent hover:bg-accent/20"
+        >
+          ▶ Play Level-1 Priya (trust prototype)
+        </button>
+        <button
+          onClick={() => setTrustProto(BOSS_PRIYA)}
+          className="rounded-md border border-fire/40 bg-fire/10 px-3 py-1.5 text-xs font-semibold text-fire hover:bg-fire/20"
+        >
+          ▶ Play Boss Priya (full difficulty)
+        </button>
+      </div>
     </div>
   );
 }

--- a/mtgoa-game/src/engine/trust/__tests__/bossPriyaCompletability.sim.test.ts
+++ b/mtgoa-game/src/engine/trust/__tests__/bossPriyaCompletability.sim.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Completability proof for full-difficulty Boss Priya.
+ *
+ * Same guarantee as Level-1 (trustCompletability.sim.test.ts), held under the
+ * harder settings: an alternating live need (read-then-respond rhythm), higher
+ * starting stress, six shadows, and two her-only domains. A smart policy wins;
+ * the safe-floor policy (only ever attune + show up honestly + dissolve) still
+ * wins — so the boss has no dead end. The loss exists but is choice-driven.
+ *
+ * Run: npm test -- bossPriyaCompletability
+ */
+import { describe, expect, it } from "vitest";
+
+import { BOSS_PRIYA } from "../bossPriya";
+import { TRUST_RULES as R } from "../trustRules";
+import type { EncounterConfig } from "../trustTypes";
+import {
+  allDomainsTouched,
+  currentNeed,
+  initTrustEncounter,
+  trustReducer,
+  type TrustAction,
+  type TrustState,
+} from "../trustEngine";
+
+const TURN_CAP = 120;
+
+type Policy = (s: TrustState) => TrustAction | null;
+
+function run(config: EncounterConfig, policy: Policy) {
+  let s = initTrustEncounter(config);
+  let guard = 0;
+  while (s.result === null && guard < TURN_CAP) {
+    const action = policy(s);
+    if (!action) break;
+    s = trustReducer(s, action);
+    guard += 1;
+  }
+  return s;
+}
+
+/** Read the moving need, respond in-channel to bank trust, dissolve to convert,
+ *  then engage all four domains (including the two her-only ones), then capstone. */
+const smartPolicy: Policy = (s) => {
+  if (s.converted && allDomainsTouched(s)) return { type: "CAPSTONE" };
+  if (!s.needRevealed) return { type: "ATTUNE" };
+  if (!s.converted) {
+    if (s.trust >= R.shadow.dissolveCost && s.shadows.length > 0) {
+      return { type: "DISSOLVE", shadowId: s.shadows[0].id };
+    }
+    const need = currentNeed(s);
+    const aligner = s.config.deck.find((c) => c.kind === "align" && c.channel === need);
+    return aligner ? { type: "PLAY", cardId: aligner.id } : { type: "BASIC" };
+  }
+  const domain = s.config.deck.find(
+    (c) => c.kind === "domain" && c.domain && !s.domainsTouched.includes(c.domain),
+  );
+  return domain ? { type: "PLAY", cardId: domain.id } : null;
+};
+
+/** Never plays an align card — only attunes and "shows up honestly" to bank trust.
+ *  Proves the floor: even a player who never risks a read-response still completes. */
+const safeFloorPolicy: Policy = (s) => {
+  if (s.converted && allDomainsTouched(s)) return { type: "CAPSTONE" };
+  if (!s.needRevealed) return { type: "ATTUNE" };
+  if (!s.converted) {
+    if (s.trust >= R.shadow.dissolveCost && s.shadows.length > 0) {
+      return { type: "DISSOLVE", shadowId: s.shadows[0].id };
+    }
+    return { type: "BASIC" };
+  }
+  const domain = s.config.deck.find(
+    (c) => c.kind === "domain" && c.domain && !s.domainsTouched.includes(c.domain),
+  );
+  return domain ? { type: "PLAY", cardId: domain.id } : null;
+};
+
+describe("trust engine — Boss Priya completability", () => {
+  it("smart play reaches a win", () => {
+    const s = run(BOSS_PRIYA, smartPolicy);
+    // eslint-disable-next-line no-console
+    console.log(`\n[boss smart]      result:${s.result} turns:${s.turn} converted:${s.converted} domains:${s.domainsTouched.length}/4`);
+    expect(s.result).toBe("win");
+    expect(allDomainsTouched(s)).toBe(true);
+  });
+
+  it("safe-floor play (attune + show up honestly only) still reaches a win — no dead end", () => {
+    const s = run(BOSS_PRIYA, safeFloorPolicy);
+    // eslint-disable-next-line no-console
+    console.log(`[boss safe-floor] result:${s.result} turns:${s.turn} converted:${s.converted} domains:${s.domainsTouched.length}/4`);
+    expect(s.result).toBe("win");
+  });
+
+  it("the need actually moves — a smart reader attunes to more than one channel", () => {
+    const s = run(BOSS_PRIYA, smartPolicy);
+    const distinctNeeds = new Set(s.needTrail);
+    expect(distinctNeeds.size).toBeGreaterThan(1);
+  });
+
+  it("a careful reader never raises her stress above the boss's higher start", () => {
+    const s = run(BOSS_PRIYA, smartPolicy);
+    expect(s.npcStress).toBeLessThanOrEqual(BOSS_PRIYA.startingStress);
+  });
+
+  it("both her-only domains stay locked until conversion", () => {
+    let s = initTrustEncounter(BOSS_PRIYA);
+    s = trustReducer(s, { type: "PLAY", cardId: "bd-aware" });
+    s = trustReducer(s, { type: "PLAY", cardId: "bd-direct" });
+    expect(s.converted).toBe(false);
+    expect(s.domainsTouched).not.toContain("Raise Awareness");
+    expect(s.domainsTouched).not.toContain("Direct Action");
+  });
+
+  it("the loss exists but is choice-driven: repeated misreads rupture", () => {
+    // A deck whose only card mismatches every need in her rhythm — forced misreads.
+    const reckless: EncounterConfig = {
+      ...BOSS_PRIYA,
+      deck: [{ id: "wrong", name: "Push the Agenda", channel: "Wood", kind: "align", text: "Wrong register, every beat." }],
+    };
+    let s = initTrustEncounter(reckless);
+    let guard = 0;
+    while (s.result === null && guard < TURN_CAP) {
+      s = s.needRevealed
+        ? trustReducer(s, { type: "PLAY", cardId: "wrong" })
+        : trustReducer(s, { type: "ATTUNE" });
+      guard += 1;
+    }
+    expect(s.result).toBe("loss-rupture");
+  });
+});

--- a/mtgoa-game/src/engine/trust/bossPriya.ts
+++ b/mtgoa-game/src/engine/trust/bossPriya.ts
@@ -1,0 +1,60 @@
+/**
+ * Boss Priya — the full-difficulty setting of the same trust/attune machine that
+ * Level-1 Priya tutorialises. Same loop, harder settings (the L-up principle:
+ * the boss is the basic loop turned up, not a new system):
+ *
+ *   - Alternating live need (a rhythm, not a fixed channel). Her defendedness
+ *     moves Water → Fire → Metal, so you must RE-READ before each response.
+ *   - Higher starting stress (4 vs 2): less margin before a misread ruptures.
+ *   - Six shadows instead of three: more defense to read, though conversion is
+ *     still the same threshold — the extra shadows are weight, not a wall.
+ *   - More her-only domain work: both Direct Action AND the honest
+ *     awareness-raising only land once she is an ally.
+ *
+ * Rhythm note: the need is authored in *pairs* (Water, Water, Fire, Fire, …).
+ * ATTUNE reveals the live need and spends the turn; the matching response lands
+ * on the second beat of the pair while that need is still live. This is the
+ * read-then-respond cadence — and it keeps the boss winnable by construction
+ * (proven in __tests__/bossPriyaCompletability.sim.test.ts).
+ *
+ * Narrative source: NPC 008, milestone "Find what's still possible inside the
+ * constraint" (the DEI-rollback scenario) — see src/data/npcs.ts. This is the
+ * climactic version of that encounter; Level-1 is the tuned-down rehearsal.
+ */
+import type { EncounterConfig } from "./trustTypes";
+
+export const BOSS_PRIYA: EncounterConfig = {
+  npcId: "npc-008",
+  npcName: "Priya",
+  level: 2,
+  // Full boss: a moving need. Paired so each channel gets a read-beat and a
+  // respond-beat. Cycles Water → Fire → Metal — grief, suppressed anger, the
+  // need to keep control — and repeats.
+  needSequence: ["Water", "Water", "Fire", "Fire", "Metal", "Metal"],
+  startingStress: 4,
+  shadows: [
+    { id: "boss-performed-compliance", name: "Performed Compliance", channel: "Water", text: "Says yes in the meeting, does nothing after." },
+    { id: "boss-strategic-withdrawal", name: "Strategic Withdrawal", channel: "Water", text: "Goes quiet to stay safe." },
+    { id: "boss-managed-anger", name: "Managed Anger", channel: "Fire", text: "Smiles through it so no one calls her difficult." },
+    { id: "boss-scorched-cynicism", name: "Scorched Cynicism", channel: "Fire", text: "Why try — it always rolls back." },
+    { id: "boss-loyalty-performance", name: "Loyalty Performance", channel: "Metal", text: "Performs okayness to keep her standing." },
+    { id: "boss-iron-control", name: "Iron Control", channel: "Metal", text: "Holds the line so tightly nothing real gets through." },
+  ],
+  deck: [
+    // Inner track — align cards for each channel in her rhythm.
+    { id: "bc-bear-witness", name: "Bear Witness", channel: "Water", kind: "align", text: "Stay present to the grief without fixing it." },
+    { id: "bc-check-in", name: "Check In", channel: "Water", kind: "align", text: "Reach toward the person who went quiet." },
+    { id: "bc-name-the-anger", name: "Name the Anger", channel: "Fire", kind: "align", text: "Say the rage is legitimate — out loud, with her." },
+    { id: "bc-honor-control", name: "Honor the Control", channel: "Metal", kind: "align", text: "Respect what the grip is protecting before you ask her to loosen it." },
+    // Outer track — engage each domain to solve her problem.
+    { id: "bd-gather", name: "Reach the People Still Inside", channel: "Water", kind: "domain", domain: "Gather Resources", text: "Find who's still reachable inside the building." },
+    { id: "bd-organize", name: "Build the Container", channel: "Earth", kind: "domain", domain: "Skillful Organizing", text: "Make a space to keep doing the real work." },
+    // Her-only: the truth-telling only lands once she trusts you.
+    { id: "bd-aware", name: "See What the Rollback Protects", channel: "Metal", kind: "domain", domain: "Raise Awareness", herOnly: true, text: "Name what's actually at stake — credibly, because she's beside you." },
+    { id: "bd-direct", name: "Communicate It Honestly", channel: "Fire", kind: "domain", domain: "Direct Action", herOnly: true, text: "Say the true thing to the employees — together." },
+  ],
+  capstone: {
+    title: "Find what's still possible inside the constraint",
+    body: "With Priya as ally and every domain engaged — even the ones only she could unlock — you name what integrity looks like from inside this.",
+  },
+};

--- a/mtgoa-game/src/screens/TrustEncounterScreen.tsx
+++ b/mtgoa-game/src/screens/TrustEncounterScreen.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 
 import { LEVEL1_PRIYA } from "@/engine/trust/level1Priya";
 import { TRUST_RULES as R } from "@/engine/trust/trustRules";
+import type { EncounterConfig } from "@/engine/trust/trustTypes";
 import {
   allDomainsTouched,
   currentNeed,
@@ -29,6 +30,9 @@ import {
 
 interface Props {
   onExit: () => void;
+  /** Which encounter to run. Defaults to the Level-1 tutorial; pass BOSS_PRIYA
+   *  for the full-difficulty fight. The screen is config-agnostic. */
+  encounter?: EncounterConfig;
 }
 
 /** A simple labelled value meter (trust has no fixed max; stress caps at rupture). */
@@ -47,8 +51,8 @@ function Meter({ label, value, max, tone }: { label: string; value: number; max:
   );
 }
 
-export function TrustEncounterScreen({ onExit }: Props) {
-  const [state, dispatch] = useReducer(trustReducer, LEVEL1_PRIYA, initTrustEncounter);
+export function TrustEncounterScreen({ onExit, encounter = LEVEL1_PRIYA }: Props) {
+  const [state, dispatch] = useReducer(trustReducer, encounter, initTrustEncounter);
 
   const need = currentNeed(state);
   const config = state.config;


### PR DESCRIPTION
## Summary

Implements the **full boss Priya** follow-up named in PR #91 — the climactic version of the Level-1 Priya encounter, built as the **same trust/attune loop at harder settings** (no new engine mechanics, fully additive, provably completable).

This work was originally pushed to PR #91's branch just after that PR merged, so it didn't make it in. This PR brings it to `main` on its own.

## What's here

- **`engine/trust/bossPriya.ts`** — `BOSS_PRIYA` config:
  - **Alternating live need** (Water → Fire → Metal), authored in read/respond **pairs**. This matters mechanically: `ATTUNE` spends the turn and the need re-hides when it changes, so a naive fully-alternating sequence would be unwinnable. Pairing gives an attune-beat then a respond-beat on the same channel — a "read her, then respond" rhythm that stays winnable by construction.
  - Higher starting stress (4 vs 2 — less margin before a misread ruptures), six shadows, and **two** her-only domains (Direct Action + Raise Awareness).
- **`engine/trust/__tests__/bossPriyaCompletability.sim.test.ts`** — completability proof mirroring the L1 pattern:
  - smart policy wins in **17 turns**; safe-floor "attune + show up honestly" policy still wins in **21** (no dead end)
  - asserts the need actually moves, both her-only domains stay locked pre-conversion, and the only loss is choice-driven misreads
- **UI wiring** — `TrustEncounterScreen` now takes an optional `encounter` config (defaults to L1, nothing breaks); `App` adds a Boss Priya launcher and `#boss-priya` route.

## Verification

- ✅ `tsc --noEmit` — clean
- ✅ `vitest run` — 20/20 pass (14 prior + 6 new boss)
- ✅ `vite build` — succeeds

## Follow-ups (not in this PR)

- Applied Mode intake / `IntakeConversation` (Migration Brief priority #8)

https://claude.ai/code/session_01AJwoziukmL2tPne4ATHdXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJwoziukmL2tPne4ATHdXj)_