### PR TITLE
Book launch funnel — sample→buy→unlock for Gumroad-PDF SKU (1.78 BLP)

### DIFF
--- a/.specify/specs/book-launch-paywall/tasks.md
+++ b/.specify/specs/book-launch-paywall/tasks.md
@@ -34,6 +34,15 @@ Implements [spec.md](./spec.md) per [plan.md](./plan.md). Order is API-first. Ch
 - [x] **T19** — `scripts/seed-cert-book-launch-paywall.ts` (idempotent; `CustomBar` `isSystem:true`, `visibility:'public'`, id `cert-book-launch-paywall-v1`) + `npm run seed:cert:book-paywall`. Steps use a mock-mode `TEST-` key for the redeem step.
 - [~] **T20** — Run the quest end-to-end in preview; confirm reward mints on the final passage. **Pending a reachable DB** (no `DATABASE_URL` in this container) — run `npm run seed:cert:book-paywall` then complete the quest on the deployed preview.
 
+## Phase 1.5 — Launch funnel (SKU: Gumroad PDF + reader-as-sample)
+
+Decided 2026-06-14: sell the full book as a Gumroad-hosted PDF; the in-app reader is the free Prologue sample and gains chapters over time. The PDF is supplied by the author.
+
+- [x] **L1** — `FooterBlock` CTA is a real link to the gated next chapter (`/handbook/chapter-one`) so the free Prologue funnels to the paywall. Dropped the "PROTOTYPE" footer note.
+- [x] **L2** — `UnlockedComingSoon` panel: entitled readers opening an unauthored chapter see an honest "you're unlocked / download on Gumroad / chapters arriving" surface instead of a load error.
+- [x] **L3** — `PUBLISHED_CHAPTER_IDS` / `isPublishedChapter` in `book-access`; gated route branches entitled → reader (published) vs coming-soon (not yet). Empty at launch.
+- [ ] **L4 (ops, not code)** — Create the Gumroad product (license keys on; upload the PDF), set Vercel **Production** env: `GUMROAD_PRODUCT_ID`, `GUMROAD_PRODUCT_URL`, leave `GUMROAD_VERIFY_MODE` live. Seed `npm run seed:cert:book-paywall` and walk it once.
+
 ## Unit tests
 
 - [x] **UT1** — `src/lib/__tests__/book-launch-paywall.test.ts` (`npm run test:book-paywall`): `verifyLicense` mock branches + `isFreeChapter` + `hasBookAccess(null)`. Passing.

--- a/scripts/seed-cert-book-launch-paywall.ts
+++ b/scripts/seed-cert-book-launch-paywall.ts
@@ -50,8 +50,8 @@ const passages = [
   {
     name: 'STEP_4',
     pid: '5',
-    text: '### Step 4: Chapter unlocks\n\n[Open /handbook/chapter-one](/handbook/chapter-one) again now that you are entitled. Confirm the paywall is **gone** and the reader shell loads (content arrives once chapters are authored via the content pipeline).',
-    cleanText: 'Step 4: Chapter unlocks. Open /handbook/chapter-one again now that you are entitled. Confirm the paywall is gone and the reader shell loads (content arrives once chapters are authored via the content pipeline).',
+    text: '### Step 4: Chapter unlocks\n\n[Open /handbook/chapter-one](/handbook/chapter-one) again now that you are entitled. Confirm the paywall is **gone** — you now see the **"You’re unlocked"** panel pointing to your Gumroad download (in-app chapters arrive as they are authored).',
+    cleanText: "Step 4: Chapter unlocks. Open /handbook/chapter-one again now that you are entitled. Confirm the paywall is gone — you now see the You're unlocked panel pointing to your Gumroad download (in-app chapters arrive as they are authored).",
     links: [{ label: 'Complete verification', target: 'END_SUCCESS' }, { label: 'Report Issue', target: 'FEEDBACK' }],
   },
   {

--- a/src/app/handbook/[chapterId]/page.tsx
+++ b/src/app/handbook/[chapterId]/page.tsx
@@ -1,16 +1,19 @@
 import type { Metadata } from "next";
 import { HandbookReader } from "@/components/handbook/HandbookReader";
 import { PaywallCTA } from "@/components/handbook/PaywallCTA";
+import { UnlockedComingSoon } from "@/components/handbook/UnlockedComingSoon";
 import { getCurrentPlayer } from "@/lib/auth";
-import { hasBookAccess, isFreeChapter } from "@/lib/book-access";
+import { hasBookAccess, isFreeChapter, isPublishedChapter } from "@/lib/book-access";
 
 export const metadata: Metadata = {
   title: "The Handbook — Mastering the Game of Allyship",
 };
 
 /**
- * Gated chapter route. Free chapters (the Prologue funnel) render for anyone;
- * every other chapter requires an active book entitlement, else the paywall.
+ * Gated chapter route. Free chapters (the Prologue funnel) render for anyone.
+ * Non-free chapters require an active entitlement → else the paywall. Entitled
+ * readers see the reader when the chapter has in-app content, or an honest
+ * "unlocked / download on Gumroad / coming soon" panel until it's authored.
  * See book-launch-paywall spec (P2/FR5).
  */
 export default async function HandbookChapterPage({
@@ -20,12 +23,18 @@ export default async function HandbookChapterPage({
 }) {
   const { chapterId } = await params;
 
-  if (!isFreeChapter(chapterId)) {
-    const player = await getCurrentPlayer();
-    if (!(await hasBookAccess(player))) {
-      return <PaywallCTA />;
-    }
+  if (isFreeChapter(chapterId)) {
+    return <HandbookReader chapterId={chapterId} />;
   }
 
-  return <HandbookReader chapterId={chapterId} />;
+  const player = await getCurrentPlayer();
+  if (!(await hasBookAccess(player))) {
+    return <PaywallCTA />;
+  }
+
+  return isPublishedChapter(chapterId) ? (
+    <HandbookReader chapterId={chapterId} />
+  ) : (
+    <UnlockedComingSoon />
+  );
 }

--- a/src/components/handbook/UnlockedComingSoon.tsx
+++ b/src/components/handbook/UnlockedComingSoon.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+import { COLOR, FONT } from "@/lib/handbook/tokens";
+
+/**
+ * Shown to an *entitled* reader who opens a chapter that doesn't have in-app
+ * content yet. At launch the paid product is the Gumroad-hosted PDF; the
+ * in-app reader gains chapters over time. This keeps the post-purchase
+ * experience honest instead of an error. See book-launch-paywall spec.
+ */
+export function UnlockedComingSoon() {
+  const buyUrl = process.env.GUMROAD_PRODUCT_URL || "https://gumroad.com";
+
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        display: "grid",
+        placeItems: "center",
+        padding: "2rem 1.25rem",
+        background: COLOR.lacquer,
+        color: COLOR.parchOnDark,
+      }}
+    >
+      <div style={{ maxWidth: 460, textAlign: "center" }}>
+        <p
+          style={{
+            fontFamily: FONT.mono,
+            fontSize: 12,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: COLOR.gold,
+            marginBottom: 14,
+          }}
+        >
+          You&rsquo;re unlocked
+        </p>
+        <h1
+          style={{
+            fontFamily: FONT.display,
+            fontWeight: 600,
+            fontSize: 30,
+            lineHeight: 1.15,
+            color: COLOR.paperHi,
+            margin: "0 0 14px",
+          }}
+        >
+          Thank you for joining the academy
+        </h1>
+        <p
+          style={{
+            fontFamily: FONT.body,
+            fontSize: 16,
+            lineHeight: 1.6,
+            color: COLOR.steelLt,
+            margin: "0 0 28px",
+          }}
+        >
+          Your full copy of <em>Mastering the Game of Allyship</em> is your
+          download from Gumroad. The interactive in-app chapters are being
+          released here over time &mdash; your access already covers them as
+          they arrive.
+        </p>
+
+        <a
+          href={buyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            display: "block",
+            fontFamily: FONT.label,
+            fontSize: 16,
+            letterSpacing: "0.04em",
+            padding: "14px 20px",
+            borderRadius: 10,
+            background: COLOR.cinnabar,
+            color: COLOR.paperHi,
+            textDecoration: "none",
+            marginBottom: 14,
+          }}
+        >
+          Get your download on Gumroad
+        </a>
+
+        <Link
+          href="/handbook"
+          style={{
+            display: "block",
+            fontFamily: FONT.label,
+            fontSize: 15,
+            letterSpacing: "0.04em",
+            padding: "12px 20px",
+            borderRadius: 10,
+            border: `1px solid ${COLOR.steel}`,
+            color: COLOR.parchOnDark,
+            textDecoration: "none",
+          }}
+        >
+          Re-read the Prologue
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/components/handbook/blocks/FooterBlock.tsx
+++ b/src/components/handbook/blocks/FooterBlock.tsx
@@ -1,19 +1,30 @@
+import Link from "next/link";
 import { COLOR, FONT } from "@/lib/handbook/tokens";
 
-export function FooterBlock({ nextLabel }: { nextLabel: string }) {
+/**
+ * End-of-chapter CTA. The next-chapter link is the conversion point: from the
+ * free Prologue it leads to the gated next chapter, which shows the paywall
+ * (buy on Gumroad) until the reader is entitled. `nextHref` defaults to the
+ * first paid chapter.
+ */
+export function FooterBlock({
+  nextLabel,
+  nextHref = "/handbook/chapter-one",
+}: {
+  nextLabel: string;
+  nextHref?: string;
+}) {
   return (
     <div style={{ marginTop: 20, padding: 24, textAlign: "center", borderTop: "1px solid #d5c8aa" }}>
       <div style={{ fontFamily: FONT.mono, fontSize: 9, letterSpacing: "0.18em", color: "#9a8d72" }}>
         — THE OPENING ENDS HERE —
       </div>
-      <div style={{ marginTop: 14, display: "inline-block", border: `1px solid ${COLOR.cinnabar}`, borderRadius: 8, padding: "11px 20px", cursor: "pointer" }}>
+      <Link
+        href={nextHref}
+        style={{ marginTop: 14, display: "inline-block", border: `1px solid ${COLOR.cinnabar}`, borderRadius: 8, padding: "11px 20px", textDecoration: "none" }}
+      >
         <span style={{ fontFamily: FONT.label, fontSize: 15, color: COLOR.cinnabar }}>{nextLabel}</span>
-      </div>
-      <div style={{ fontFamily: FONT.mono, fontSize: 9, color: "#b3a583", marginTop: 16, lineHeight: 1.6 }}>
-        PROTOTYPE · front-of-book vertical slice
-        <br />
-        content + skin shared with the print export
-      </div>
+      </Link>
     </div>
   );
 }

--- a/src/lib/book-access.ts
+++ b/src/lib/book-access.ts
@@ -19,6 +19,19 @@ export function isFreeChapter(chapterId: string): boolean {
 }
 
 /**
+ * Non-free chapters that actually have in-app content authored (a JSON in
+ * public/handbook/). Empty at launch — the paid product ships as a Gumroad PDF
+ * and the in-app reader gains chapters over time (content pipeline, 1.79 HCP).
+ * Add ids here as chapters are published so the gate renders the reader instead
+ * of the "unlocked, coming soon" panel.
+ */
+export const PUBLISHED_CHAPTER_IDS: string[] = []
+
+export function isPublishedChapter(chapterId: string): boolean {
+  return PUBLISHED_CHAPTER_IDS.includes(chapterId)
+}
+
+/**
  * Whether the given player holds an active entitlement for the book.
  * Fails closed: any unexpected error denies access (callers still allow free
  * chapters explicitly via isFreeChapter).


### PR DESCRIPTION
Makes the free-sample → buy → unlock path coherent for the chosen launch SKU: **the full book is sold as a Gumroad-hosted PDF**, and the in-app `/handbook` reader is the **free Prologue sample** that gains chapters over time. Builds on the merged Phase 1 paywall (#100). Epic: #99.

## Why
After Phase 1 the paywall gated correctly, but the funnel had two rough edges for an actual launch:
- The Prologue's "Continue to Chapter One" button was **inert** (a styled div) — the free sample led nowhere.
- An entitled buyer opening an unauthored chapter hit a **"could not load"** error.

## Changes
- **`FooterBlock`** CTA is now a real link to the gated next chapter (`/handbook/chapter-one`), so the free Prologue funnels into the paywall. Removed the "PROTOTYPE" footer note (this is a launch surface now).
- **`UnlockedComingSoon`** panel — entitled readers opening a not-yet-authored chapter see an honest *"You're unlocked / get your download on Gumroad / in-app chapters arriving"* surface instead of an error.
- **`PUBLISHED_CHAPTER_IDS` / `isPublishedChapter`** in `book-access`; the `[chapterId]` route branches entitled → reader (published) vs coming-soon (not yet). Empty at launch.
- Verification quest step 4 updated to match the new panel.

## Launch SKU decision (2026-06-14)
- Sell the full book as a **Gumroad-hosted PDF**; in-app reader = free sample, access code unlocks growing in-app chapters.
- **Author supplies the PDF.** No in-app download endpoint needed at launch (Gumroad delivers the file).

## Verification
- `npm run check` green (0 errors); `npm run test:book-paywall` passing; precommit `validate-manifest` passing.

## After merge — remaining is ops only (no code blocks selling)
1. Create the Gumroad product, upload the PDF, enable license keys, set price.
2. Set Vercel **Production** env: `GUMROAD_PRODUCT_ID`, `GUMROAD_PRODUCT_URL` (verify mode `live`).
3. `npm run seed:cert:book-paywall` in prod, then walk the cert once.

Epic #99 · branch `claude/sleepy-ride-f7ptcl`

https://claude.ai/code/session_0154uNkLDmgAnNxsCDHKPvyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0154uNkLDmgAnNxsCDHKPvyQ)_