### PR TITLE
Launch funnel: storefront readiness check, /redeem linkage, post-purchase next step

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:migrate:deploy": "tsx scripts/migrate-with-direct-url.ts deploy",
     "db:migrate:status": "tsx scripts/migrate-with-direct-url.ts status",
     "db:url:doctor": "tsx scripts/db-url-doctor.ts",
+    "launch:check": "tsx scripts/launch-check.ts",
     "deck:export-pdf": "tsx scripts/export-oracle-deck-pdf.ts",
     "db:studio": "prisma studio",
     "db:seed": "tsx prisma/seed.ts",

--- a/scripts/launch-check.ts
+++ b/scripts/launch-check.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env npx tsx
+/**
+ * Launch storefront readiness check — is the store actually sellable?
+ *
+ * Every offer on /launch links out to Gumroad via a NEXT_PUBLIC_GUMROAD_*_URL.
+ * When that's unset the offer renders "Setup pending" (isOfferLive) and CANNOT
+ * be bought. This script reports, per SKU, whether the buy link and the
+ * license-verify product id are wired, plus the global webhook config — so you
+ * get instant feedback while setting up Gumroad instead of discovering a dead
+ * storefront in production.
+ *
+ * Usage:
+ *   npm run launch:check            # report; exits 1 if NOTHING is sellable
+ *   npm run launch:check -- --strict  # exits 1 if ANY offer is not fully wired
+ *
+ * Run after `npm run env:pull:production` (or against your local .env.local) to
+ * check what Production will actually serve.
+ */
+import { config } from 'dotenv'
+
+config({ path: '.env' })
+config({ path: '.env.local', override: true })
+
+// Buy-link env var per SKU — mirrors the GUMROAD map in
+// src/lib/launch/offers.ts (Next inlines those NEXT_PUBLIC_* reads statically,
+// so they can't be derived dynamically there). KEEP IN SYNC with offers.ts.
+const BUY_URL_ENV: Record<string, string> = {
+  'founding-ally': 'NEXT_PUBLIC_GUMROAD_FOUNDING_ALLY_URL',
+  'book-digital': 'NEXT_PUBLIC_GUMROAD_BOOK_DIGITAL_URL',
+  'rpg-handbook-digital': 'NEXT_PUBLIC_GUMROAD_RPG_DIGITAL_URL',
+  'deck-digital': 'NEXT_PUBLIC_GUMROAD_DECK_DIGITAL_URL',
+  'game-subscription': 'NEXT_PUBLIC_GUMROAD_GAME_SUB_URL',
+  'book-physical': 'NEXT_PUBLIC_GUMROAD_BOOK_PHYSICAL_URL',
+  'rpg-handbook-physical': 'NEXT_PUBLIC_GUMROAD_RPG_PHYSICAL_URL',
+}
+
+/** Product-id env candidates per SKU (mirrors gumroad.ts productIdForSku). */
+function productIdEnvs(sku: string): string[] {
+  const specific = `GUMROAD_PRODUCT_ID_${sku.toUpperCase().replace(/-/g, '_')}`
+  return sku === 'book-digital' ? [specific, 'GUMROAD_PRODUCT_ID'] : [specific]
+}
+
+const has = (name: string): boolean => !!process.env[name]?.trim()
+const firstSet = (names: string[]): string | undefined => names.find(has)
+const yes = '✓'
+const no = '✗'
+
+async function main() {
+  const { LAUNCH_OFFERS } = await import('../src/lib/launch/offers')
+  const strict = process.argv.includes('--strict')
+
+  console.log('\nLaunch storefront readiness — env: .env + .env.local\n')
+  console.log('  ' + 'OFFER'.padEnd(26) + 'BUY LINK'.padEnd(12) + 'LICENSE VERIFY')
+
+  let sellable = 0
+  let fullyWired = 0
+  for (const offer of LAUNCH_OFFERS) {
+    const buyEnv = BUY_URL_ENV[offer.key]
+    const buyOk = !!buyEnv && has(buyEnv)
+    const idEnv = firstSet(productIdEnvs(offer.key))
+    if (buyOk) sellable++
+    if (buyOk && idEnv) fullyWired++
+    const buyCell = buyOk ? `${yes} live` : `${no} pending`
+    const idCell = idEnv ? `${yes} ${idEnv}` : `${no} (no ${productIdEnvs(offer.key)[0]})`
+    console.log('  ' + offer.key.padEnd(26) + buyCell.padEnd(12) + idCell)
+  }
+
+  console.log('')
+  // Global commerce config.
+  const webhook = has('GUMROAD_WEBHOOK_SECRET')
+  const verifyMode = process.env.GUMROAD_VERIFY_MODE?.trim() || 'live'
+  console.log(`  GUMROAD_WEBHOOK_SECRET   ${webhook ? yes + ' set' : no + ' MISSING — webhook rejects all sales (buyers must use the /redeem license fallback)'}`)
+  console.log(`  GUMROAD_SELLER_ID        ${has('GUMROAD_SELLER_ID') ? yes + ' set' : '· optional'}`)
+  console.log(`  GUMROAD_PRODUCT_MAP      ${has('GUMROAD_PRODUCT_MAP') ? yes + ' set' : '· optional (permalink→SKU override)'}`)
+  console.log(`  GUMROAD_VERIFY_MODE      ${verifyMode === 'mock' ? no + ' mock — NOT verifying real licenses!' : yes + ' live'}`)
+
+  const total = LAUNCH_OFFERS.length
+  console.log(`\n  ${sellable}/${total} offers sellable (buy link wired) · ${fullyWired}/${total} also license-verifiable\n`)
+
+  if (sellable === 0) {
+    console.log(`${no} Store is NOT sellable — no offer has a buy link. Set the NEXT_PUBLIC_GUMROAD_*_URL vars in Vercel (+ .env.local), then re-run.\n`)
+    process.exit(1)
+  }
+  if (strict && (fullyWired < total || !webhook || verifyMode === 'mock')) {
+    console.log(`${no} --strict: not every offer is fully wired (buy link + product id + webhook + live verify).\n`)
+    process.exit(1)
+  }
+  console.log(`${yes} ${sellable} offer(s) can be purchased on /launch.\n`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/actions/entitlements.ts
+++ b/src/actions/entitlements.ts
@@ -28,6 +28,17 @@ const REDEEM_MESSAGES: Record<string, string> = {
   network: 'Could not reach the store to verify your key. Please try again.',
 }
 
+/** Where a buyer should go right after unlocking each SKU — the "now what?" CTA. */
+const NEXT_STEP: Record<string, { href: string; label: string }> = {
+  'book-digital': { href: '/handbook', label: 'Read the book' },
+  'book-physical': { href: '/handbook', label: 'Read the digital book' },
+  'rpg-handbook-digital': { href: '/handbook', label: 'Open the handbook' },
+  'rpg-handbook-physical': { href: '/handbook', label: 'Open the digital handbook' },
+  'deck-digital': { href: '/deck', label: 'Open the Oracle deck' },
+  'game-subscription': { href: '/play', label: 'Start playing' },
+  'founding-ally': { href: '/dashboard', label: 'Enter the app' },
+}
+
 function unlocked(sku: string, alreadyRedeemed: boolean) {
   // One unlock can open the reader, the deck, and downloads — revalidate broadly.
   for (const p of ['/', '/redeem', '/handbook', '/downloads']) revalidatePath(p)
@@ -36,6 +47,7 @@ function unlocked(sku: string, alreadyRedeemed: boolean) {
     sku,
     offerName: offerName(sku),
     alreadyRedeemed,
+    nextStep: NEXT_STEP[sku] ?? { href: '/dashboard', label: 'Enter the app' },
     message: alreadyRedeemed
       ? `You've already unlocked ${offerName(sku)}.`
       : `Unlocked: ${offerName(sku)}.`,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -181,6 +181,16 @@ export default async function PricingPage() {
               Already have an account? Log in
             </Link>
           </div>
+          <p className="text-xs text-zinc-500">
+            Already bought on Gumroad?{" "}
+            <Link
+              href="/redeem"
+              className="font-semibold text-zinc-300 underline-offset-2 hover:text-white hover:underline"
+            >
+              Redeem your code
+            </Link>{" "}
+            to unlock it in the app.
+          </p>
         </section>
       </div>
     </div>

--- a/src/app/redeem/RedeemForm.tsx
+++ b/src/app/redeem/RedeemForm.tsx
@@ -29,7 +29,6 @@ export function RedeemForm({ initialCode, next }: { initialCode: string; next?: 
   }
 
   const ok = result?.ok === true
-  const continueHref = next || '/'
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -70,14 +69,24 @@ export function RedeemForm({ initialCode, next }: { initialCode: string; next?: 
               : 'border-amber-700/60 bg-amber-950/40 text-amber-200'
           }`}
         >
-          <p>{result.message}</p>
-          {ok && (
-            <Link
-              href={continueHref}
-              className="mt-2 inline-block font-bold text-emerald-300 underline-offset-2 hover:underline"
-            >
-              {next ? 'Continue →' : 'Enter the app →'}
-            </Link>
+          <p className={result.ok ? 'font-semibold' : undefined}>{result.message}</p>
+          {result.ok && (
+            <div className="mt-3 flex flex-col gap-2">
+              <Link
+                href={next || result.nextStep.href}
+                className="inline-flex min-h-11 items-center justify-center rounded-lg bg-emerald-600 px-4 font-bold text-white transition-colors hover:bg-emerald-500"
+              >
+                {next ? 'Continue →' : `${result.nextStep.label} →`}
+              </Link>
+              {!next && result.nextStep.href !== '/dashboard' && (
+                <Link
+                  href="/dashboard"
+                  className="text-xs font-semibold text-emerald-300/80 underline-offset-2 hover:text-emerald-200 hover:underline"
+                >
+                  Or go to your dashboard →
+                </Link>
+              )}
+            </div>
           )}
           {!ok && 'needsAuth' in result && result.needsAuth && (
             <Link


### PR DESCRIPTION
Raises purchase-funnel throughput. The funnel code was already production-ready end-to-end (buy → key → `/redeem` → unlock); this closes the conversion gaps around it. The one remaining launch blocker is **ops, not code** — creating the Gumroad products + setting the `NEXT_PUBLIC_GUMROAD_*_URL` env vars (this PR adds the tool to verify that).

## 1. `npm run launch:check` — storefront readiness
Every `/launch` offer links out via a `NEXT_PUBLIC_GUMROAD_*_URL`; unset → the offer renders "Setup pending" and **can't be bought**. The check reports, per SKU, whether the buy link and license-verify product id are wired, plus global webhook/verify config, and exits non-zero when nothing is sellable (`--strict`: when any offer isn't fully wired). Instant feedback while wiring Gumroad instead of finding a dead storefront in prod.

```
  OFFER                     BUY LINK    LICENSE VERIFY
  founding-ally             ✓ live      ✗ (no GUMROAD_PRODUCT_ID_FOUNDING_ALLY)
  book-digital              ✓ live      ✓ GUMROAD_PRODUCT_ID
  …
  2/7 offers sellable · 1/7 also license-verifiable
```

## 2. Funnel linkage — `/pricing` → `/redeem`
Added "Already bought on Gumroad? Redeem your code" → `/redeem` on `/pricing`, so the secondary funnel entry point no longer dead-ends for buyers.

(`/game` is a static standalone from `public/game`; a link there needs the mtgoa-game app rebuilt — the post-purchase step below covers the "where do I go now" need more directly.)

## 3. Post-purchase next step
`redeemLaunchCode` now returns a per-SKU `nextStep`, and the `/redeem` success card shows it as the primary CTA — **"Read the book →"**, **"Open the Oracle deck →"**, **"Start playing →"** — instead of a generic "Enter the app." A buyer knows exactly what they unlocked and where to go (falls back to the `?next=` destination when they came from a specific surface).

## Verification
- `tsc --noEmit` clean; eslint clean on all changed files.
- All deep-link targets exist (`/handbook`, `/deck`, `/play`, `/dashboard`).

## Not in this PR
- **Conversion analytics** (the 4th funnel item) — needs a provider decision (leaning Vercel Web Analytics: privacy-first, zero-config, fits the privacy-conscious community). Following up separately.
- **Gumroad product creation + env wiring** — ops; `launch:check` is the verifier.

https://claude.ai/code/session_014TU6sTCE9KSF1HQAyMq1qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014TU6sTCE9KSF1HQAyMq1qZ)_