### PR TITLE
feat(IOA): move inner/outer aspect to the base BAR layer (Nation-free)

### DIFF
--- a/.specify/specs/inner-outer-allyship-moves/data-model.md
+++ b/.specify/specs/inner-outer-allyship-moves/data-model.md
@@ -86,9 +86,23 @@ joins `moveType` as a sibling column, consistent with `allyshipDomain`.
 - The with/for shadow — still a documented seam, never encoded (engine does not judge).
 - Phase 3 deliverables and the verification quest.
 
-## Open items
-- Whether to **revert** the Phase 4 `QuestMoveLog` columns now (PR #120 open) or leave
-  them as the demoted echo. Lean: leave (already applied; nullable; harmless).
-- Does the Nation-move path (`nation-moves.ts`) also write aspect to the base CustomBar
-  it creates, so Layer 0 stays the single source even when entered via a Nation move?
-  Lean: yes — Nation move is an overlay *expression* of a base move.
+## Decisions (locked 2026-06-17)
+- **Keep** the Phase 4 `QuestMoveLog.moveAspect/allyshipTarget` columns as a demoted
+  Nation-path **echo** (already applied to the DB; nullable; harmless). No revert.
+- The Nation-move path (`nation-moves.ts`) **does** write aspect down to the base
+  `CustomBar` it creates — Layer 0 stays the single source of truth even when entered
+  via a Nation move (a Nation move is an overlay expression of a base move). It also
+  copies the aspect onto its `QuestMoveLog` echo.
+- Sequencing: built on branch `claude/ioa-base-layer-aspect` (on top of the Phase 4
+  branch's HEAD). Note: the Phase 4 work has **no open PR yet** (an earlier "PR #120"
+  reference was incorrect).
+
+## Build status (this branch)
+- [x] `CustomBar.moveAspect` + `CustomBar.allyshipTarget` (schema + migration
+  `20260617000000_add_custom_bar_move_aspect`).
+- [x] `createBarFromMoveChoice` persists aspect/target (Nation-free) + adds `openUp`.
+- [x] `recordEnactedMove` writes the base `CustomBar`; `moveId`/NationMove optional;
+  `QuestMoveLog` written only as the Nation-path echo.
+- [x] `applyNationMoveWithState` stamps aspect on the base `CustomBar` it creates.
+- [ ] **UI**: inline Inner|Outer segmented control on the base / CYOA move-taking
+  surface (`AdventurePlayer`), never gated on `player.nationId` — next pass.

--- a/prisma/migrations/20260617000000_add_custom_bar_move_aspect/migration.sql
+++ b/prisma/migrations/20260617000000_add_custom_bar_move_aspect/migration.sql
@@ -1,0 +1,6 @@
+-- IOA base layer: the inner/outer aspect belongs to the base BAR move (CustomBar),
+-- a sibling of moveType, recorded Nation-free. Additive + nullable: no backfill.
+-- The Phase 4 columns on quest_move_logs remain as a demoted Nation-path echo.
+-- See .specify/specs/inner-outer-allyship-moves/data-model.md
+ALTER TABLE "custom_bars" ADD COLUMN "moveAspect" TEXT;
+ALTER TABLE "custom_bars" ADD COLUMN "allyshipTarget" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -319,6 +319,11 @@ model CustomBar {
   rootId                               String?
   allowedNations                       String?
   allyshipDomain                       String?
+  /// IOA base layer: inner (self-development) | outer (allyship). Sibling of moveType —
+  /// the base move's aspect, recorded Nation-free. See specs/inner-outer-allyship-moves/data-model.md.
+  moveAspect                           String?
+  /// IOA base layer: who an outer move acts on — individual | collective | system. Null for inner.
+  allyshipTarget                       String?
   nation                               String?
   archetype                            String?
   lockType                             String?

--- a/src/actions/create-bar-from-move-choice.ts
+++ b/src/actions/create-bar-from-move-choice.ts
@@ -4,8 +4,11 @@ import { db } from '@/lib/db'
 import { getCurrentPlayer } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
 import { appendCyoaArtifactBar } from '@/actions/cyoa-artifact-ledger'
+import { isValidAspectTarget } from '@/lib/quest-grammar/move-aspect'
+import type { MoveAspect, AllyshipTarget } from '@/lib/quest-grammar/types'
 
-const MOVE_TYPES = ['wakeUp', 'cleanUp', 'growUp', 'showUp'] as const
+// Layer 0 base moves — the full WAVE set, including the fifth move (Open Up).
+const MOVE_TYPES = ['wakeUp', 'openUp', 'cleanUp', 'growUp', 'showUp'] as const
 type MoveType = (typeof MOVE_TYPES)[number]
 
 function isValidMoveType(s: string): s is MoveType {
@@ -14,10 +17,14 @@ function isValidMoveType(s: string): s is MoveType {
 
 const MOVE_LABELS: Record<MoveType, string> = {
   wakeUp: 'Wake Up',
+  openUp: 'Open Up',
   cleanUp: 'Clean Up',
   growUp: 'Grow Up',
   showUp: 'Show Up',
 }
+
+const VALID_ASPECTS: readonly MoveAspect[] = ['inner', 'outer']
+const VALID_TARGETS: readonly AllyshipTarget[] = ['individual', 'collective', 'system']
 
 export type CreateBarFromMoveChoiceResult =
   | { success: true; barId: string }
@@ -35,12 +42,37 @@ export async function createBarFromMoveChoice(input: {
   choiceText?: string
   questId?: string
   campaignRef?: string | null
+  /** IOA base layer: inner (self) | outer (allyship). Optional — Nation-free. */
+  aspect?: MoveAspect
+  /** Required when aspect === 'outer'; omitted for inner. */
+  target?: AllyshipTarget
 }): Promise<CreateBarFromMoveChoiceResult> {
   const player = await getCurrentPlayer()
   if (!player) return { error: 'Not logged in' }
 
   if (!isValidMoveType(input.moveType)) {
     return { error: `Invalid moveType: ${input.moveType}` }
+  }
+
+  // Aspect is optional, but when present it must satisfy the allyship invariant
+  // (outer ⇒ target; inner ⇒ none) — one source of truth with the grammar.
+  if (input.aspect !== undefined) {
+    if (!VALID_ASPECTS.includes(input.aspect)) {
+      return { error: `Invalid aspect: ${String(input.aspect)}` }
+    }
+    if (input.target !== undefined && !VALID_TARGETS.includes(input.target)) {
+      return { error: `Invalid target: ${String(input.target)}` }
+    }
+    if (!isValidAspectTarget(input.aspect, input.target)) {
+      return {
+        error:
+          input.aspect === 'outer'
+            ? 'Outer (allyship) moves require a target (individual, collective, or system).'
+            : 'Inner moves are self-directed and cannot carry a target.',
+      }
+    }
+  } else if (input.target !== undefined) {
+    return { error: 'A target requires an outer aspect.' }
   }
 
   const label = MOVE_LABELS[input.moveType]
@@ -73,6 +105,8 @@ export async function createBarFromMoveChoice(input: {
         claimedById: player.id,
         inputs: JSON.stringify([]),
         moveType: input.moveType,
+        moveAspect: input.aspect ?? null,
+        allyshipTarget: input.target ?? null,
         parentId: input.questId ?? null,
         rootId: `cyoa_move_${input.passageNodeId}`,
         campaignRef,

--- a/src/actions/move-aspect.ts
+++ b/src/actions/move-aspect.ts
@@ -3,16 +3,21 @@
 /**
  * Inner / Outer Allyship — persistence of a player's aspect choice on move-taking.
  *
- * FR8 (Phase 4): when a player takes a move they may enact it **inner** (self-
- * development) or **outer** (allyship, which requires a target). This Server Action
- * is the contract for that choice — it annotates a `QuestMoveLog` row with
- * `moveAspect` (+ `allyshipTarget` for outer). Deterministic, no AI.
+ * Base layer: when a player takes a move they may enact it **inner** (self-
+ * development) or **outer** (allyship, which requires a target). Aspect is a
+ * property of the *base* move, so the source of truth is the base `CustomBar`
+ * (`moveAspect` + `allyshipTarget`) — recorded **Nation-free**. A `NationMove`
+ * is no longer required to record an aspect.
+ *
+ * When the move is taken via a Nation overlay (a `NationMove` id is supplied), a
+ * `QuestMoveLog` row is also written as a secondary *echo* of the same aspect, so
+ * the Nation path stays observable. The base `CustomBar` remains canonical.
  *
  * The with/for shadow reading of the chosen face×cell is a documented seam and is
  * deliberately NOT recorded here — the engine logs *what* was enacted, it does not
  * judge it (CLAUDE.md: "emotional energy is fuel, not judgment").
  *
- * See .specify/specs/inner-outer-allyship-moves/spec.md.
+ * See .specify/specs/inner-outer-allyship-moves/data-model.md and spec.md.
  */
 
 import { db } from '@/lib/db'
@@ -27,10 +32,18 @@ const VALID_TARGETS: readonly AllyshipTarget[] = ['individual', 'collective', 's
 
 /** Contract for recording a player's inner/outer choice when they take a move. */
 export interface RecordEnactedMoveInput {
-  /** The quest (CustomBar) the move is taken on. */
-  questId: string
-  /** The NationMove being taken (FK on QuestMoveLog.moveId). */
-  moveId: string
+  /**
+   * The base move-BAR (CustomBar) to stamp as the canonical aspect record.
+   * Defaults to `questId` when omitted. At least one of `barId`/`questId` is required.
+   */
+  barId?: string
+  /** The quest (CustomBar) the move is taken on / the base move-BAR's context. */
+  questId?: string
+  /**
+   * Optional NationMove id. When present, a QuestMoveLog echo is also written
+   * (the Nation overlay path). Omit for a Nation-free base move.
+   */
+  moveId?: string
   /** inner = self-development; outer = allyship (requires target). */
   aspect: MoveAspect
   /** Required when aspect === 'outer'; omitted/undefined for inner. */
@@ -38,7 +51,7 @@ export interface RecordEnactedMoveInput {
 }
 
 export type RecordEnactedMoveResult =
-  | { ok: true; logId: string; aspect: MoveAspect; target: AllyshipTarget | null }
+  | { ok: true; logId: string | null; aspect: MoveAspect; target: AllyshipTarget | null }
   | { ok: false; error: string }
 
 function userSafeError(error: unknown): string {
@@ -66,8 +79,9 @@ export async function recordEnactedMove(input: RecordEnactedMoveInput): Promise<
 
     const questId = input.questId?.trim()
     const moveId = input.moveId?.trim()
-    if (!questId) return { ok: false, error: 'Missing questId' }
-    if (!moveId) return { ok: false, error: 'Missing moveId' }
+    // Canonical home for the aspect is the base move-BAR; fall back to the quest.
+    const barId = input.barId?.trim() || questId
+    if (!barId) return { ok: false, error: 'Missing barId/questId' }
 
     if (!VALID_ASPECTS.includes(input.aspect)) {
       return { ok: false, error: `Invalid aspect: ${String(input.aspect)}` }
@@ -86,38 +100,51 @@ export async function recordEnactedMove(input: RecordEnactedMoveInput): Promise<
       }
     }
 
-    // Access: creator, claimer, or assigned (mirrors nation-moves).
-    const quest = await db.customBar.findUnique({
-      where: { id: questId },
+    // Access: creator, claimer, or assigned (mirrors nation-moves), checked on the
+    // base CustomBar that will carry the aspect.
+    const bar = await db.customBar.findUnique({
+      where: { id: barId },
       select: { id: true, creatorId: true, claimedById: true },
     })
-    if (!quest) return { ok: false, error: 'Quest not found' }
+    if (!bar) return { ok: false, error: 'BAR not found' }
 
-    const hasDirectAccess = quest.creatorId === player.id || quest.claimedById === player.id
+    const hasDirectAccess = bar.creatorId === player.id || bar.claimedById === player.id
     if (!hasDirectAccess) {
       const pq = await db.playerQuest.findUnique({
-        where: { playerId_questId: { playerId: player.id, questId } },
+        where: { playerId_questId: { playerId: player.id, questId: barId } },
         select: { status: true },
       })
-      if (pq?.status !== 'assigned') return { ok: false, error: 'Not authorized to act on this quest' }
+      if (pq?.status !== 'assigned') return { ok: false, error: 'Not authorized to act on this BAR' }
     }
 
     const target = input.target ?? null
-    const log = await db.questMoveLog.create({
-      data: {
-        questId,
-        moveId,
-        playerId: player.id,
-        moveAspect: input.aspect,
-        allyshipTarget: target,
-      },
-      select: { id: true },
+
+    // Canonical: stamp the base move-BAR (Nation-free source of truth).
+    await db.customBar.update({
+      where: { id: barId },
+      data: { moveAspect: input.aspect, allyshipTarget: target },
     })
+
+    // Echo: only on the Nation overlay path (a NationMove id + its quest context).
+    let logId: string | null = null
+    if (moveId && questId) {
+      const log = await db.questMoveLog.create({
+        data: {
+          questId,
+          moveId,
+          playerId: player.id,
+          moveAspect: input.aspect,
+          allyshipTarget: target,
+        },
+        select: { id: true },
+      })
+      logId = log.id
+    }
 
     revalidatePath('/')
     revalidatePath('/vault')
 
-    return { ok: true, logId: log.id, aspect: input.aspect, target }
+    return { ok: true, logId, aspect: input.aspect, target }
   } catch (error) {
     console.error('[move-aspect] recordEnactedMove failed:', error)
     return { ok: false, error: userSafeError(error) }

--- a/src/actions/nation-moves.ts
+++ b/src/actions/nation-moves.ts
@@ -6,6 +6,8 @@ import { getActiveDaemonMoves } from '@/actions/daemons'
 import { getAppConfig } from '@/actions/config'
 import { revalidatePath } from 'next/cache'
 import { Prisma } from '@prisma/client'
+import { isValidAspectTarget } from '@/lib/quest-grammar/move-aspect'
+import type { MoveAspect, AllyshipTarget } from '@/lib/quest-grammar/types'
 
 // ---------------------------------------------------------------------------
 // Types (MVP schemas stored in DB as JSON strings)
@@ -387,6 +389,32 @@ export async function applyNationMoveWithState(_prev: ApplyNationMoveState | nul
     if (!questId) return { error: 'Missing questId' }
     if (!moveKey) return { error: 'Missing moveKey' }
 
+    // IOA base layer: a Nation move is an overlay expression of a base move, so the
+    // optional inner/outer aspect is stamped on the base CustomBar this move creates
+    // (Layer 0 stays the single source of truth). Aspect is optional/Nation-free in shape.
+    const rawAspect = (formData.get('aspect') as string | null)?.trim() || ''
+    const rawTarget = (formData.get('allyshipTarget') as string | null)?.trim() || ''
+    let moveAspect: MoveAspect | null = null
+    let allyshipTarget: AllyshipTarget | null = null
+    if (rawAspect) {
+      if (rawAspect !== 'inner' && rawAspect !== 'outer') return { error: `Invalid aspect: ${rawAspect}` }
+      if (rawTarget && rawTarget !== 'individual' && rawTarget !== 'collective' && rawTarget !== 'system') {
+        return { error: `Invalid target: ${rawTarget}` }
+      }
+      const t = (rawTarget || undefined) as AllyshipTarget | undefined
+      if (!isValidAspectTarget(rawAspect, t)) {
+        return {
+          error: rawAspect === 'outer'
+            ? 'Outer (allyship) moves require a target (individual, collective, or system).'
+            : 'Inner moves are self-directed and cannot carry a target.',
+        }
+      }
+      moveAspect = rawAspect
+      allyshipTarget = t ?? null
+    } else if (rawTarget) {
+      return { error: 'A target requires an outer aspect.' }
+    }
+
     const quest = await db.customBar.findUnique({
       where: { id: questId },
       select: {
@@ -503,6 +531,8 @@ export async function applyNationMoveWithState(_prev: ApplyNationMoveState | nul
           inputs: '[]',
           parentId: questId,
           rootId: 'temp',
+          moveAspect,
+          allyshipTarget,
         }
       })
 
@@ -520,6 +550,9 @@ export async function applyNationMoveWithState(_prev: ApplyNationMoveState | nul
           createdBarId: bar.id,
           inputsJson: JSON.stringify(validated.inputs),
           effectsJson: JSON.stringify(effects),
+          // Echo of the base CustomBar's aspect (canonical home is bar.moveAspect).
+          moveAspect,
+          allyshipTarget,
         }
       })
 


### PR DESCRIPTION
## Inner/Outer Allyship — base-layer correction

Aspect (**inner** = self-development, **outer** = allyship) is a property of the **base WAVE move**, not the Nation overlay. The earlier phase stored `moveAspect`/`allyshipTarget` on `QuestMoveLog`, which has a required `NationMove` FK — so recording an aspect was coupled to *having a Nation*. This moves the source of truth down to the base `CustomBar`, a sibling of `moveType`, and makes aspect recordable Nation-free.

### Changes
- **Schema + migration** (`add_custom_bar_move_aspect`): `CustomBar.moveAspect` + `CustomBar.allyshipTarget` — additive, nullable, no backfill.
- **`createBarFromMoveChoice`** (the live CYOA base path): persists aspect/target Nation-free; validates the allyship invariant via the shared `isValidAspectTarget`; adds the fifth move **`openUp`** (the list was stale at four).
- **`recordEnactedMove`**: stamps the base `CustomBar` as canonical; `moveId`/`NationMove` is now **optional**; `QuestMoveLog` is written **only** as the Nation-path echo (`logId` nullable).
- **`applyNationMoveWithState`**: stamps aspect on the base `CustomBar` it creates, so Layer 0 stays the single source of truth even when entered via a Nation move; echoed onto the `QuestMoveLog` row.

### Decisions (locked)
- Phase 4 `QuestMoveLog.moveAspect/allyshipTarget` columns **kept** as a demoted Nation-path echo (no revert; nullable; harmless).
- Nation path **does** write aspect down to the base `CustomBar` (a Nation move is an overlay *expression* of a base move).

### Verification
- `tsc --noEmit` clean.
- `npm run test:move-aspect` green (allyship invariant: outer ⇒ target; inner ⇒ none).
- Server actions hit the DB, so they're validated by type-check rather than executed here. The migration is additive/nullable and applies on the next `migrate deploy`.

### Not in this PR
- **UI**: the inline `Inner | Outer` segmented control on the move-taking surface (`AdventurePlayer`), wired to pass `aspect`/`target` into `createBarFromMoveChoice` and never gated on `player.nationId` — next pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAfb4KqDsZt6th5DDp1kVh)_