### PR TITLE
Spec: canvas gestures & text editor fixes

### DIFF
--- a/.specify/specs/canvas-gestures/plan.md
+++ b/.specify/specs/canvas-gestures/plan.md
@@ -1,0 +1,150 @@
+# Plan: Canvas Gestures & Text Editor Fixes
+
+## Implementation order
+
+Fix the bugs first (1.1, 1.2) — they're isolated. Then extend the gesture system (1.3) which touches the most code.
+
+---
+
+## Phase 1: Bug fixes
+
+### 1.1 Fix size slider
+
+In `TextEditorOverlay`, remove the rotated absolutely-positioned slider div. Replace with a horizontal slider row at the bottom of the overlay, below the element colour rail:
+
+```tsx
+{/* Size row */}
+<div className="flex items-center gap-3 px-6 pb-4">
+  <span style={{ fontFamily: 'Jost', fontWeight: 800, fontSize: 11, color: 'rgba(232,226,218,0.5)' }}>A</span>
+  <input
+    type="range"
+    min={12}
+    max={80}
+    step={1}
+    value={draftSize}
+    onChange={(e) => onDraftSizeChange(Number(e.target.value))}
+    style={{ flex: 1 }}
+  />
+  <span style={{ fontFamily: 'Jost', fontWeight: 800, fontSize: 22, color: 'rgba(232,226,218,0.5)' }}>A</span>
+</div>
+```
+
+Also widen the min/max to `12–80` (was `16–54`) to match the free pinch range.
+
+### 1.2 Remove tap-empty-canvas
+
+In `SeedCaptureWhiteboard`, `handleCanvasTap` currently opens the text editor. Replace its body with a no-op (or remove it entirely and change `onPointerDown` on the canvas div to `undefined`). The canvas layer div still needs `onPointerMove` and `onPointerUp` for drag handling.
+
+Keep `onPointerDown` on the canvas div — it's needed to detect drags that start on empty canvas (so we don't accidentally start dragging an item when the user pans). Just remove the text-editor-open logic inside it.
+
+---
+
+## Phase 2: Two-finger gestures
+
+### 2.1 Extend `DragState` + add `GestureState`
+
+Add a second ref for tracking the gesture when two pointers are active on the same item:
+
+```ts
+interface GestureState {
+  pointer1Id: number
+  pointer2Id: number
+  itemId: string
+  // positions at gesture start
+  p1Start: { x: number; y: number }
+  p2Start: { x: number; y: number }
+  // latest positions (updated on move)
+  p1Current: { x: number; y: number }
+  p2Current: { x: number; y: number }
+  // item state at gesture start
+  originSize: number   // font px for text; scale factor for photo
+  originRot: number    // degrees
+  originX: number      // item center x
+  originY: number      // item center y
+  scale: number        // canvas scale (for coordinate conversion)
+}
+```
+
+Store in `gestureRef = useRef<GestureState | null>(null)`.
+
+### 2.2 Second-pointer detection
+
+In `handlePointerMove` (on canvas div), add a check: if `gestureRef.current` is already active, update the matching pointer's current position and recompute size + rotation. Otherwise fall through to existing single-drag logic.
+
+In `handlePointerUp` (on canvas div), if either `pointer1Id` or `pointer2Id` from `gestureRef.current` lifts, clear `gestureRef.current` and allow the remaining pointer to resume as a single drag (update `dragRef.current` accordingly).
+
+**Initiating gesture**: In a new `handleSecondPointerDown` — called when `pointerdown` fires on an item AND `dragRef.current` is already set for that item:
+
+```ts
+function handleSecondPointerDown(e: React.PointerEvent, id: string) {
+  const drag = dragRef.current
+  if (!drag || drag.itemId !== id) return
+  const item = items.find(i => i.id === id)
+  if (!item) return
+  const board = boardRef.current!
+  const rect = board.getBoundingClientRect()
+  const s = rect.width / LOGICAL_W
+
+  const p1 = { x: drag.startX, y: drag.startY }  // first pointer's last known position
+  const p2 = { x: e.clientX, y: e.clientY }
+
+  gestureRef.current = {
+    pointer1Id: drag.pointerId,
+    pointer2Id: e.pointerId,
+    itemId: id,
+    p1Start: p1, p2Start: p2,
+    p1Current: p1, p2Current: p2,
+    originSize: item.size ?? (item.type === 'photo' ? 1.0 : 27),
+    originRot: item.rot,
+    originX: item.x,
+    originY: item.y,
+    scale: s,
+  }
+  dragRef.current = null  // suspend single drag while gesturing
+  ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+}
+```
+
+In the sticker `onPointerDown` handler, check if a drag is already active for that item and route to `handleSecondPointerDown`.
+
+### 2.3 Gesture math
+
+On each `pointermove` while `gestureRef.current` is set:
+
+```ts
+const g = gestureRef.current
+// update current positions
+if (e.pointerId === g.pointer1Id) g.p1Current = { x: e.clientX, y: e.clientY }
+if (e.pointerId === g.pointer2Id) g.p2Current = { x: e.clientX, y: e.clientY }
+
+const initDist = Math.hypot(g.p2Start.x - g.p1Start.x, g.p2Start.y - g.p1Start.y)
+const curDist  = Math.hypot(g.p2Current.x - g.p1Current.x, g.p2Current.y - g.p1Current.y)
+const scaleFactor = initDist > 0 ? curDist / initDist : 1
+
+const initAngle = Math.atan2(g.p2Start.y - g.p1Start.y, g.p2Start.x - g.p1Start.x)
+const curAngle  = Math.atan2(g.p2Current.y - g.p1Current.y, g.p2Current.x - g.p1Current.x)
+const angleDelta = (curAngle - initAngle) * (180 / Math.PI)
+
+setItems(prev => prev.map(it => {
+  if (it.id !== g.itemId) return it
+  const isPhoto = it.type === 'photo'
+  const newSize = isPhoto
+    ? clamp(g.originSize * scaleFactor, 0.35, 3.5)
+    : clamp(Math.round(g.originSize * scaleFactor), 12, 80)
+  return { ...it, size: newSize, rot: g.originRot + angleDelta }
+}))
+```
+
+### 2.4 Photo size rendering
+
+Update the photo sticker JSX to use `item.size` (default `1.0`) as a scale factor:
+
+```ts
+const photoW = Math.round(118 * (item.size ?? 1.0))
+const photoH = Math.round(132 * (item.size ?? 1.0))
+```
+
+### 2.5 Type-check + verify
+
+- `npm run check` — no errors
+- Manual: run `cert-canvas-gestures-v1` (11 steps)

--- a/.specify/specs/canvas-gestures/spec.md
+++ b/.specify/specs/canvas-gestures/spec.md
@@ -1,0 +1,75 @@
+# Spec: Canvas Gestures & Text Editor Fixes
+
+## Purpose
+
+Three related problems with the Seed Capture Whiteboard canvas that make it feel broken on mobile:
+
+1. **Slider never worked** — The font-size slider in the text editor is CSS-rotated (`rotate(-90deg)`). On touch devices, the browser maps pointer coordinates to the pre-transform layout position, so dragging the visually-vertical slider does nothing. Bug, not missing feature.
+
+2. **Text editor opens by accident** — Tapping any empty area of the canvas opens the text editor overlay. Players will constantly trigger this accidentally while browsing or repositioning items.
+
+3. **No pinch / rotate gestures** — Placed stickers (text + photos) can only be moved. There's no way to resize or rotate them once on canvas, which is the core Instagram-Stories-style interaction the BSCW is modelling.
+
+---
+
+## Design Decisions
+
+### Slider fix
+Replace the rotated horizontal `<input type="range">` with a proper horizontal slider placed beneath the color swatch rail at the bottom of the `TextEditorOverlay`. Small **A** on the left, large **A** on the right — no transform, no rotation. The textarea font size updates in real-time as expected.
+
+### Text editor trigger
+- **Remove**: tap on empty canvas → open text editor
+- **Keep**: tap the **Aa** button in ToolRail → open new-text editor
+- **Keep**: tap an existing placed text sticker → open that sticker's editor (already implemented in `handlePointerUp`)
+
+### Two-finger gestures on placed stickers
+Single-pointer drag = move (unchanged). When a **second** pointer goes down on the **same item** while a drag is active, switch to gesture mode:
+
+- **Pinch in/out** → scale the sticker. For text: changes `item.size` (font size, free range 12–80px). For photos: changes `item.size` as a scale factor (default `1.0`, min `0.4`, max `3.0`; renders as `118 * size` × `132 * size` px).
+- **Twist** → changes `item.rot` (degrees, unbounded). Computed as the angle delta between the two-finger vector at gesture start vs. current.
+- Both happen simultaneously from the same two-finger interaction.
+
+Gesture mode exits when either pointer is released; single-pointer drag can resume after.
+
+### Scope
+- Gestures only on **placed stickers** on canvas (text and photo). Not on voice chips, link chips, or inside editor overlays.
+- Photo `size` field (`number`, default `1.0`) is new on `CanvasItem`. Text already has `size`.
+- No minimum snap on pinch — free continuous scale.
+
+---
+
+## Conceptual Model
+
+```
+One finger on sticker  →  move
+Two fingers on sticker →  pinch = scale · twist = rotate (simultaneous)
+Tap (no move, one finger, text sticker) → open text editor
+Aa button → open text editor (new text)
+Empty canvas tap → nothing (removed)
+```
+
+---
+
+## Data / API Contracts
+
+`CanvasItem` (already in `src/actions/bars.ts`):
+- `size?: number` — already used by text (font px). For photos: treat as scale factor, default `1.0`.
+- `rot: number` — already present. Unbounded degrees.
+
+No schema changes needed — `canvasLayout` already stores the full `CanvasItem[]` as JSON.
+
+---
+
+## Verification Quest: `cert-canvas-gestures-v1`
+
+1. Open `/bars/capture`. Tap empty canvas area → nothing opens.
+2. Tap **Aa** button → text editor opens. Type text, tap Done → sticker placed.
+3. Tap the placed text sticker → editor reopens with existing text.
+4. In editor: drag size slider left/right → textarea font size updates live.
+5. Place two text stickers. With one finger on one sticker, drag it → it moves. The other sticker stays put.
+6. Two-finger pinch on a text sticker → font size grows/shrinks.
+7. Two-finger twist on a text sticker → sticker rotates.
+8. Add a photo. Two-finger pinch on the photo sticker → photo grows/shrinks.
+9. Two-finger twist on the photo sticker → photo rotates.
+10. Drag a resized/rotated sticker to the compost zone → it is removed.
+11. Capture → BAR saved with correct canvas layout (positions, sizes, rotations preserved).

--- a/.specify/specs/canvas-gestures/tasks.md
+++ b/.specify/specs/canvas-gestures/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: Canvas Gestures & Text Editor Fixes
+
+## Phase 1: Bug fixes
+
+### 1.1 Fix size slider
+
+- [ ] In `TextEditorOverlay`: remove the rotated absolutely-positioned slider div (lines ~722–746)
+- [ ] Add horizontal size row below the element colour rail: `<input type="range" min={12} max={80}>` with small/large **A** labels, no transform
+- [ ] Widen `draftSize` initial value range if needed (default `30` is fine, clamp is 12–80)
+- [ ] Run `npm run check` — types clean
+
+### 1.2 Remove tap-empty-canvas
+
+- [ ] In `handleCanvasTap`: remove the `setEditing('new')` call and related draft-reset logic
+- [ ] The handler can be a no-op or removed entirely — keep `onPointerDown` on canvas div for drag-start detection if needed, or just remove it
+- [ ] Confirm tapping empty canvas no longer opens editor; Aa button still does
+
+---
+
+## Phase 2: Two-finger gestures
+
+### 2.1 Extend gesture tracking
+
+- [ ] Add `GestureState` interface (pointer1Id, pointer2Id, itemId, p1/p2 start/current, originSize, originRot, originX, originY, scale)
+- [ ] Add `gestureRef = useRef<GestureState | null>(null)` to main component
+
+### 2.2 Second-pointer initiation
+
+- [ ] Add `handleSecondPointerDown(e, id)` function — fires when `pointerdown` hits an item that already has an active drag
+- [ ] In `TextSticker` and photo sticker `onPointerDown`: check `dragRef.current?.itemId === id` and call `handleSecondPointerDown` if so, else call existing `handleItemPointerDown`
+- [ ] `handleSecondPointerDown` captures second pointer, populates `gestureRef.current`, clears `dragRef.current`
+
+### 2.3 Gesture math in `handlePointerMove`
+
+- [ ] At top of `handlePointerMove`: if `gestureRef.current` is set, update the matching pointer's current position, compute `scaleFactor` and `angleDelta`, update item `size` + `rot` via `setItems`, return early
+- [ ] Clamp: text `size` → `clamp(round(originSize * scaleFactor), 12, 80)`; photo `size` → `clamp(originSize * scaleFactor, 0.35, 3.5)`
+
+### 2.4 Gesture exit in `handlePointerUp`
+
+- [ ] If lifted pointer matches `gestureRef.current?.pointer1Id` or `pointer2Id`, clear `gestureRef.current` and `setDragId(null)`
+- [ ] Resume single-drag for the remaining pointer if needed (or just let user re-initiate)
+
+### 2.5 Photo size rendering
+
+- [ ] In the photo sticker JSX: compute `photoW = 118 * (item.size ?? 1.0)`, `photoH = 132 * (item.size ?? 1.0)`, use for `width`/`height` style props
+
+### 2.6 Final check
+
+- [ ] `npm run check` — no type errors
+- [ ] Manual: run `cert-canvas-gestures-v1` (11 steps in spec)
+- [ ] Verify slider updates textarea font size live
+- [ ] Verify empty canvas tap does nothing
+- [ ] Verify pinch-resize on text and photo
+- [ ] Verify twist-rotate on text and photo
+- [ ] Verify compost still works after resize/rotate


### PR DESCRIPTION
## Summary

Adds `.specify/specs/canvas-gestures/` spec kit covering three related canvas issues:

- **Slider bug** — `rotate(-90deg)` CSS transform on `<input type="range">` breaks touch event mapping on mobile. Fix: lay it horizontal below the colour rail, no transform.
- **Tap-empty-canvas** — tapping any empty area accidentally opens the text editor. Remove this; only the Aa button and tapping an existing text sticker should trigger the editor.
- **Pinch-to-resize + two-finger rotate** — placed text and photo stickers support no gestures beyond move. Add two-finger pinch (scale) and twist (rotate) using a second pointer tracked in a new `gestureRef`. Text scales font size (12–80px free), photos scale a size factor (0.35–3.5×). Both axes compute simultaneously from the same two-finger gesture.

## Files

- `.specify/specs/canvas-gestures/spec.md` — purpose, design decisions, verification quest (11 steps)
- `.specify/specs/canvas-gestures/plan.md` — implementation order and pseudocode
- `.specify/specs/canvas-gestures/tasks.md` — checklist

## Test plan

Run `cert-canvas-gestures-v1` from the spec after implementation:
- [ ] Empty canvas tap → nothing
- [ ] Aa button → text editor opens
- [ ] Tap placed text sticker → editor reopens with existing text
- [ ] Size slider updates textarea font live
- [ ] Pinch text sticker → font size changes
- [ ] Twist text sticker → rotates
- [ ] Pinch photo sticker → scales
- [ ] Twist photo sticker → rotates
- [ ] Compost still works on resized/rotated stickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt5SM4meY1EYFhCET9eCAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt5SM4meY1EYFhCET9eCAy)_