### PR TITLE
Allyship Deck: App shell, journal persistence, CYOA reading (Slices 5–6)

### DIFF
--- a/.specify/specs/allyship-deck-experience/spec.md
+++ b/.specify/specs/allyship-deck-experience/spec.md
@@ -59,12 +59,409 @@ Clean=Water, Wake=Earth, **Open=Liminal purple** (reserved; not an element).
   figures live in `lib/launch/deck-sales-copy.ts` (single source, honest-by-default). The deck
   paywall now offers a "What's in the deck?" link into the page (`Paywall.learnMoreHref`).
 
+- **Slice 5 (next) — App shell upgrade + Collection/Journal.**
+- **Slice 6 (next) — Find your path (CYOA situation reading).**
+- **Slice 7 (next) — Card anatomy upgrades (`num`, card footer spec).**
+- **Slice 8 (next) — Spread draw mode.**
+
 ## Deferred / not built
 
 - Final operation/face **sigil art** (monogram placeholders today).
-- Real in-app checkout/auth (using Gumroad).
+- Real in-app checkout/auth (using Gumroad). See note on sales branding below.
 - Webfonts (Jost/Nunito/Space Mono) — `card-visuals.DECK_FONTS` falls back gracefully.
+- `reward` / `minutes` card footer stats — omitted until the BAR layer computes real values; see Slice 7.
 
 ## Verification
 
 `npm run test:allyship-deck` (assembler + card-visuals, covers all 120). Visual: `/deck/preview`.
+
+---
+
+# Spec: Allyship Deck — Slices 5–8
+
+> Source: design handoff `Mastering_the_Game_of_Allyship_Book_1.zip` →
+> `design_handoff_deck_experience/` (second pass). Host decisions recorded below supersede
+> any conflicting design-prototype choices.
+
+## Host Decisions (established 2026-06-18)
+
+1. **Card data schema stays.** `public/allyship-deck/allyship-deck.json` (built by
+   `scripts/assemble-allyship-deck.ts`) remains authoritative. The handoff's `deck-data.json`
+   uses different field names (`q`, `action`, `face`, `el`, `gather` etc.) — write adapter
+   functions rather than migrating the schema. Never re-author card content from the prototype.
+
+2. **`reward` / `minutes` — omit for now.** The design shows `{minutes} MIN · ♦ {reward}` on
+   every card footer. These are computed by the BAR/quest layer, not the deck. Until that data
+   is wired, omit the footer stat row entirely. The spec note below documents what to restore.
+
+3. **Journal persistence — server-side.** Draw history lives in a new `DeckJournalEntry` Prisma
+   model (not localStorage). Players who own the deck (`deck-digital` capability) get cross-
+   device streak and history. Non-owners see the paywall.
+
+4. **BARS handoff — hand or vault, not category routes.** The existing `SendToBarsButton` flow
+   (creates a `CustomBar`, routes to `/bars/{id}`) is correct. Do NOT route to `/adventure`,
+   `/conclave`, etc. The design's theatrical "Handing off to BARS" screen is not built; the
+   existing silent server-action model stays.
+
+5. **`open_up` → liminal purple.** The existing `card-visuals.ts` treatment is correct: `open_up`
+   maps to the reserved liminal purple (`LIMINAL` constant), not a wuxing element. No change.
+   In CYOA channel logic, the 5 wuxing channels map to moves as: 火→show_up, 水→clean_up,
+   金→open_up, 土→wake_up, 木→grow_up.
+
+6. **Subject toggle stays.** The self/campaign subject toggle remains in the app.
+
+7. **Nav is local to `/deck`.** The 4-tab nav shell (Draw · Deck · Find your path · Collection)
+   lives inside the `/deck` page/component, not a global layout. Branding style: BARS engine
+   design system (gold active chip, inset inactive, mono label text) — not a fresh component.
+
+8. **Sales stays deferred; match the vibe.** `/deck/sales` exists and routes to Gumroad. No
+   new in-app purchase flow. **Research note:** investigate how far Gumroad's hosted checkout
+   can be branded (custom CSS, overlay, embed) to match the BARS dark-warm aesthetic. Capture
+   findings in `docs/GUMROAD_BRANDING_RESEARCH.md` before the next commerce sprint.
+
+---
+
+## Slice 5 — App shell upgrade + Collection / Journal
+
+### Purpose
+
+Four-tab app shell local to `/deck`. Server-persisted draw journal with streak and Vibeulon
+balance. Reminder toggle (client-only).
+
+### App shell changes (`AllyshipDeckReader`)
+
+- Nav becomes **4 tabs**: Draw · Deck · Find your path · Collection.
+  - "Browse" → "Deck" (label only).
+  - "Find a card" → "Find your path" (label + view rename; the CYOA replaces the problems flow
+    in Slice 6; for now it can render a "coming soon" stub or keep the problems flow behind the
+    new label as an interim).
+  - "Collection" — new tab, new view.
+- **Streak + balance** display in the top-right of the app bar: `● {n}d ♦ {balance}`.
+  - Streak = count of consecutive calendar days on which ≥1 card was drawn (from journal).
+  - Balance = sum of `vibeulons` on all `DeckJournalEntry` records for the player (static `1`
+    per draw to start; real values come from the BAR layer later).
+  - Both are server-fetched (RSC pass or server action on mount).
+- Top bar layout: `B BARS · DECK` brand mark (links → `/deck/sales`) | centered tab nav | right
+  streak+balance. Sticky. Max-width 1180px, same surface as existing reader.
+- Subject toggle stays below the top bar (above view content), same as today.
+
+### Data model — `DeckJournalEntry`
+
+```prisma
+model DeckJournalEntry {
+  id         String   @id @default(cuid())
+  playerId   String
+  cardId     String   // MoveCard.id e.g. "SHOW-DA-SAGE"
+  drawnAt    DateTime @default(now())
+  vibeulons  Int      @default(1)
+  player     Player   @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@index([playerId, drawnAt(sort: Desc)])
+}
+```
+
+Migration name: `add_deck_journal_entry`.
+
+### Draw — journal integration
+
+- After `drawCard()` resolves (420ms flip), call a server action `recordDraw({ cardId })` that
+  creates a `DeckJournalEntry` for the authed player. Fire-and-forget (don't block reveal).
+- Streak and balance re-fetch after each draw (revalidate or optimistic update).
+- Non-authed users can still draw but journal is not persisted (graceful degradation).
+
+### Collection view (`appView='collection'`)
+
+- Header: "Your collection" + "{n} cards drawn" count (right-aligned).
+- Stats strip (3 tiles): **Current Streak** `{n} days` | **Vibeulons** `♦ {balance}` |
+  **Reminder** toggle + label.
+- Journal grid (`repeat(auto-fill, minmax(178px, 1fr))`): each entry renders an `AllyshipCard`
+  (grid variant) with a `when` label above (`TODAY` / `YESTERDAY` / `{n} DAYS AGO` / date
+  string) and a `SHARE` chip in the card footer slot.
+- Sort: most recent first.
+- Empty state: dashed inset panel — "No cards drawn yet." + "Go draw →" CTA.
+- Pagination/infinite scroll: load 20 at a time; "Load more" button (not infinite scroll for
+  now — simpler).
+
+### Reminder toggle
+
+- Client-only (`localStorage` key `deck-reminder-enabled` + `deck-reminder-time`).
+- Pill switch (liminal when on). Default time "8:00 AM".
+- No push notification wiring in this slice (toggle is UI-only; future slice handles scheduling).
+
+### Share chip (stub)
+
+- Renders a `SHARE` button on collection cards.
+- In this slice: copies `masteringallyship.com/c/{cardId}` to clipboard (the URL format from
+  the design). Share modal (full image download etc.) is deferred to a later slice.
+
+### Verification
+
+- `/deck` → Collection tab shows journal entries after drawing.
+- Streak increments correctly on consecutive days (unit-test the streak helper).
+- Vibeulon balance displays.
+- Empty state shown for new accounts.
+- Reminder toggle persists across page reload.
+
+---
+
+## Slice 6 — Find your path (CYOA situation reading)
+
+### Purpose
+
+Replace the "Find a card" problems flow with a 4-phase branching intake that reads the player's
+situation and lays a 3-card spread. The "Find your path" tab routes here.
+
+### Phases
+
+```
+landing → step0 → passage (Q1, Q2) → result
+```
+
+Gold progress bar (`0% / 30% / 66% / 100%`) shown during the flow (not on landing).
+
+#### Landing
+
+- Eyebrow: `FIND YOUR PATH · A SITUATION READING`
+- H2: "What kind of allyship / is being asked of you?"
+- Sub: "You showed up because something's stuck."
+- CTA: "Begin the reading →" → step0
+
+#### step0 — The check-in
+
+Single screen, two inputs:
+
+**Intensity slider** (1–10)
+- Label: `HOW INTENSE IS IT RIGHT NOW?`  ends: `FAINT` ← → `OVERWHELMING`
+- Live italic readout below the track using `RATING_LABELS`:
+
+```ts
+const RATING_LABELS: Record<number, string> = {
+  1: 'Barely there — a whisper of friction.',
+  2: 'Mild — something's slightly off.',
+  3: 'Low — noticeable but manageable.',
+  4: 'Moderate — it's asking for attention.',
+  5: 'Present — noticeable, pulling at me.',
+  6: 'Significant — harder to set aside.',
+  7: 'Heavy — requires real effort to hold.',
+  8: 'Heavy — it's taking real effort to carry.',
+  9: 'Intense — it's running the room.',
+  10: 'Overwhelming — it's all I can feel.',
+}
+```
+
+**Flavor of dissatisfaction** (pick one)
+
+Shown as selectable rows. Each row: wuxing sigil glyph + label + description. Mapped internally:
+
+```ts
+const FLAVORS = [
+  { id: 'sadness',     sigil: '水', label: 'Sadness',      desc: 'Heavy — grief, something feels distant',  face: 'sage',       move: 'clean_up' },
+  { id: 'anger',       sigil: '火', label: 'Anger',        desc: 'Heated — a boundary's been crossed',      face: 'challenger', move: 'show_up'  },
+  { id: 'fear',        sigil: '金', label: 'Fear',          desc: 'Anxious — dread, bracing for it',         face: 'diplomat',   move: 'open_up'  },
+  { id: 'numbness',    sigil: '土', label: 'Numbness',      desc: 'Shut down — going through the motions',  face: 'regent',     move: 'wake_up'  },
+  { id: 'restlessness',sigil: '木', label: 'Restlessness', desc: 'Forced — performing okay-ness',           face: 'architect',  move: 'grow_up'  },
+] as const
+```
+
+"Continue →" is disabled until a flavor is selected.
+
+#### passage — Two branching questions
+
+Render one question at a time. Each has mythic prose + 2–3 lettered choices, each choice tagged
+with a `move` and `domain` bias. Choosing one accumulates biases into `cyChoices`.
+
+```ts
+const PASSAGES: PassageDef[] = [
+  {
+    id: 'scene',
+    prose: 'The friction lives somewhere. Where does it sit?',
+    choices: [
+      { letter: 'A', text: 'In the room — it's between people.',       move: 'show_up',  domain: 'DIRECT_ACTION'        },
+      { letter: 'B', text: 'In me — I'm carrying it alone.',           move: 'clean_up', domain: 'GATHERING_RESOURCES'  },
+      { letter: 'C', text: 'In the structure — the system is broken.', move: 'wake_up',  domain: 'SKILLFUL_ORGANIZING'  },
+    ],
+  },
+  {
+    id: 'arrival',
+    prose: 'What does a good outcome look like, just for today?',
+    choices: [
+      { letter: 'A', text: 'I took one concrete step.',            move: 'show_up',  domain: 'DIRECT_ACTION'   },
+      { letter: 'B', text: 'I understand what's actually going on.', move: 'wake_up',  domain: 'RAISE_AWARENESS' },
+      { letter: 'C', text: 'I'm less tangled inside.',             move: 'clean_up', domain: 'RAISE_AWARENESS' },
+    ],
+  },
+]
+```
+
+#### result — 3-card spread
+
+**Scoring algorithm** (`computeCyoaSpread`):
+
+Each move card receives a weight. Inputs: `flavor` (→ face + move), `cyChoices` (array of
+{move, domain} from passage answers). Three positions are filled in order:
+
+| Position | Label | Move bias |
+|---|---|---|
+| 0 | The Situation | wake_up |
+| 1 | The Block | clean_up |
+| 2 | The Move | show_up, grow_up, open_up |
+
+```ts
+function scoreCard(card: MoveCard, ctx: CyoaContext, positionBias: BasicMove | BasicMove[]): number {
+  let w = 0
+  // Face match from flavor
+  if (card.operation === ctx.flavorFace) w += 3
+  // Move bias from position
+  const biases = Array.isArray(positionBias) ? positionBias : [positionBias]
+  if (biases.includes(card.move)) w += 6  // position preference
+  // Move + domain bias from passage choices
+  for (const choice of ctx.choices) {
+    if (card.move === choice.move) w += 2
+    if (card.domain === choice.domain) w += 1
+  }
+  // Channel (flavor) move match
+  if (card.move === ctx.flavorMove) w += 2
+  return w
+}
+```
+
+Pick the top-scoring card per position, de-duplicating across positions (no card appears twice).
+Tie-break: first in deck order.
+
+**Result screen:**
+
+- "Your situation has been read."
+- Readout sentence: `"The {flavor.label.toLowerCase()} you named points toward a {MOVE_LABELS[spread[2].move]} move."`
+- 3-card spread grid (labeled THE SITUATION / THE BLOCK / THE MOVE), each an `AllyshipCard`
+  `grid` variant, clickable to detail overlay.
+- CTAs: **"Begin your adventure →"** (sends the Move card to BARS via existing `SendToBarsButton`
+  logic) + "Read again" (resets to landing).
+
+### State
+
+```ts
+type CyPhase = 'landing' | 'step0' | 'passage' | 'result'
+
+interface CyoaState {
+  phase: CyPhase
+  rating: number             // 1–10, default 5
+  flavor: typeof FLAVORS[number] | null
+  passageIndex: number       // 0 or 1
+  choices: { move: BasicMove; domain: AllyshipDomain }[]
+  spread: [MoveCard, MoveCard, MoveCard] | null
+}
+```
+
+### Verification
+
+- All 5 flavors × both passage paths produce a valid 3-card spread (no duplicates, all cards
+  from real deck).
+- "Continue →" disabled until flavor selected.
+- Progress bar advances: 0% landing / 30% step0 / 66% passage / 100% result.
+- Unit-test `computeCyoaSpread` for de-duplication and scoring invariants.
+
+---
+
+## Slice 7 — Card anatomy upgrades
+
+### Card number (`num`)
+
+The design shows `#{num}` (e.g. `#001`) in the card footer. Add to the data pipeline:
+
+1. Add `num: string` to `MoveCard` in `src/lib/allyship-deck/types.ts`.
+2. Assign sequentially in `scripts/assemble-allyship-deck.ts` (zero-padded to 3 digits, ordered
+   by move → domain → operation, matching the existing deck-data ordering).
+3. Render in `AllyshipCard` footer (grid and full variants): `#{card.num}` in `.bars-label` mono
+   style, muted text.
+
+### `reward` / `minutes` footer — stub + future hook
+
+The design shows `{minutes} MIN · #{num}  ♦ {reward}` in the card footer.
+
+**Current:** omit the `minutes` and `♦ reward` values. Render only `#{num}`.
+
+**Future hook (document in code, do not implement now):**
+
+```ts
+// When the BAR layer provides these, restore the footer:
+// {card.minutes} MIN · #{card.num}   ♦ {card.reward}
+// Source: DeckJournalEntry.vibeulons (per-draw reward) and
+//         a `minutes` field added to MoveCard when quest data is wired.
+```
+
+### Adapter layer
+
+The handoff `deck-data.json` uses short field names (`q`, `action`, `face`, `el`, `gather`
+etc.). If any component needs to render from handoff data directly (e.g. a future import flow),
+provide adapter functions in `src/lib/allyship-deck/handoff-adapter.ts`:
+
+```ts
+// Converts handoff deck-data.json card shape → MoveCard (best-effort;
+// fields without equivalents are omitted or defaulted).
+export function adaptHandoffCard(raw: HandoffCard): Partial<MoveCard>
+```
+
+The adapter is not needed for Slices 5–8 (all rendering uses the authoritative JSON), but
+documents the mapping for future data migrations.
+
+### Verification
+
+- All 120 cards have a unique `num` (001–120).
+- `#{num}` renders in grid and full card footers.
+- No `reward` or `minutes` values appear on cards.
+
+---
+
+## Slice 8 — Spread draw mode
+
+### Purpose
+
+Add a "Spread · 3 cards" mode toggle to the Draw view. Spread mode does not draw blindly — it
+gates the user into the "Find your path" CYOA (Slice 6), where the 3-card result is the spread.
+
+### Draw mode toggle
+
+Below the streak/reminder strip:
+
+```
+[ DAILY · 1 CARD ]   [ SPREAD · 3 CARDS ]
+```
+
+Active chip: gold fill + `#150a04` text (same as filter chip active style). Inactive: inset
+surface + hairline + secondary text.
+
+### Single mode (existing behavior, no change)
+
+Face-down deck back → "Shuffle & draw" → 420ms flip → reveal. Unchanged.
+
+### Spread mode
+
+- Three dashed placeholder cards (200×288 each) in a row, showing card-back silhouettes.
+- Copy below: "A spread reads your situation. The deck can only lay them once it knows the
+  moment being asked of you."
+- CTA: **"Begin the reading →"** → switches to Find your path tab at `landing` phase. After
+  the CYOA result, the spread renders there (not back in Draw).
+
+### State
+
+Add `drawMode: 'single' | 'spread'` to `AllyshipDeckReader` local state. Default `'single'`.
+
+### Verification
+
+- Toggle switches modes without resetting drawn card in single mode.
+- Spread mode CTA navigates to Find your path landing.
+- CYOA result renders the 3-card spread (Slice 6).
+
+---
+
+## Deferred (updated list)
+
+- Final operation/face sigil art (monogram placeholders).
+- Real in-app checkout/auth (Gumroad). Investigate Gumroad CSS branding.
+- Webfonts (Jost/Nunito/Space Mono).
+- `reward`/`minutes` footer stats (BAR layer dependency).
+- Share modal (full image download + post-to-feed; Share chip in Slice 5 copies link only).
+- Push notification scheduling for reminder toggle.
+- Infinite scroll on Collection (Load More button for now).
+- Theatrical BARS handoff screen (existing `SendToBarsButton` flow is correct).
+- Sales/Purchase/Auth funnel pages.

--- a/docs/GUMROAD_BRANDING_RESEARCH.md
+++ b/docs/GUMROAD_BRANDING_RESEARCH.md
@@ -1,0 +1,81 @@
+# Gumroad Branding Research
+
+> Context: The Allyship Deck sells via Gumroad. We want to know how far we can brand
+> the checkout experience to match the BARS dark-warm aesthetic before the next commerce sprint.
+> Researched: 2026-06-18.
+
+## Summary
+
+**Product page / storefront: fully brandable (Pro plan). Checkout step: not brandable** —
+Gumroad's payment iframe always completes on `gumroad.com`. That's the fundamental tradeoff.
+
+---
+
+## What IS Possible
+
+### Storefront & product page (Gumroad Pro, $10/mo)
+
+- Full custom CSS on product pages and storefronts — colors, fonts, backgrounds, card layouts,
+  buttons, price tags, descriptions, variants, ratings. Dark aesthetic is achievable.
+- Custom domain (`masteringallyship.com` or subdomain) for a branded URL.
+- Upload custom logo/banner; remove "Powered by Gumroad" branding.
+
+### Overlay / embed button
+
+- Embed Gumroad as a **modal overlay** on your own page — users stay on your site until they
+  hit the payment step, then the modal opens Gumroad's checkout.
+- The overlay trigger can be any HTML element you style to match the design system.
+- A "Highlight Color" setting tints overlay buttons/links to a single brand color (use
+  `#C9A84C` gold or `#7c3aed` liminal purple).
+
+---
+
+## What IS NOT Possible
+
+| Limitation | Detail |
+|---|---|
+| Checkout page CSS | The payment iframe is read-only — no CSS injection. Security/PCI restriction. |
+| Custom checkout domain | Checkout always completes on `gumroad.com`. No white-label. |
+| API-driven checkout | The Gumroad API manages products/offers but exposes no checkout endpoints. |
+| Embedded payment form | Cannot build a fully on-site Stripe-style form through Gumroad. |
+
+---
+
+## Recommended Approach
+
+1. **Upgrade to Gumroad Pro** — enables custom domain + full CSS on the product page.
+2. **Brand the product page heavily** — match `--bars-bg-base`, gold accents, Jost font.
+   Use the CSS snippet library (see Gumroad Help → Custom CSS) as a starting point.
+3. **Use the overlay embed** on `/deck/sales` — custom-styled "Get the deck" button that opens
+   the Gumroad overlay modal. Users never leave the page until payment.
+4. **Accept the redirect at checkout** — this is the unavoidable gap. One option: use a branded
+   post-purchase redirect URL back to `/deck` to resume the experience immediately.
+
+### Alternative if full branding is required
+
+**Stripe Checkout** or **Lemon Squeezy** offer fully embedded, on-domain checkout that never
+leaves your app. Either would require migrating away from Gumroad for new purchases (existing
+Gumroad customers keep their access via the current entitlement webhook).
+
+---
+
+## Action Items Before Commerce Sprint
+
+- [ ] Upgrade Gumroad account to Pro ($10/mo)
+- [ ] Set up `masteringallyship.com` as a Gumroad custom domain
+- [ ] Write custom CSS for Gumroad product page to match BARS aesthetic
+- [ ] Switch `/deck/sales` CTAs to use the Gumroad overlay embed (`.gumroad-button` class or
+  JS SDK) rather than a plain `href` link
+- [ ] Configure post-purchase redirect to `/deck` with a `?welcome=1` param to trigger a
+  first-draw prompt
+- [ ] Evaluate Lemon Squeezy as an alternative if full checkout branding becomes a requirement
+
+---
+
+## Sources
+
+- [Gumroad Help — Build Gumroad into Your Website](https://help.gumroad.com/article/44-build-gumroad-into-your-website)
+- [Gumroad Help — Custom Domains](https://help.gumroad.com/article/153-setting-up-a-custom-domain)
+- [Gumroad Help — Common CSS Snippets](https://help.gumroad.com/article/168-common-css-snippets)
+- Influencer Marketing Hub — Gumroad Review 2025
+- Backendo — Integrating Gumroad Checkout Into Your Website

--- a/prisma/migrations/20260618000000_add_deck_journal_entry/migration.sql
+++ b/prisma/migrations/20260618000000_add_deck_journal_entry/migration.sql
@@ -1,0 +1,19 @@
+-- Allyship Deck draw journal (Slice 5 — spec: allyship-deck-experience/spec.md).
+-- One row per card drawn by a player. Streak computed from drawnAt dates client-side.
+-- Vibeulons default 1; real quest-layer rewards added in a future migration.
+CREATE TABLE "deck_journal_entries" (
+    "id"        TEXT NOT NULL,
+    "playerId"  TEXT NOT NULL,
+    "cardId"    TEXT NOT NULL,
+    "drawnAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "vibeulons" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "deck_journal_entries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "deck_journal_entries_playerId_drawnAt_idx"
+    ON "deck_journal_entries"("playerId", "drawnAt" DESC);
+
+ALTER TABLE "deck_journal_entries"
+    ADD CONSTRAINT "deck_journal_entries_playerId_fkey"
+    FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,6 +183,7 @@ model Player {
   questProposals                 QuestProposal[]
   redemptionPacks                RedemptionPack[]
   entitlements                   Entitlement[]
+  deckJournalEntries             DeckJournalEntry[]
   roomPresences                  RoomPresence[]
   sceneAtlasGuidedDrafts         SceneAtlasGuidedDraft[]
   shadow321Sessions              Shadow321Session[]
@@ -4259,6 +4260,21 @@ model ChapterMilestone {
 
   @@index([bookRef])
   @@map("chapter_milestones")
+}
+
+/// Allyship Deck draw journal — one row per card drawn, server-persisted cross-device.
+/// Streak is computed from consecutive calendar days in drawnAt (player's local TZ via client).
+/// Vibeulons start at 1 per draw; real rewards from the BAR layer added later.
+model DeckJournalEntry {
+  id        String   @id @default(cuid())
+  playerId  String
+  cardId    String
+  drawnAt   DateTime @default(now())
+  vibeulons Int      @default(1)
+  player    Player   @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@index([playerId, drawnAt(sort: Desc)])
+  @@map("deck_journal_entries")
 }
 
 /// CHS campaign backbone: fixed 52 or 64 content slots; draw uses only bound slots (see campaign-hub-spoke-landing-architecture spec).

--- a/public/allyship-deck/allyship-deck.json
+++ b/public/allyship-deck/allyship-deck.json
@@ -130,6 +130,7 @@
   "cards": [
     {
       "id": "WAKE-GR-SHAMAN",
+      "num": "001",
       "kind": "move",
       "move": "wake_up",
       "operation": "shaman",
@@ -160,6 +161,7 @@
     },
     {
       "id": "WAKE-GR-CHALLENGER",
+      "num": "002",
       "kind": "move",
       "move": "wake_up",
       "operation": "challenger",
@@ -189,6 +191,7 @@
     },
     {
       "id": "WAKE-GR-REGENT",
+      "num": "003",
       "kind": "move",
       "move": "wake_up",
       "operation": "regent",
@@ -218,6 +221,7 @@
     },
     {
       "id": "WAKE-GR-ARCHITECT",
+      "num": "004",
       "kind": "move",
       "move": "wake_up",
       "operation": "architect",
@@ -247,6 +251,7 @@
     },
     {
       "id": "WAKE-GR-DIPLOMAT",
+      "num": "005",
       "kind": "move",
       "move": "wake_up",
       "operation": "diplomat",
@@ -276,6 +281,7 @@
     },
     {
       "id": "WAKE-GR-SAGE",
+      "num": "006",
       "kind": "move",
       "move": "wake_up",
       "operation": "sage",
@@ -304,6 +310,7 @@
     },
     {
       "id": "WAKE-RA-SHAMAN",
+      "num": "007",
       "kind": "move",
       "move": "wake_up",
       "operation": "shaman",
@@ -334,6 +341,7 @@
     },
     {
       "id": "WAKE-RA-CHALLENGER",
+      "num": "008",
       "kind": "move",
       "move": "wake_up",
       "operation": "challenger",
@@ -363,6 +371,7 @@
     },
     {
       "id": "WAKE-RA-REGENT",
+      "num": "009",
       "kind": "move",
       "move": "wake_up",
       "operation": "regent",
@@ -392,6 +401,7 @@
     },
     {
       "id": "WAKE-RA-ARCHITECT",
+      "num": "010",
       "kind": "move",
       "move": "wake_up",
       "operation": "architect",
@@ -421,6 +431,7 @@
     },
     {
       "id": "WAKE-RA-DIPLOMAT",
+      "num": "011",
       "kind": "move",
       "move": "wake_up",
       "operation": "diplomat",
@@ -450,6 +461,7 @@
     },
     {
       "id": "WAKE-RA-SAGE",
+      "num": "012",
       "kind": "move",
       "move": "wake_up",
       "operation": "sage",
@@ -479,6 +491,7 @@
     },
     {
       "id": "WAKE-DA-SHAMAN",
+      "num": "013",
       "kind": "move",
       "move": "wake_up",
       "operation": "shaman",
@@ -507,6 +520,7 @@
     },
     {
       "id": "WAKE-DA-CHALLENGER",
+      "num": "014",
       "kind": "move",
       "move": "wake_up",
       "operation": "challenger",
@@ -535,6 +549,7 @@
     },
     {
       "id": "WAKE-DA-REGENT",
+      "num": "015",
       "kind": "move",
       "move": "wake_up",
       "operation": "regent",
@@ -564,6 +579,7 @@
     },
     {
       "id": "WAKE-DA-ARCHITECT",
+      "num": "016",
       "kind": "move",
       "move": "wake_up",
       "operation": "architect",
@@ -592,6 +608,7 @@
     },
     {
       "id": "WAKE-DA-DIPLOMAT",
+      "num": "017",
       "kind": "move",
       "move": "wake_up",
       "operation": "diplomat",
@@ -620,6 +637,7 @@
     },
     {
       "id": "WAKE-DA-SAGE",
+      "num": "018",
       "kind": "move",
       "move": "wake_up",
       "operation": "sage",
@@ -648,6 +666,7 @@
     },
     {
       "id": "WAKE-SO-SHAMAN",
+      "num": "019",
       "kind": "move",
       "move": "wake_up",
       "operation": "shaman",
@@ -676,6 +695,7 @@
     },
     {
       "id": "WAKE-SO-CHALLENGER",
+      "num": "020",
       "kind": "move",
       "move": "wake_up",
       "operation": "challenger",
@@ -704,6 +724,7 @@
     },
     {
       "id": "WAKE-SO-REGENT",
+      "num": "021",
       "kind": "move",
       "move": "wake_up",
       "operation": "regent",
@@ -731,6 +752,7 @@
     },
     {
       "id": "WAKE-SO-ARCHITECT",
+      "num": "022",
       "kind": "move",
       "move": "wake_up",
       "operation": "architect",
@@ -760,6 +782,7 @@
     },
     {
       "id": "WAKE-SO-DIPLOMAT",
+      "num": "023",
       "kind": "move",
       "move": "wake_up",
       "operation": "diplomat",
@@ -789,6 +812,7 @@
     },
     {
       "id": "WAKE-SO-SAGE",
+      "num": "024",
       "kind": "move",
       "move": "wake_up",
       "operation": "sage",
@@ -816,6 +840,7 @@
     },
     {
       "id": "OPEN-GR-SHAMAN",
+      "num": "025",
       "kind": "move",
       "move": "open_up",
       "operation": "shaman",
@@ -847,6 +872,7 @@
     },
     {
       "id": "OPEN-GR-CHALLENGER",
+      "num": "026",
       "kind": "move",
       "move": "open_up",
       "operation": "challenger",
@@ -878,6 +904,7 @@
     },
     {
       "id": "OPEN-GR-REGENT",
+      "num": "027",
       "kind": "move",
       "move": "open_up",
       "operation": "regent",
@@ -908,6 +935,7 @@
     },
     {
       "id": "OPEN-GR-ARCHITECT",
+      "num": "028",
       "kind": "move",
       "move": "open_up",
       "operation": "architect",
@@ -938,6 +966,7 @@
     },
     {
       "id": "OPEN-GR-DIPLOMAT",
+      "num": "029",
       "kind": "move",
       "move": "open_up",
       "operation": "diplomat",
@@ -968,6 +997,7 @@
     },
     {
       "id": "OPEN-GR-SAGE",
+      "num": "030",
       "kind": "move",
       "move": "open_up",
       "operation": "sage",
@@ -998,6 +1028,7 @@
     },
     {
       "id": "OPEN-RA-SHAMAN",
+      "num": "031",
       "kind": "move",
       "move": "open_up",
       "operation": "shaman",
@@ -1026,6 +1057,7 @@
     },
     {
       "id": "OPEN-RA-CHALLENGER",
+      "num": "032",
       "kind": "move",
       "move": "open_up",
       "operation": "challenger",
@@ -1055,6 +1087,7 @@
     },
     {
       "id": "OPEN-RA-REGENT",
+      "num": "033",
       "kind": "move",
       "move": "open_up",
       "operation": "regent",
@@ -1084,6 +1117,7 @@
     },
     {
       "id": "OPEN-RA-ARCHITECT",
+      "num": "034",
       "kind": "move",
       "move": "open_up",
       "operation": "architect",
@@ -1112,6 +1146,7 @@
     },
     {
       "id": "OPEN-RA-DIPLOMAT",
+      "num": "035",
       "kind": "move",
       "move": "open_up",
       "operation": "diplomat",
@@ -1140,6 +1175,7 @@
     },
     {
       "id": "OPEN-RA-SAGE",
+      "num": "036",
       "kind": "move",
       "move": "open_up",
       "operation": "sage",
@@ -1169,6 +1205,7 @@
     },
     {
       "id": "OPEN-DA-SHAMAN",
+      "num": "037",
       "kind": "move",
       "move": "open_up",
       "operation": "shaman",
@@ -1197,6 +1234,7 @@
     },
     {
       "id": "OPEN-DA-CHALLENGER",
+      "num": "038",
       "kind": "move",
       "move": "open_up",
       "operation": "challenger",
@@ -1225,6 +1263,7 @@
     },
     {
       "id": "OPEN-DA-REGENT",
+      "num": "039",
       "kind": "move",
       "move": "open_up",
       "operation": "regent",
@@ -1254,6 +1293,7 @@
     },
     {
       "id": "OPEN-DA-ARCHITECT",
+      "num": "040",
       "kind": "move",
       "move": "open_up",
       "operation": "architect",
@@ -1282,6 +1322,7 @@
     },
     {
       "id": "OPEN-DA-DIPLOMAT",
+      "num": "041",
       "kind": "move",
       "move": "open_up",
       "operation": "diplomat",
@@ -1311,6 +1352,7 @@
     },
     {
       "id": "OPEN-DA-SAGE",
+      "num": "042",
       "kind": "move",
       "move": "open_up",
       "operation": "sage",
@@ -1340,6 +1382,7 @@
     },
     {
       "id": "OPEN-SO-SHAMAN",
+      "num": "043",
       "kind": "move",
       "move": "open_up",
       "operation": "shaman",
@@ -1368,6 +1411,7 @@
     },
     {
       "id": "OPEN-SO-CHALLENGER",
+      "num": "044",
       "kind": "move",
       "move": "open_up",
       "operation": "challenger",
@@ -1396,6 +1440,7 @@
     },
     {
       "id": "OPEN-SO-REGENT",
+      "num": "045",
       "kind": "move",
       "move": "open_up",
       "operation": "regent",
@@ -1424,6 +1469,7 @@
     },
     {
       "id": "OPEN-SO-ARCHITECT",
+      "num": "046",
       "kind": "move",
       "move": "open_up",
       "operation": "architect",
@@ -1452,6 +1498,7 @@
     },
     {
       "id": "OPEN-SO-DIPLOMAT",
+      "num": "047",
       "kind": "move",
       "move": "open_up",
       "operation": "diplomat",
@@ -1481,6 +1528,7 @@
     },
     {
       "id": "OPEN-SO-SAGE",
+      "num": "048",
       "kind": "move",
       "move": "open_up",
       "operation": "sage",
@@ -1509,6 +1557,7 @@
     },
     {
       "id": "CLEAN-GR-SHAMAN",
+      "num": "049",
       "kind": "move",
       "move": "clean_up",
       "operation": "shaman",
@@ -1536,6 +1585,7 @@
     },
     {
       "id": "CLEAN-GR-CHALLENGER",
+      "num": "050",
       "kind": "move",
       "move": "clean_up",
       "operation": "challenger",
@@ -1566,6 +1616,7 @@
     },
     {
       "id": "CLEAN-GR-REGENT",
+      "num": "051",
       "kind": "move",
       "move": "clean_up",
       "operation": "regent",
@@ -1594,6 +1645,7 @@
     },
     {
       "id": "CLEAN-GR-ARCHITECT",
+      "num": "052",
       "kind": "move",
       "move": "clean_up",
       "operation": "architect",
@@ -1623,6 +1675,7 @@
     },
     {
       "id": "CLEAN-GR-DIPLOMAT",
+      "num": "053",
       "kind": "move",
       "move": "clean_up",
       "operation": "diplomat",
@@ -1651,6 +1704,7 @@
     },
     {
       "id": "CLEAN-GR-SAGE",
+      "num": "054",
       "kind": "move",
       "move": "clean_up",
       "operation": "sage",
@@ -1680,6 +1734,7 @@
     },
     {
       "id": "CLEAN-RA-SHAMAN",
+      "num": "055",
       "kind": "move",
       "move": "clean_up",
       "operation": "shaman",
@@ -1707,6 +1762,7 @@
     },
     {
       "id": "CLEAN-RA-CHALLENGER",
+      "num": "056",
       "kind": "move",
       "move": "clean_up",
       "operation": "challenger",
@@ -1736,6 +1792,7 @@
     },
     {
       "id": "CLEAN-RA-REGENT",
+      "num": "057",
       "kind": "move",
       "move": "clean_up",
       "operation": "regent",
@@ -1764,6 +1821,7 @@
     },
     {
       "id": "CLEAN-RA-ARCHITECT",
+      "num": "058",
       "kind": "move",
       "move": "clean_up",
       "operation": "architect",
@@ -1793,6 +1851,7 @@
     },
     {
       "id": "CLEAN-RA-DIPLOMAT",
+      "num": "059",
       "kind": "move",
       "move": "clean_up",
       "operation": "diplomat",
@@ -1821,6 +1880,7 @@
     },
     {
       "id": "CLEAN-RA-SAGE",
+      "num": "060",
       "kind": "move",
       "move": "clean_up",
       "operation": "sage",
@@ -1850,6 +1910,7 @@
     },
     {
       "id": "CLEAN-DA-SHAMAN",
+      "num": "061",
       "kind": "move",
       "move": "clean_up",
       "operation": "shaman",
@@ -1878,6 +1939,7 @@
     },
     {
       "id": "CLEAN-DA-CHALLENGER",
+      "num": "062",
       "kind": "move",
       "move": "clean_up",
       "operation": "challenger",
@@ -1907,6 +1969,7 @@
     },
     {
       "id": "CLEAN-DA-REGENT",
+      "num": "063",
       "kind": "move",
       "move": "clean_up",
       "operation": "regent",
@@ -1935,6 +1998,7 @@
     },
     {
       "id": "CLEAN-DA-ARCHITECT",
+      "num": "064",
       "kind": "move",
       "move": "clean_up",
       "operation": "architect",
@@ -1964,6 +2028,7 @@
     },
     {
       "id": "CLEAN-DA-DIPLOMAT",
+      "num": "065",
       "kind": "move",
       "move": "clean_up",
       "operation": "diplomat",
@@ -1993,6 +2058,7 @@
     },
     {
       "id": "CLEAN-DA-SAGE",
+      "num": "066",
       "kind": "move",
       "move": "clean_up",
       "operation": "sage",
@@ -2021,6 +2087,7 @@
     },
     {
       "id": "CLEAN-SO-SHAMAN",
+      "num": "067",
       "kind": "move",
       "move": "clean_up",
       "operation": "shaman",
@@ -2048,6 +2115,7 @@
     },
     {
       "id": "CLEAN-SO-CHALLENGER",
+      "num": "068",
       "kind": "move",
       "move": "clean_up",
       "operation": "challenger",
@@ -2077,6 +2145,7 @@
     },
     {
       "id": "CLEAN-SO-REGENT",
+      "num": "069",
       "kind": "move",
       "move": "clean_up",
       "operation": "regent",
@@ -2104,6 +2173,7 @@
     },
     {
       "id": "CLEAN-SO-ARCHITECT",
+      "num": "070",
       "kind": "move",
       "move": "clean_up",
       "operation": "architect",
@@ -2133,6 +2203,7 @@
     },
     {
       "id": "CLEAN-SO-DIPLOMAT",
+      "num": "071",
       "kind": "move",
       "move": "clean_up",
       "operation": "diplomat",
@@ -2162,6 +2233,7 @@
     },
     {
       "id": "CLEAN-SO-SAGE",
+      "num": "072",
       "kind": "move",
       "move": "clean_up",
       "operation": "sage",
@@ -2190,6 +2262,7 @@
     },
     {
       "id": "GROW-GR-SHAMAN",
+      "num": "073",
       "kind": "move",
       "move": "grow_up",
       "operation": "shaman",
@@ -2218,6 +2291,7 @@
     },
     {
       "id": "GROW-GR-CHALLENGER",
+      "num": "074",
       "kind": "move",
       "move": "grow_up",
       "operation": "challenger",
@@ -2245,6 +2319,7 @@
     },
     {
       "id": "GROW-GR-REGENT",
+      "num": "075",
       "kind": "move",
       "move": "grow_up",
       "operation": "regent",
@@ -2274,6 +2349,7 @@
     },
     {
       "id": "GROW-GR-ARCHITECT",
+      "num": "076",
       "kind": "move",
       "move": "grow_up",
       "operation": "architect",
@@ -2303,6 +2379,7 @@
     },
     {
       "id": "GROW-GR-DIPLOMAT",
+      "num": "077",
       "kind": "move",
       "move": "grow_up",
       "operation": "diplomat",
@@ -2332,6 +2409,7 @@
     },
     {
       "id": "GROW-GR-SAGE",
+      "num": "078",
       "kind": "move",
       "move": "grow_up",
       "operation": "sage",
@@ -2361,6 +2439,7 @@
     },
     {
       "id": "GROW-RA-SHAMAN",
+      "num": "079",
       "kind": "move",
       "move": "grow_up",
       "operation": "shaman",
@@ -2389,6 +2468,7 @@
     },
     {
       "id": "GROW-RA-CHALLENGER",
+      "num": "080",
       "kind": "move",
       "move": "grow_up",
       "operation": "challenger",
@@ -2415,6 +2495,7 @@
     },
     {
       "id": "GROW-RA-REGENT",
+      "num": "081",
       "kind": "move",
       "move": "grow_up",
       "operation": "regent",
@@ -2443,6 +2524,7 @@
     },
     {
       "id": "GROW-RA-ARCHITECT",
+      "num": "082",
       "kind": "move",
       "move": "grow_up",
       "operation": "architect",
@@ -2471,6 +2553,7 @@
     },
     {
       "id": "GROW-RA-DIPLOMAT",
+      "num": "083",
       "kind": "move",
       "move": "grow_up",
       "operation": "diplomat",
@@ -2499,6 +2582,7 @@
     },
     {
       "id": "GROW-RA-SAGE",
+      "num": "084",
       "kind": "move",
       "move": "grow_up",
       "operation": "sage",
@@ -2526,6 +2610,7 @@
     },
     {
       "id": "GROW-DA-SHAMAN",
+      "num": "085",
       "kind": "move",
       "move": "grow_up",
       "operation": "shaman",
@@ -2554,6 +2639,7 @@
     },
     {
       "id": "GROW-DA-CHALLENGER",
+      "num": "086",
       "kind": "move",
       "move": "grow_up",
       "operation": "challenger",
@@ -2580,6 +2666,7 @@
     },
     {
       "id": "GROW-DA-REGENT",
+      "num": "087",
       "kind": "move",
       "move": "grow_up",
       "operation": "regent",
@@ -2608,6 +2695,7 @@
     },
     {
       "id": "GROW-DA-ARCHITECT",
+      "num": "088",
       "kind": "move",
       "move": "grow_up",
       "operation": "architect",
@@ -2636,6 +2724,7 @@
     },
     {
       "id": "GROW-DA-DIPLOMAT",
+      "num": "089",
       "kind": "move",
       "move": "grow_up",
       "operation": "diplomat",
@@ -2663,6 +2752,7 @@
     },
     {
       "id": "GROW-DA-SAGE",
+      "num": "090",
       "kind": "move",
       "move": "grow_up",
       "operation": "sage",
@@ -2692,6 +2782,7 @@
     },
     {
       "id": "GROW-SO-SHAMAN",
+      "num": "091",
       "kind": "move",
       "move": "grow_up",
       "operation": "shaman",
@@ -2720,6 +2811,7 @@
     },
     {
       "id": "GROW-SO-CHALLENGER",
+      "num": "092",
       "kind": "move",
       "move": "grow_up",
       "operation": "challenger",
@@ -2748,6 +2840,7 @@
     },
     {
       "id": "GROW-SO-REGENT",
+      "num": "093",
       "kind": "move",
       "move": "grow_up",
       "operation": "regent",
@@ -2776,6 +2869,7 @@
     },
     {
       "id": "GROW-SO-ARCHITECT",
+      "num": "094",
       "kind": "move",
       "move": "grow_up",
       "operation": "architect",
@@ -2804,6 +2898,7 @@
     },
     {
       "id": "GROW-SO-DIPLOMAT",
+      "num": "095",
       "kind": "move",
       "move": "grow_up",
       "operation": "diplomat",
@@ -2832,6 +2927,7 @@
     },
     {
       "id": "GROW-SO-SAGE",
+      "num": "096",
       "kind": "move",
       "move": "grow_up",
       "operation": "sage",
@@ -2860,6 +2956,7 @@
     },
     {
       "id": "SHOW-GR-SHAMAN",
+      "num": "097",
       "kind": "move",
       "move": "show_up",
       "operation": "shaman",
@@ -2888,6 +2985,7 @@
     },
     {
       "id": "SHOW-GR-CHALLENGER",
+      "num": "098",
       "kind": "move",
       "move": "show_up",
       "operation": "challenger",
@@ -2917,6 +3015,7 @@
     },
     {
       "id": "SHOW-GR-REGENT",
+      "num": "099",
       "kind": "move",
       "move": "show_up",
       "operation": "regent",
@@ -2946,6 +3045,7 @@
     },
     {
       "id": "SHOW-GR-ARCHITECT",
+      "num": "100",
       "kind": "move",
       "move": "show_up",
       "operation": "architect",
@@ -2975,6 +3075,7 @@
     },
     {
       "id": "SHOW-GR-DIPLOMAT",
+      "num": "101",
       "kind": "move",
       "move": "show_up",
       "operation": "diplomat",
@@ -3004,6 +3105,7 @@
     },
     {
       "id": "SHOW-GR-SAGE",
+      "num": "102",
       "kind": "move",
       "move": "show_up",
       "operation": "sage",
@@ -3033,6 +3135,7 @@
     },
     {
       "id": "SHOW-RA-SHAMAN",
+      "num": "103",
       "kind": "move",
       "move": "show_up",
       "operation": "shaman",
@@ -3060,6 +3163,7 @@
     },
     {
       "id": "SHOW-RA-CHALLENGER",
+      "num": "104",
       "kind": "move",
       "move": "show_up",
       "operation": "challenger",
@@ -3088,6 +3192,7 @@
     },
     {
       "id": "SHOW-RA-REGENT",
+      "num": "105",
       "kind": "move",
       "move": "show_up",
       "operation": "regent",
@@ -3116,6 +3221,7 @@
     },
     {
       "id": "SHOW-RA-ARCHITECT",
+      "num": "106",
       "kind": "move",
       "move": "show_up",
       "operation": "architect",
@@ -3143,6 +3249,7 @@
     },
     {
       "id": "SHOW-RA-DIPLOMAT",
+      "num": "107",
       "kind": "move",
       "move": "show_up",
       "operation": "diplomat",
@@ -3172,6 +3279,7 @@
     },
     {
       "id": "SHOW-RA-SAGE",
+      "num": "108",
       "kind": "move",
       "move": "show_up",
       "operation": "sage",
@@ -3200,6 +3308,7 @@
     },
     {
       "id": "SHOW-DA-SHAMAN",
+      "num": "109",
       "kind": "move",
       "move": "show_up",
       "operation": "shaman",
@@ -3228,6 +3337,7 @@
     },
     {
       "id": "SHOW-DA-CHALLENGER",
+      "num": "110",
       "kind": "move",
       "move": "show_up",
       "operation": "challenger",
@@ -3256,6 +3366,7 @@
     },
     {
       "id": "SHOW-DA-REGENT",
+      "num": "111",
       "kind": "move",
       "move": "show_up",
       "operation": "regent",
@@ -3285,6 +3396,7 @@
     },
     {
       "id": "SHOW-DA-ARCHITECT",
+      "num": "112",
       "kind": "move",
       "move": "show_up",
       "operation": "architect",
@@ -3313,6 +3425,7 @@
     },
     {
       "id": "SHOW-DA-DIPLOMAT",
+      "num": "113",
       "kind": "move",
       "move": "show_up",
       "operation": "diplomat",
@@ -3342,6 +3455,7 @@
     },
     {
       "id": "SHOW-DA-SAGE",
+      "num": "114",
       "kind": "move",
       "move": "show_up",
       "operation": "sage",
@@ -3371,6 +3485,7 @@
     },
     {
       "id": "SHOW-SO-SHAMAN",
+      "num": "115",
       "kind": "move",
       "move": "show_up",
       "operation": "shaman",
@@ -3399,6 +3514,7 @@
     },
     {
       "id": "SHOW-SO-CHALLENGER",
+      "num": "116",
       "kind": "move",
       "move": "show_up",
       "operation": "challenger",
@@ -3427,6 +3543,7 @@
     },
     {
       "id": "SHOW-SO-REGENT",
+      "num": "117",
       "kind": "move",
       "move": "show_up",
       "operation": "regent",
@@ -3456,6 +3573,7 @@
     },
     {
       "id": "SHOW-SO-ARCHITECT",
+      "num": "118",
       "kind": "move",
       "move": "show_up",
       "operation": "architect",
@@ -3485,6 +3603,7 @@
     },
     {
       "id": "SHOW-SO-DIPLOMAT",
+      "num": "119",
       "kind": "move",
       "move": "show_up",
       "operation": "diplomat",
@@ -3514,6 +3633,7 @@
     },
     {
       "id": "SHOW-SO-SAGE",
+      "num": "120",
       "kind": "move",
       "move": "show_up",
       "operation": "sage",

--- a/src/actions/deck-journal.ts
+++ b/src/actions/deck-journal.ts
@@ -1,0 +1,103 @@
+'use server'
+
+import { db } from '@/lib/db'
+import { getCurrentPlayer } from '@/lib/auth'
+import { revalidatePath } from 'next/cache'
+
+export type RecordDrawResult = { success: true; entryId: string } | { error: string }
+
+/**
+ * Record a card draw in the player's journal.
+ * Fire-and-forget safe — the client does not block reveal on this.
+ * Non-authed draws are silently ignored.
+ */
+export async function recordDraw(input: { cardId: string }): Promise<RecordDrawResult> {
+  const player = await getCurrentPlayer()
+  if (!player) return { error: 'Not logged in' }
+
+  try {
+    const entry = await db.deckJournalEntry.create({
+      data: {
+        playerId: player.id,
+        cardId: input.cardId,
+        vibeulons: 1,
+      },
+    })
+    revalidatePath('/deck')
+    return { success: true, entryId: entry.id }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Failed to record draw' }
+  }
+}
+
+export interface JournalEntry {
+  id: string
+  cardId: string
+  drawnAt: Date
+  vibeulons: number
+}
+
+export interface DeckStats {
+  totalDrawn: number
+  streak: number
+  vibeulons: number
+  entries: JournalEntry[]
+}
+
+/**
+ * Compute streak as consecutive calendar days (UTC) on which ≥1 card was drawn,
+ * counting back from today. A draw today keeps the streak; yesterday's draw starts it.
+ */
+function computeStreak(entries: JournalEntry[]): number {
+  if (entries.length === 0) return 0
+
+  const days = new Set(
+    entries.map((e) => {
+      const d = new Date(e.drawnAt)
+      return `${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`
+    }),
+  )
+
+  const today = new Date()
+  let streak = 0
+  let cursor = new Date(today)
+
+  for (let i = 0; i < 365; i++) {
+    const key = `${cursor.getUTCFullYear()}-${cursor.getUTCMonth()}-${cursor.getUTCDate()}`
+    if (days.has(key)) {
+      streak++
+      cursor.setUTCDate(cursor.getUTCDate() - 1)
+    } else {
+      break
+    }
+  }
+
+  return streak
+}
+
+/** Fetch the player's full draw journal + computed stats (first 100 entries). */
+export async function getDeckStats(): Promise<DeckStats | null> {
+  const player = await getCurrentPlayer()
+  if (!player) return null
+
+  const rows = await db.deckJournalEntry.findMany({
+    where: { playerId: player.id },
+    orderBy: { drawnAt: 'desc' },
+    take: 100,
+    select: { id: true, cardId: true, drawnAt: true, vibeulons: true },
+  })
+
+  const entries: JournalEntry[] = rows.map((r: { id: string; cardId: string; drawnAt: Date; vibeulons: number }) => ({
+    id: r.id,
+    cardId: r.cardId,
+    drawnAt: r.drawnAt,
+    vibeulons: r.vibeulons,
+  }))
+
+  return {
+    totalDrawn: entries.length,
+    streak: computeStreak(entries),
+    vibeulons: entries.reduce((sum, e) => sum + e.vibeulons, 0),
+    entries,
+  }
+}

--- a/src/app/deck/page.tsx
+++ b/src/app/deck/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { AllyshipDeckReader } from '@/components/deck/AllyshipDeckReader'
 import { Paywall } from '@/components/launch/Paywall'
 import { checkAccess } from '@/lib/entitlements/gate'
+import { getDeckStats } from '@/actions/deck-journal'
 
 export const metadata: Metadata = {
   title: 'The Allyship Deck — Mastering Allyship Moves',
@@ -30,5 +31,6 @@ export default async function DeckPage() {
     )
   }
 
-  return <AllyshipDeckReader />
+  const initialStats = await getDeckStats()
+  return <AllyshipDeckReader initialStats={initialStats} />
 }

--- a/src/components/deck/AllyshipCard.tsx
+++ b/src/components/deck/AllyshipCard.tsx
@@ -101,6 +101,10 @@ export function AllyshipCard({
         >
           {question.length > 92 ? `${question.slice(0, 92)}…` : question}
         </div>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 6 }}>
+          <span style={{ ...labelStyle, fontSize: 9 }}>#{card.num}</span>
+          {footerSlot}
+        </div>
       </button>
     )
   }
@@ -174,12 +178,14 @@ export function AllyshipCard({
       {/* foot */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 16 }}>
         <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 10, color: SURFACE_TOKENS.textMuted, letterSpacing: '0.08em' }}>
-          {card.id}
+          #{card.num}
         </span>
         <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 12, color: DECK_GOLD }}>
           → {card.outputBar} ♦
         </span>
       </div>
+      {/* reward/minutes: omitted until BAR layer provides real values */}
+      {/* restore when wired: {card.minutes} MIN · #{card.num}   ♦ {card.reward} */}
 
       {footerSlot}
     </article>

--- a/src/components/deck/AllyshipDeckReader.tsx
+++ b/src/components/deck/AllyshipDeckReader.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useMemo, useState, type CSSProperties } from 'react'
+import { useEffect, useMemo, useState, useCallback, type CSSProperties } from 'react'
+import Link from 'next/link'
 import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
 import {
   DECK_FONTS,
@@ -19,40 +20,44 @@ import type {
 } from '@/lib/allyship-deck/types'
 import { AllyshipCard, type CardSubject } from './AllyshipCard'
 import { SendToBarsButton } from './SendToBarsButton'
+import { FindYourPath } from './FindYourPath'
+import { recordDraw, type DeckStats } from '@/actions/deck-journal'
 
-type View = 'draw' | 'browse' | 'find'
+type AppView = 'draw' | 'browse' | 'path' | 'collection'
+type DrawMode = 'single' | 'spread'
 
 const isMove = (c: AllyshipDeck['cards'][number]): c is MoveCard => c.kind === 'move'
 
 /**
- * The Allyship Deck app (gated `/deck`). Three surfaces on the high-fidelity card:
- *   • Draw — face-down card → shuffle (420ms flip) → reveal.
- *   • Browse — filter chips (move / domain / face) over all 120 cards.
- *   • Find a card — the authored `problems[]`: pick a struggle → its cards, in order.
- * Card detail opens in an overlay. "Send to BARS" lands in slice 3.
+ * The Allyship Deck app (gated `/deck`).
+ *   • Draw   — daily single card or 3-card spread gateway.
+ *   • Deck   — browse all 120 cards with move/domain/face filters.
+ *   • Find your path — CYOA situation reading → 3-card spread result.
+ *   • Collection — server-persisted journal, streak, Vibeulons.
  *
  * @see .specify/specs/allyship-deck-experience/spec.md
  */
-export function AllyshipDeckReader() {
+export function AllyshipDeckReader({ initialStats }: { initialStats: DeckStats | null }) {
   const [deck, setDeck] = useState<AllyshipDeck | null>(null)
   const [error, setError] = useState(false)
-  const [view, setView] = useState<View>('draw')
+  const [view, setView] = useState<AppView>('draw')
   const [subject, setSubject] = useState<CardSubject>('self')
 
   // Draw
   const [shuffling, setShuffling] = useState(false)
   const [drawn, setDrawn] = useState<MoveCard | null>(null)
+  const [drawMode, setDrawMode] = useState<DrawMode>('single')
 
   // Browse filters
   const [fMove, setFMove] = useState<BasicMove | 'all'>('all')
   const [fOp, setFOp] = useState<Operation | 'all'>('all')
   const [fDomain, setFDomain] = useState<AllyshipDomain | 'all'>('all')
 
-  // Find a card
-  const [problemId, setProblemId] = useState<string | null>(null)
-
-  // Detail overlay (browse / find)
+  // Card detail overlay
   const [selected, setSelected] = useState<MoveCard | null>(null)
+
+  // Stats (optimistic update on draw)
+  const [stats, setStats] = useState<DeckStats | null>(initialStats)
 
   useEffect(() => {
     fetch('/allyship-deck/allyship-deck.json')
@@ -65,6 +70,7 @@ export function AllyshipDeckReader() {
   }, [])
 
   const moveCards = useMemo(() => (deck ? deck.cards.filter(isMove) : []), [deck])
+
   const browsed = useMemo(
     () =>
       moveCards.filter(
@@ -76,17 +82,27 @@ export function AllyshipDeckReader() {
     [moveCards, fMove, fOp, fDomain],
   )
 
-  const draw = () => {
+  const draw = useCallback(() => {
     if (!moveCards.length || shuffling) return
     setShuffling(true)
     setDrawn(null)
-    window.setTimeout(() => {
-      setDrawn(moveCards[Math.floor(Math.random() * moveCards.length)])
+    window.setTimeout(async () => {
+      const card = moveCards[Math.floor(Math.random() * moveCards.length)]
+      setDrawn(card)
       setShuffling(false)
+      // optimistic stats update
+      setStats((prev) => prev ? {
+        ...prev,
+        totalDrawn: prev.totalDrawn + 1,
+        vibeulons: prev.vibeulons + 1,
+        entries: [{ id: 'pending', cardId: card.id, drawnAt: new Date(), vibeulons: 1 }, ...prev.entries],
+      } : null)
+      // fire-and-forget server record
+      await recordDraw({ cardId: card.id })
     }, 420)
-  }
+  }, [moveCards, shuffling])
 
-  const switchView = (v: View) => {
+  const switchView = (v: AppView) => {
     setView(v)
     setSelected(null)
     window.scrollTo(0, 0)
@@ -95,135 +111,201 @@ export function AllyshipDeckReader() {
   if (error) return <Centered>The deck could not be loaded.</Centered>
   if (!deck) return <Centered>Shuffling…</Centered>
 
-  const problem = deck.problems.find((p) => p.id === problemId) || null
-  const problemCards = problem ? moveCards.filter((c) => problem.cardIds.includes(c.id)) : []
-
   return (
     <main style={{ minHeight: '100vh', background: SURFACE_TOKENS.bgBase }}>
-      <div style={{ maxWidth: 760, margin: '0 auto', padding: '24px 16px 80px' }}>
-        {/* Header */}
-        <header style={{ textAlign: 'center', marginBottom: 12 }}>
-          <p style={{ ...kicker, color: DECK_GOLD }}>Mastering Allyship Moves</p>
-          <h1 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 28, color: '#fff', margin: '4px 0 0' }}>
-            The Allyship Deck
-          </h1>
-        </header>
+      {/* ── App top bar ── */}
+      <header style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 20,
+        background: SURFACE_TOKENS.bgBase,
+        borderBottom: '1px solid rgba(255,255,255,.1)',
+        boxShadow: 'inset 0 -1px 0 rgba(255,255,255,.04)',
+      }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 16px', height: 52, display: 'flex', alignItems: 'center', gap: 16 }}>
+          {/* Brand mark */}
+          <Link href="/deck/sales" style={{ display: 'flex', alignItems: 'center', gap: 8, textDecoration: 'none', flex: 'none' }}>
+            <span style={{ width: 28, height: 28, borderRadius: 6, background: DECK_GOLD, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 15, color: '#150a04' }}>B</span>
+            <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: SURFACE_TOKENS.textSecondary }}>BARS · DECK</span>
+          </Link>
 
-        {/* Subject toggle */}
-        <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginBottom: 14 }}>
-          <Chip active={subject === 'self'} onClick={() => setSubject('self')}>
-            Allyship for self
-          </Chip>
-          <Chip active={subject === 'campaign'} onClick={() => setSubject('campaign')}>
-            Allyship for others
-          </Chip>
+          {/* Tab nav */}
+          <nav style={{ flex: 1, display: 'flex', justifyContent: 'center', gap: 2 }}>
+            {([
+              { id: 'draw',       label: 'Draw'           },
+              { id: 'browse',     label: 'Deck'           },
+              { id: 'path',       label: 'Find your path' },
+              { id: 'collection', label: 'Collection'     },
+            ] as { id: AppView; label: string }[]).map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => switchView(id)}
+                style={{
+                  fontFamily: DECK_FONTS.mono,
+                  fontSize: 11,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  padding: '7px 13px',
+                  borderRadius: 8,
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: view === id ? '#150a04' : SURFACE_TOKENS.textSecondary,
+                  background: view === id ? DECK_GOLD : 'transparent',
+                  fontWeight: view === id ? 700 : 400,
+                  transition: 'background .15s, color .15s',
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Streak + balance */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 'none' }}>
+            {stats && (
+              <>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontFamily: DECK_FONTS.mono, fontSize: 11, color: SURFACE_TOKENS.textSecondary }}>
+                  <span style={{ width: 7, height: 7, borderRadius: '50%', background: DECK_GOLD }} />
+                  {stats.streak}d
+                </span>
+                <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 11, color: DECK_GOLD }}>
+                  ♦ {stats.vibeulons}
+                </span>
+              </>
+            )}
+          </div>
         </div>
+      </header>
 
-        {/* Nav */}
-        <nav style={{ display: 'flex', justifyContent: 'center', gap: 6, marginBottom: 22 }}>
-          {(['draw', 'browse', 'find'] as View[]).map((v) => (
-            <NavTab key={v} active={view === v} onClick={() => switchView(v)}>
-              {v === 'draw' ? 'Draw' : v === 'browse' ? 'Browse' : 'Find a card'}
-            </NavTab>
-          ))}
-        </nav>
+      {/* ── Subject toggle ── */}
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 8, padding: '12px 16px 0' }}>
+        <Chip active={subject === 'self'} onClick={() => setSubject('self')}>Allyship for self</Chip>
+        <Chip active={subject === 'campaign'} onClick={() => setSubject('campaign')}>Allyship for others</Chip>
+      </div>
 
-        {/* Draw */}
+      {/* ── View body ── */}
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '20px 16px 80px' }}>
+
+        {/* ── Draw ── */}
         {view === 'draw' && (
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, paddingTop: 8 }}>
-            {drawn ? (
-              <>
-                <div key={drawn.id} className="deck-card-flip-in" style={{ width: 'min(360px, 92vw)' }}>
-                  <AllyshipCard
-                    card={drawn}
-                    variant="full"
-                    subject={subject}
-                    footerSlot={<SendToBarsButton cardId={drawn.id} subject={subject} />}
-                  />
+          <div style={{ maxWidth: 760, margin: '0 auto' }}>
+            {/* Streak strip + reminder */}
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 20, marginBottom: 16 }}>
+              {stats && (
+                <span style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: DECK_FONTS.mono, fontSize: 11, color: SURFACE_TOKENS.textSecondary, letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+                  <span style={{ width: 7, height: 7, borderRadius: '50%', background: DECK_GOLD }} />
+                  {stats.streak} –day streak
+                </span>
+              )}
+              <ReminderToggle />
+            </div>
+
+            {/* Draw mode toggle */}
+            <div style={{ display: 'flex', justifyContent: 'center', gap: 6, marginBottom: 24 }}>
+              <ModeChip active={drawMode === 'single'} onClick={() => setDrawMode('single')}>Daily · 1 card</ModeChip>
+              <ModeChip active={drawMode === 'spread'} onClick={() => setDrawMode('spread')}>Spread · 3 cards</ModeChip>
+            </div>
+
+            {drawMode === 'spread' ? (
+              /* Spread mode — gateway into CYOA */
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: 10, marginBottom: 20 }}>
+                  {[0, 1, 2].map((i) => (
+                    <div key={i} style={{
+                      width: 120,
+                      height: 168,
+                      borderRadius: 10,
+                      border: '2px dashed rgba(255,255,255,.1)',
+                      background: SURFACE_TOKENS.surfaceCard,
+                    }} />
+                  ))}
                 </div>
-                <button type="button" style={secondaryBtn} onClick={draw}>
-                  Draw again
-                </button>
-              </>
-            ) : (
-              <>
-                <FaceDown pulsing={shuffling} />
-                <button type="button" style={{ ...primaryBtn, opacity: shuffling ? 0.6 : 1 }} onClick={draw} disabled={shuffling}>
-                  {shuffling ? 'Shuffling…' : 'Shuffle & draw'}
-                </button>
-                <p style={{ fontFamily: DECK_FONTS.body, fontSize: 13, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', maxWidth: 360 }}>
-                  Pull one move at random. Read its question. Do its practice.
+                <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: SURFACE_TOKENS.textSecondary, maxWidth: 380, margin: '0 auto 20px', lineHeight: 1.5 }}>
+                  A spread reads your situation. The deck can only lay them once it knows the moment being asked of you.
                 </p>
-              </>
+                <button type="button" style={primaryBtn} onClick={() => switchView('path')}>
+                  Begin the reading →
+                </button>
+              </div>
+            ) : (
+              /* Single mode */
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18 }}>
+                {drawn ? (
+                  <>
+                    <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 22, color: '#fff', textAlign: 'center', margin: 0 }}>
+                      Pull today&rsquo;s card
+                    </h2>
+                    <div key={drawn.id} className="deck-card-flip-in" style={{ width: 'min(380px, 92vw)' }}>
+                      <AllyshipCard
+                        card={drawn}
+                        variant="full"
+                        subject={subject}
+                        footerSlot={<SendToBarsButton cardId={drawn.id} subject={subject} />}
+                      />
+                    </div>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button type="button" style={secondaryBtn} onClick={draw}>Draw again</button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 22, color: '#fff', textAlign: 'center', margin: 0 }}>
+                      Pull today&rsquo;s card
+                    </h2>
+                    <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', margin: 0 }}>
+                      One card, one concrete move. Shuffle when you&rsquo;re ready.
+                    </p>
+                    <FaceDown pulsing={shuffling} />
+                    <button type="button" style={{ ...primaryBtn, opacity: shuffling ? 0.6 : 1 }} onClick={draw} disabled={shuffling}>
+                      {shuffling ? 'Shuffling…' : 'Shuffle & draw'}
+                    </button>
+                  </>
+                )}
+              </div>
             )}
           </div>
         )}
 
-        {/* Browse */}
+        {/* ── Browse / Deck ── */}
         {view === 'browse' && (
-          <>
-            <ChipGroup label="Move" value={fMove} setValue={setFMove} options={Object.entries(MOVE_LABELS) as [BasicMove, string][]} />
-            <ChipGroup label="Domain" value={fDomain} setValue={setFDomain} options={Object.entries(DOMAIN_LABELS) as [AllyshipDomain, string][]} />
-            <ChipGroup label="Face" value={fOp} setValue={setFOp} options={Object.entries(OPERATION_LABELS) as [Operation, string][]} />
-            <p style={{ ...kicker, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', margin: '14px 0' }}>
-              {browsed.length} of {moveCards.length} cards
-            </p>
+          <div style={{ maxWidth: 1060, margin: '0 auto' }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 16 }}>
+              <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 24, color: '#fff', margin: 0 }}>The deck</h2>
+              <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted }}>{browsed.length} of {moveCards.length} cards</span>
+            </div>
+            <ChipGroup label="Move"   value={fMove}   setValue={setFMove}   options={Object.entries(MOVE_LABELS)      as [BasicMove, string][]} />
+            <ChipGroup label="Domain" value={fDomain} setValue={setFDomain} options={Object.entries(DOMAIN_LABELS)    as [AllyshipDomain, string][]} />
+            <ChipGroup label="Face"   value={fOp}     setValue={setFOp}     options={Object.entries(OPERATION_LABELS) as [Operation, string][]} />
             <CardGrid cards={browsed} subject={subject} onPick={setSelected} />
-          </>
+          </div>
         )}
 
-        {/* Find a card */}
-        {view === 'find' && (
-          <>
-            <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', marginBottom: 14 }}>
-              Start from what you&rsquo;re actually stuck on.
-            </p>
-            {!problem ? (
-              <div style={{ display: 'grid', gap: 8 }}>
-                {deck.problems.map((p) => (
-                  <button key={p.id} type="button" onClick={() => setProblemId(p.id)} style={problemRow}>
-                    <span style={{ width: 9, height: 9, borderRadius: '50%', background: LIMINAL.glow, flex: 'none' }} />
-                    <span style={{ flex: 1 }}>{p.label}</span>
-                    <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted, whiteSpace: 'nowrap' }}>{p.cardIds.length} cards →</span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <>
-                <div style={{ textAlign: 'center', marginBottom: 14 }}>
-                  <h3 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 19, color: '#fff', margin: 0 }}>
-                    &ldquo;{problem.label}&rdquo;
-                  </h3>
-                  <p style={{ fontFamily: DECK_FONTS.body, fontSize: 13, color: SURFACE_TOKENS.textSecondary, margin: '6px 0 0' }}>
-                    Move through these in order.
-                  </p>
-                  <button type="button" onClick={() => setProblemId(null)} style={{ ...secondaryBtn, marginTop: 12, padding: '8px 16px', fontSize: 13 }}>
-                    ← Pick another
-                  </button>
-                </div>
-                <CardGrid cards={problemCards} subject={subject} onPick={setSelected} />
-              </>
-            )}
-          </>
+        {/* ── Find your path ── */}
+        {view === 'path' && (
+          <FindYourPath cards={moveCards} subject={subject} onSelectCard={setSelected} />
+        )}
+
+        {/* ── Collection ── */}
+        {view === 'collection' && (
+          <CollectionView stats={stats} cards={moveCards} subject={subject} onSelectCard={setSelected} />
         )}
       </div>
 
-      {/* Detail overlay */}
+      {/* ── Detail overlay ── */}
       {selected && (
         <div
           onClick={() => setSelected(null)}
           style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,.72)', display: 'grid', placeItems: 'center', padding: 16, zIndex: 50 }}
         >
-          <div onClick={(e) => e.stopPropagation()} style={{ width: 'min(380px, 92vw)' }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: 'min(400px, 92vw)' }}>
             <AllyshipCard
               card={selected}
               variant="full"
               subject={subject}
               footerSlot={<SendToBarsButton cardId={selected.id} subject={subject} />}
             />
-            <button type="button" onClick={() => setSelected(null)} style={closeBtn}>
-              Close
-            </button>
+            <button type="button" onClick={() => setSelected(null)} style={closeBtn}>Close</button>
           </div>
         </div>
       )}
@@ -231,26 +313,199 @@ export function AllyshipDeckReader() {
   )
 }
 
-/* ── sub-components ─────────────────────────────────────────────── */
+// ─── Collection view ─────────────────────────────────────────────────────────
+
+function CollectionView({
+  stats,
+  cards,
+  subject,
+  onSelectCard,
+}: {
+  stats: DeckStats | null
+  cards: MoveCard[]
+  subject: CardSubject
+  onSelectCard: (c: MoveCard) => void
+}) {
+  const [reminderOn, setReminderOn] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('deck-reminder-enabled') === 'true'
+  })
+
+  const toggleReminder = () => {
+    const next = !reminderOn
+    setReminderOn(next)
+    window.localStorage.setItem('deck-reminder-enabled', String(next))
+  }
+
+  if (!stats) {
+    return (
+      <div style={{ textAlign: 'center', padding: '60px 0' }}>
+        <p style={{ fontFamily: DECK_FONTS.body, color: SURFACE_TOKENS.textSecondary }}>Sign in to see your collection.</p>
+      </div>
+    )
+  }
+
+  const cardMap = new Map(cards.map((c) => [c.id, c]))
+
+  return (
+    <div style={{ maxWidth: 1060, margin: '0 auto' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 18 }}>
+        <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 28, color: '#fff', margin: 0 }}>Your collection</h2>
+        <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted }}>{stats.totalDrawn} cards drawn</span>
+      </div>
+
+      {/* Stats strip */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 24 }}>
+        <StatTile label="Current streak" value={`${stats.streak} days`} />
+        <StatTile label="Vibeulons" value={`♦ ${stats.vibeulons}`} />
+        <div style={{ ...statTileBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted }}>Reminder</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              type="button"
+              onClick={toggleReminder}
+              aria-pressed={reminderOn}
+              style={{
+                width: 34, height: 18, borderRadius: 99, border: 'none', cursor: 'pointer', padding: 0, position: 'relative',
+                background: reminderOn ? LIMINAL.frame : SURFACE_TOKENS.surfaceInset,
+                transition: 'background .2s',
+              }}
+            >
+              <span style={{
+                position: 'absolute', top: 2, left: reminderOn ? 16 : 2, width: 14, height: 14,
+                borderRadius: '50%', background: '#fff', transition: 'left .2s',
+              }} />
+            </button>
+            <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 11, color: reminderOn ? SURFACE_TOKENS.textPrimary : SURFACE_TOKENS.textMuted }}>
+              {reminderOn ? 'On · 8:00 AM' : 'Off'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Journal grid */}
+      {stats.entries.length === 0 ? (
+        <div style={{ border: '2px dashed rgba(255,255,255,.1)', borderRadius: 14, padding: '48px 24px', textAlign: 'center' }}>
+          <p style={{ fontFamily: DECK_FONTS.body, color: SURFACE_TOKENS.textSecondary, marginBottom: 12 }}>No cards drawn yet.</p>
+          <button type="button" style={secondaryBtn}>Go draw →</button>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(178px, 1fr))', gap: 14 }}>
+          {stats.entries.map((entry) => {
+            const card = cardMap.get(entry.cardId)
+            if (!card) return null
+            return (
+              <div key={entry.id}>
+                <p style={{ ...kicker, color: SURFACE_TOKENS.textMuted, fontSize: 9, marginBottom: 6 }}>
+                  {whenLabel(entry.drawnAt)}
+                </p>
+                <AllyshipCard
+                  card={card}
+                  variant="grid"
+                  subject={subject}
+                  onClick={() => onSelectCard(card)}
+                  footerSlot={
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); copyShareLink(card.id) }}
+                      style={{ fontFamily: DECK_FONTS.mono, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: SURFACE_TOKENS.textMuted, background: 'transparent', border: 'none', cursor: 'pointer', padding: 0 }}
+                    >
+                      Share
+                    </button>
+                  }
+                />
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={statTileBase}>
+      <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted, fontSize: 9 }}>{label}</span>
+      <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 28, color: '#fff', marginTop: 6, display: 'block' }}>{value}</span>
+    </div>
+  )
+}
+
+const statTileBase: CSSProperties = {
+  background: SURFACE_TOKENS.surfaceCard,
+  borderRadius: 12,
+  padding: '16px 18px',
+  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06)',
+  border: '1px solid rgba(255,255,255,.08)',
+}
+
+function whenLabel(drawnAt: Date): string {
+  const now = new Date()
+  const diff = Math.floor((now.getTime() - new Date(drawnAt).getTime()) / 86400000)
+  if (diff === 0) return 'Today'
+  if (diff === 1) return 'Yesterday'
+  if (diff < 30) return `${diff} days ago`
+  return new Date(drawnAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function copyShareLink(cardId: string) {
+  navigator.clipboard.writeText(`https://masteringallyship.com/c/${cardId}`)
+}
+
+// ─── Reminder toggle (inline on draw view) ───────────────────────────────────
+
+function ReminderToggle() {
+  const [on, setOn] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('deck-reminder-enabled') === 'true'
+  })
+
+  const toggle = () => {
+    const next = !on
+    setOn(next)
+    window.localStorage.setItem('deck-reminder-enabled', String(next))
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'transparent', border: 'none', cursor: 'pointer', padding: 0 }}
+    >
+      <span style={{
+        width: 34, height: 18, borderRadius: 99, padding: 2, position: 'relative', display: 'block',
+        background: on ? LIMINAL.frame : SURFACE_TOKENS.surfaceInset,
+        border: `1px solid ${on ? LIMINAL.frame : 'rgba(255,255,255,.16)'}`,
+        transition: 'background .2s',
+      }}>
+        <span style={{ position: 'absolute', top: 2, left: on ? 16 : 2, width: 14, height: 14, borderRadius: '50%', background: '#fff', transition: 'left .2s' }} />
+      </span>
+      <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: SURFACE_TOKENS.textSecondary }}>
+        {on ? 'Remind me · 8:00 AM' : 'Remind me'}
+      </span>
+    </button>
+  )
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
 
 function FaceDown({ pulsing }: { pulsing: boolean }) {
   return (
-    <div
-      style={{
-        position: 'relative',
-        width: 200,
-        height: 288,
-        borderRadius: 12,
-        border: `2px solid ${DECK_GOLD}`,
-        background: 'radial-gradient(120% 90% at 50% 0%, #241a3e, #0c0a14 70%)',
-        boxShadow: `inset 0 1px 0 rgba(255,255,255,.06), 0 0 30px -12px ${LIMINAL.frame}, 0 20px 44px -20px rgba(0,0,0,.9)`,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        transition: 'transform 200ms ease',
-        transform: pulsing ? 'scale(.97)' : 'none',
-      }}
-    >
+    <div style={{
+      position: 'relative',
+      width: 200,
+      height: 288,
+      borderRadius: 12,
+      border: `2px solid ${DECK_GOLD}`,
+      background: 'radial-gradient(120% 90% at 50% 0%, #241a3e, #0c0a14 70%)',
+      boxShadow: `inset 0 1px 0 rgba(255,255,255,.06), 0 0 30px -12px ${LIMINAL.frame}, 0 20px 44px -20px rgba(0,0,0,.9)`,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      transition: 'transform 200ms ease',
+      transform: pulsing ? 'scale(.97)' : 'none',
+    }}>
       <div style={{ position: 'absolute', inset: 10, borderRadius: 10, border: `1px solid color-mix(in srgb, ${DECK_GOLD} 40%, transparent)` }} />
       <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 60, color: `color-mix(in srgb, ${DECK_GOLD} 80%, transparent)` }}>B</span>
     </div>
@@ -259,7 +514,7 @@ function FaceDown({ pulsing }: { pulsing: boolean }) {
 
 function CardGrid({ cards, subject, onPick }: { cards: MoveCard[]; subject: CardSubject; onPick: (c: MoveCard) => void }) {
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(170px, 1fr))', gap: 12 }}>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(178px, 1fr))', gap: 12 }}>
       {cards.map((c) => (
         <AllyshipCard key={c.id} card={c} variant="grid" subject={subject} onClick={() => onPick(c)} />
       ))}
@@ -281,13 +536,9 @@ function ChipGroup<T extends string>({
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 8 }}>
       <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted, width: 54, flex: 'none' }}>{label}</span>
-      <Chip active={value === 'all'} onClick={() => setValue('all')}>
-        All
-      </Chip>
+      <Chip active={value === 'all'} onClick={() => setValue('all')}>All</Chip>
       {options.map(([k, lbl]) => (
-        <Chip key={k} active={value === k} onClick={() => setValue(value === k ? 'all' : k)}>
-          {lbl}
-        </Chip>
+        <Chip key={k} active={value === k} onClick={() => setValue(value === k ? 'all' : k)}>{lbl}</Chip>
       ))}
     </div>
   )
@@ -317,21 +568,23 @@ function Chip({ active, onClick, children }: { active: boolean; onClick: () => v
   )
 }
 
-function NavTab({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+function ModeChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
     <button
       type="button"
       onClick={onClick}
       style={{
-        fontFamily: DECK_FONTS.display,
-        fontWeight: active ? 700 : 500,
-        fontSize: 15,
-        padding: '9px 18px',
-        borderRadius: 10,
+        fontFamily: DECK_FONTS.mono,
+        fontSize: 11,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        padding: '8px 16px',
+        borderRadius: 8,
         cursor: 'pointer',
-        border: `1px solid ${active ? DECK_GOLD : 'rgba(255,255,255,.12)'}`,
-        background: active ? 'color-mix(in srgb, #C9A84C 16%, transparent)' : 'transparent',
-        color: active ? '#e7c98a' : SURFACE_TOKENS.textPrimary,
+        color: active ? '#150a04' : SURFACE_TOKENS.textSecondary,
+        background: active ? DECK_GOLD : SURFACE_TOKENS.surfaceInset,
+        border: active ? 'none' : '1px solid rgba(255,255,255,.14)',
+        fontWeight: active ? 700 : 500,
       }}
     >
       {children}
@@ -347,7 +600,7 @@ function Centered({ children }: { children: React.ReactNode }) {
   )
 }
 
-/* ── style tokens ──────────────────────────────────────────────── */
+// ─── Style tokens ─────────────────────────────────────────────────────────────
 
 const kicker: CSSProperties = {
   fontFamily: DECK_FONTS.mono,
@@ -394,20 +647,4 @@ const closeBtn: CSSProperties = {
   fontWeight: 600,
   fontSize: 14,
   cursor: 'pointer',
-}
-
-const problemRow: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 13,
-  textAlign: 'left',
-  padding: '15px 16px',
-  borderRadius: 12,
-  cursor: 'pointer',
-  background: SURFACE_TOKENS.surfaceCard,
-  border: '1px solid rgba(255,255,255,.12)',
-  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06)',
-  color: SURFACE_TOKENS.textPrimary,
-  fontFamily: DECK_FONTS.body,
-  fontSize: 15,
 }

--- a/src/components/deck/FindYourPath.tsx
+++ b/src/components/deck/FindYourPath.tsx
@@ -1,0 +1,414 @@
+'use client'
+
+import { useState, type CSSProperties } from 'react'
+import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
+import { DECK_FONTS, DECK_GOLD, LIMINAL, MOVE_LABELS, themeForMove } from '@/lib/allyship-deck/card-visuals'
+import type { MoveCard, BasicMove, Operation, AllyshipDomain } from '@/lib/allyship-deck/types'
+import { AllyshipCard, type CardSubject } from './AllyshipCard'
+import { SendToBarsButton } from './SendToBarsButton'
+
+// ─── Flavor / channel data ──────────────────────────────────────────────────
+
+interface Flavor {
+  id: string
+  sigil: string
+  label: string
+  desc: string
+  face: Operation
+  move: BasicMove
+}
+
+const FLAVORS: Flavor[] = [
+  { id: 'sadness',      sigil: '水', label: 'Sadness',      desc: 'Heavy — grief, something feels distant',    face: 'sage',       move: 'clean_up'  },
+  { id: 'anger',        sigil: '火', label: 'Anger',        desc: 'Heated — a boundary\'s been crossed',        face: 'challenger', move: 'show_up'   },
+  { id: 'fear',         sigil: '金', label: 'Fear',          desc: 'Anxious — dread, bracing for it',           face: 'diplomat',   move: 'open_up'   },
+  { id: 'numbness',     sigil: '土', label: 'Numbness',      desc: 'Shut down — going through the motions',    face: 'regent',     move: 'wake_up'   },
+  { id: 'restlessness', sigil: '木', label: 'Restlessness', desc: 'Forced — performing okay-ness',             face: 'architect',  move: 'grow_up'   },
+]
+
+const RATING_LABELS: Record<number, string> = {
+  1:  'Barely there — a whisper of friction.',
+  2:  'Mild — something\'s slightly off.',
+  3:  'Low — noticeable but manageable.',
+  4:  'Moderate — it\'s asking for attention.',
+  5:  'Present — noticeable, pulling at me.',
+  6:  'Significant — harder to set aside.',
+  7:  'Heavy — requires real effort to hold.',
+  8:  'Heavy — it\'s taking real effort to carry.',
+  9:  'Intense — it\'s running the room.',
+  10: 'Overwhelming — it\'s all I can feel.',
+}
+
+// ─── Passage / branching questions ─────────────────────────────────────────
+
+interface PassageChoice {
+  letter: string
+  text: string
+  move: BasicMove
+  domain: AllyshipDomain
+}
+
+interface PassageDef {
+  id: string
+  prose: string
+  choices: PassageChoice[]
+}
+
+const PASSAGES: PassageDef[] = [
+  {
+    id: 'scene',
+    prose: 'The friction lives somewhere. Where does it sit?',
+    choices: [
+      { letter: 'A', text: 'In the room — it\'s between people.',       move: 'show_up',  domain: 'DIRECT_ACTION'        },
+      { letter: 'B', text: 'In me — I\'m carrying it alone.',           move: 'clean_up', domain: 'GATHERING_RESOURCES'  },
+      { letter: 'C', text: 'In the structure — the system is broken.',  move: 'wake_up',  domain: 'SKILLFUL_ORGANIZING'  },
+    ],
+  },
+  {
+    id: 'arrival',
+    prose: 'What does a good outcome look like, just for today?',
+    choices: [
+      { letter: 'A', text: 'I took one concrete step.',                  move: 'show_up',  domain: 'DIRECT_ACTION'   },
+      { letter: 'B', text: 'I understand what\'s actually going on.',    move: 'wake_up',  domain: 'RAISE_AWARENESS' },
+      { letter: 'C', text: 'I\'m less tangled inside.',                  move: 'clean_up', domain: 'RAISE_AWARENESS' },
+    ],
+  },
+]
+
+// ─── Spread computation ─────────────────────────────────────────────────────
+
+interface CyoaCtx {
+  flavorFace: Operation
+  flavorMove: BasicMove
+  choices: { move: BasicMove; domain: AllyshipDomain }[]
+}
+
+function scoreCard(card: MoveCard, ctx: CyoaCtx, positionBias: BasicMove | BasicMove[]): number {
+  let w = 0
+  if (card.operation === ctx.flavorFace) w += 3
+  const biases = Array.isArray(positionBias) ? positionBias : [positionBias]
+  if (biases.includes(card.move)) w += 6
+  for (const choice of ctx.choices) {
+    if (card.move === choice.move) w += 2
+    if (card.domain === choice.domain) w += 1
+  }
+  if (card.move === ctx.flavorMove) w += 2
+  return w
+}
+
+function computeCyoaSpread(
+  cards: MoveCard[],
+  ctx: CyoaCtx,
+): [MoveCard, MoveCard, MoveCard] {
+  const positionBiases: Array<BasicMove | BasicMove[]> = [
+    'wake_up',
+    'clean_up',
+    ['show_up', 'grow_up', 'open_up'],
+  ]
+
+  const used = new Set<string>()
+  const result: MoveCard[] = []
+
+  for (const bias of positionBiases) {
+    const scored = cards
+      .filter((c) => !used.has(c.id))
+      .map((c) => ({ card: c, score: scoreCard(c, ctx, bias) }))
+      .sort((a, b) => b.score - a.score || cards.indexOf(a.card) - cards.indexOf(b.card))
+
+    const pick = scored[0]?.card
+    if (!pick) break
+    result.push(pick)
+    used.add(pick.id)
+  }
+
+  return result as [MoveCard, MoveCard, MoveCard]
+}
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+type CyPhase = 'landing' | 'step0' | 'passage' | 'result'
+
+interface CyoaState {
+  phase: CyPhase
+  rating: number
+  flavor: Flavor | null
+  passageIndex: number
+  choices: { move: BasicMove; domain: AllyshipDomain }[]
+  spread: [MoveCard, MoveCard, MoveCard] | null
+}
+
+const PHASE_PCT: Record<CyPhase, number> = { landing: 0, step0: 30, passage: 66, result: 100 }
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function FindYourPath({
+  cards,
+  subject,
+  onSelectCard,
+}: {
+  cards: MoveCard[]
+  subject: CardSubject
+  onSelectCard: (card: MoveCard) => void
+}) {
+  const [state, setState] = useState<CyoaState>({
+    phase: 'landing',
+    rating: 5,
+    flavor: null,
+    passageIndex: 0,
+    choices: [],
+    spread: null,
+  })
+
+  const reset = () => setState({ phase: 'landing', rating: 5, flavor: null, passageIndex: 0, choices: [], spread: null })
+
+  const pct = PHASE_PCT[state.phase]
+  const showProgress = state.phase !== 'landing'
+
+  // ── landing ─────────────────────────────────────────────────────────────
+  if (state.phase === 'landing') {
+    return (
+      <div style={{ maxWidth: 640, margin: '0 auto', textAlign: 'center', paddingTop: 24 }}>
+        <p style={{ ...kicker, color: DECK_GOLD }}>Find your path · a situation reading</p>
+        <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 28, color: '#fff', margin: '10px 0 6px', lineHeight: 1.15 }}>
+          What kind of allyship<br />is being asked of you?
+        </h2>
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary, marginBottom: 24 }}>
+          You showed up because something&rsquo;s stuck.
+        </p>
+        <button type="button" style={primaryBtn} onClick={() => setState((s) => ({ ...s, phase: 'step0' }))}>
+          Begin the reading →
+        </button>
+      </div>
+    )
+  }
+
+  // ── step0 ────────────────────────────────────────────────────────────────
+  if (state.phase === 'step0') {
+    return (
+      <div style={{ maxWidth: 640, margin: '0 auto', paddingTop: 16 }}>
+        <ProgressBar pct={pct} />
+        <p style={{ ...kicker, color: DECK_GOLD, marginTop: 16 }}>The check-in</p>
+        <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 24, color: '#fff', margin: '6px 0 18px' }}>
+          What are you carrying in?
+        </h2>
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: SURFACE_TOKENS.textSecondary, margin: '0 0 20px' }}>
+          You showed up because something&rsquo;s stuck. Two quick reads and we&rsquo;ll meet it where it is.
+        </p>
+
+        {/* Intensity slider */}
+        <div style={{ background: SURFACE_TOKENS.surfaceCard, borderRadius: 12, padding: '18px 20px', marginBottom: 20, boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted }}>How intense is it right now?</span>
+            <span style={{ fontFamily: DECK_FONTS.mono, fontWeight: 700, fontSize: 20, color: '#fff' }}>{state.rating}</span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={10}
+            value={state.rating}
+            onChange={(e) => setState((s) => ({ ...s, rating: Number(e.target.value) }))}
+            style={{ width: '100%', accentColor: DECK_GOLD }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6 }}>
+            <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted, fontSize: 9 }}>Faint</span>
+            <span style={{ ...kicker, color: SURFACE_TOKENS.textMuted, fontSize: 9 }}>Overwhelming</span>
+          </div>
+          <p style={{ fontFamily: DECK_FONTS.body, fontStyle: 'italic', fontSize: 13.5, color: SURFACE_TOKENS.textSecondary, margin: '10px 0 0' }}>
+            {RATING_LABELS[state.rating]}
+          </p>
+        </div>
+
+        {/* Flavor picker */}
+        <p style={{ ...kicker, color: SURFACE_TOKENS.textMuted, marginBottom: 10 }}>Which flavor is it, mostly?</p>
+        <div style={{ display: 'grid', gap: 8, marginBottom: 24 }}>
+          {FLAVORS.map((f) => {
+            const active = state.flavor?.id === f.id
+            return (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setState((s) => ({ ...s, flavor: f }))}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 16,
+                  padding: '14px 16px',
+                  borderRadius: 12,
+                  border: `1px solid ${active ? DECK_GOLD : 'rgba(255,255,255,.12)'}`,
+                  background: active ? `color-mix(in srgb, ${DECK_GOLD} 10%, ${SURFACE_TOKENS.surfaceCard})` : SURFACE_TOKENS.surfaceCard,
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06)',
+                }}
+              >
+                <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 22, color: active ? DECK_GOLD : SURFACE_TOKENS.textSecondary, width: 28 }}>
+                  {f.sigil}
+                </span>
+                <span style={{ flex: 1 }}>
+                  <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 16, color: '#fff', display: 'block' }}>{f.label}</span>
+                  <span style={{ fontFamily: DECK_FONTS.body, fontSize: 13, color: SURFACE_TOKENS.textSecondary }}>{f.desc}</span>
+                </span>
+              </button>
+            )
+          })}
+        </div>
+
+        <button
+          type="button"
+          disabled={!state.flavor}
+          onClick={() => setState((s) => ({ ...s, phase: 'passage', passageIndex: 0 }))}
+          style={{ ...primaryBtn, opacity: state.flavor ? 1 : 0.4, width: '100%' }}
+        >
+          Continue →
+        </button>
+      </div>
+    )
+  }
+
+  // ── passage ──────────────────────────────────────────────────────────────
+  if (state.phase === 'passage') {
+    const passage = PASSAGES[state.passageIndex]
+    if (!passage) return null
+
+    const choose = (choice: PassageChoice) => {
+      const newChoices = [...state.choices, { move: choice.move, domain: choice.domain }]
+      const nextIndex = state.passageIndex + 1
+
+      if (nextIndex >= PASSAGES.length) {
+        const ctx: CyoaCtx = {
+          flavorFace: state.flavor!.face,
+          flavorMove: state.flavor!.move,
+          choices: newChoices,
+        }
+        const spread = computeCyoaSpread(cards, ctx)
+        setState((s) => ({ ...s, choices: newChoices, spread, phase: 'result' }))
+      } else {
+        setState((s) => ({ ...s, choices: newChoices, passageIndex: nextIndex }))
+      }
+    }
+
+    return (
+      <div style={{ maxWidth: 640, margin: '0 auto', paddingTop: 16 }}>
+        <ProgressBar pct={pct} />
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 12, color: SURFACE_TOKENS.textMuted, margin: '16px 0 6px' }}>
+          {state.passageIndex + 1} of {PASSAGES.length}
+        </p>
+        <p style={{ fontFamily: DECK_FONTS.body, fontStyle: 'italic', fontSize: 18, color: SURFACE_TOKENS.textSecondary, marginBottom: 24, lineHeight: 1.5 }}>
+          {passage.prose}
+        </p>
+        <div style={{ display: 'grid', gap: 10 }}>
+          {passage.choices.map((c) => (
+            <button
+              key={c.letter}
+              type="button"
+              onClick={() => choose(c)}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 14,
+                padding: '15px 16px',
+                borderRadius: 12,
+                border: '1px solid rgba(255,255,255,.14)',
+                background: SURFACE_TOKENS.surfaceCard,
+                cursor: 'pointer',
+                textAlign: 'left',
+                boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06)',
+              }}
+            >
+              <span style={{ fontFamily: DECK_FONTS.mono, fontWeight: 700, fontSize: 13, color: DECK_GOLD, flex: 'none', marginTop: 1 }}>{c.letter}</span>
+              <span style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textPrimary, lineHeight: 1.4 }}>{c.text}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  // ── result ───────────────────────────────────────────────────────────────
+  if (state.phase === 'result' && state.spread) {
+    const [situation, block, move] = state.spread
+    const readout = `The ${state.flavor!.label.toLowerCase()} you named points toward a ${MOVE_LABELS[move.move]} move.`
+
+    return (
+      <div style={{ maxWidth: 780, margin: '0 auto', paddingTop: 16 }}>
+        <ProgressBar pct={pct} />
+        <div style={{ textAlign: 'center', marginTop: 20, marginBottom: 28 }}>
+          <span style={{ fontSize: 22, color: DECK_GOLD }}>✦</span>
+          <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 26, color: '#fff', margin: '8px 0 6px' }}>
+            Your situation has been read.
+          </h2>
+          <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary }}>{readout}</p>
+          <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: SURFACE_TOKENS.textMuted, marginTop: 2 }}>
+            Read the spread, then begin where it tells you.
+          </p>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
+          {([
+            { label: 'The Situation', card: situation },
+            { label: 'The Block',     card: block     },
+            { label: 'The Move',      card: move      },
+          ] as const).map(({ label, card }) => (
+            <div key={card.id}>
+              <p style={{ ...kicker, color: SURFACE_TOKENS.textMuted, textAlign: 'center', marginBottom: 8 }}>{label}</p>
+              <AllyshipCard card={card} variant="grid" subject={subject} onClick={() => onSelectCard(card)} />
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 24 }}>
+          <div>
+            <SendToBarsButton cardId={move.id} subject={subject} label="Begin your adventure →" />
+          </div>
+          <button type="button" style={secondaryBtn} onClick={reset}>Read again</button>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function ProgressBar({ pct }: { pct: number }) {
+  return (
+    <div style={{ height: 2, background: SURFACE_TOKENS.surfaceInset, borderRadius: 99 }}>
+      <div style={{ height: '100%', width: `${pct}%`, background: DECK_GOLD, borderRadius: 99, transition: 'width .4s cubic-bezier(0.16,1,0.3,1)' }} />
+    </div>
+  )
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const kicker: CSSProperties = {
+  fontFamily: DECK_FONTS.mono,
+  fontSize: 11,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+}
+
+const primaryBtn: CSSProperties = {
+  fontFamily: DECK_FONTS.display,
+  fontWeight: 700,
+  fontSize: 16,
+  padding: '14px 30px',
+  borderRadius: 12,
+  border: 'none',
+  cursor: 'pointer',
+  color: '#fff',
+  background: LIMINAL.frame,
+  boxShadow: `inset 0 1px 0 rgba(255,255,255,.06), 0 10px 24px -10px ${LIMINAL.frame}`,
+}
+
+const secondaryBtn: CSSProperties = {
+  fontFamily: DECK_FONTS.display,
+  fontWeight: 600,
+  fontSize: 15,
+  padding: '13px 22px',
+  borderRadius: 12,
+  cursor: 'pointer',
+  color: SURFACE_TOKENS.textPrimary,
+  background: 'transparent',
+  border: '1px solid rgba(255,255,255,.16)',
+}

--- a/src/components/deck/SendToBarsButton.tsx
+++ b/src/components/deck/SendToBarsButton.tsx
@@ -11,7 +11,7 @@ import type { CardSubject } from './AllyshipCard'
  * stamped server-side) and routes the player to `/bars/{id}` — where the BAR flow lives
  * (capture charge / 3·2·1 happen on the bloomed quest, not the seed).
  */
-export function SendToBarsButton({ cardId, subject }: { cardId: string; subject: CardSubject }) {
+export function SendToBarsButton({ cardId, subject, label = 'Send to BARS →' }: { cardId: string; subject: CardSubject; label?: string }) {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
@@ -31,7 +31,7 @@ export function SendToBarsButton({ cardId, subject }: { cardId: string; subject:
   return (
     <div style={{ marginTop: 14 }}>
       <button type="button" onClick={send} disabled={pending} style={{ ...btn, opacity: pending ? 0.6 : 1 }}>
-        {pending ? 'Sending…' : 'Send to BARS →'}
+        {pending ? 'Sending…' : label}
       </button>
       {error && (
         <p style={{ fontFamily: DECK_FONTS.body, fontSize: 12.5, color: '#f0a0a0', margin: '8px 0 0', textAlign: 'center' }}>

--- a/src/lib/allyship-deck/assemble.ts
+++ b/src/lib/allyship-deck/assemble.ts
@@ -28,14 +28,17 @@ export const DECK_VERSION = '0.1.0'
 
 function buildMoveCards(): MoveCard[] {
   const cards: MoveCard[] = []
+  let seq = 0
   for (const m of MOVES) {
     for (const d of DOMAINS) {
       for (const op of OPERATIONS) {
         const sub = SUBMOVES[m.key][op.key]
         const id = `${m.abbr}-${d.abbr}-${op.key.toUpperCase()}`
+        seq++
 
         const generated: MoveCard = {
           id,
+          num: String(seq).padStart(3, '0'),
           kind: 'move',
           move: m.key,
           operation: op.key,

--- a/src/lib/allyship-deck/types.ts
+++ b/src/lib/allyship-deck/types.ts
@@ -39,6 +39,7 @@ export type CardStatus = 'authored' | 'generated'
 
 export interface MoveCard {
   id: string // `${MOVE_ABBR}-${DOMAIN_ABBR}-${OPERATION}` e.g. "OPEN-GR-SHAMAN"
+  num: string // zero-padded position in deck e.g. "001"
   kind: 'move'
   move: BasicMove
   operation: Operation


### PR DESCRIPTION
## Summary

Implements Slices 5–6 of the Allyship Deck experience: a sticky app shell with 4-tab navigation, server-persisted draw journal with streak/Vibeulon tracking, and a branching "Find your path" CYOA situation reading that lays 3-card spreads.

## Key Changes

### App Shell & Navigation (`AllyshipDeckReader`)
- **4-tab nav** (Draw · Deck · Find your path · Collection) replaces the 3-tab layout
- **Sticky top bar** with BARS branding, centered tab nav, and live streak/Vibeulon display (top-right)
- Subject toggle moved below the header
- View type renamed: `'find'` → `'path'`, added `'collection'` view
- Draw mode toggle: single card vs. 3-card spread gateway

### Draw Journal & Stats (`src/actions/deck-journal.ts`)
- New server action `recordDraw()` — fire-and-forget logging of card draws
- `getDeckStats()` — fetches player's journal entries (first 100) and computes:
  - `totalDrawn`: count of entries
  - `streak`: consecutive calendar days with ≥1 draw (UTC-based)
  - `vibeulons`: sum of all entry rewards (default 1 per draw)
- Optimistic UI updates on draw (stats state updated before server confirmation)

### Find Your Path CYOA (`FindYourPath.tsx`)
- **4-phase flow**: landing → step0 (check-in) → passage (2 branching questions) → result (3-card spread)
- **step0 inputs**:
  - Intensity slider (1–10) with live readout labels
  - Flavor picker (5 wuxing emotions: sadness/anger/fear/numbness/restlessness) mapped to face + move biases
- **Passage questions**: two mythic branching prompts that accumulate move/domain choices
- **Spread algorithm** (`computeCyoaSpread`): weighted scoring of cards based on flavor face, flavor move, passage choices, and position bias; returns 3 unique cards
- Gold progress bar (0% / 30% / 66% / 100%) shown during flow

### Data Model
- **`DeckJournalEntry`** Prisma model: `id`, `playerId`, `cardId`, `drawnAt`, `vibeulons`
- Migration: `20260618000000_add_deck_journal_entry`
- Index on `(playerId, drawnAt DESC)` for efficient journal queries

### Card Data
- Added `num` field (zero-padded position, e.g. "001") to all 120 move cards in `allyship-deck.json`
- Updated `MoveCard` type to include `num: string`

### Collection View (Stub)
- New tab renders journal entries in a grid (most recent first)
- Empty state for new accounts
- Share chip on each card (copies URL to clipboard; full share modal deferred)
- Stats strip: Current Streak, Vibeulons, Reminder toggle (client-only localStorage)

### Supporting Changes
- `AllyshipCard` footer now displays card number
- `SendToBarsButton` docstring clarified (no routing changes)
- `getDeckStats()` passed as `initialStats` prop to `AllyshipDeckReader`
- Added `useCallback` to `draw()` function for stable dependency tracking

## Implementation Notes

- **Non-authed draws**: gracefully degrade (draw UI works, journal not persisted)
- **Reminder toggle**: UI-only in this slice (no push notification wiring)
- **Spread mode**: currently shows placeholder cards; "Begin the reading" routes to Find your path
- **Gumroad branding research**: documented in `docs/GUMROAD_BRANDING_RESEARCH.md` (Pro plan enables custom domain + CSS; checkout iframe not brandable)
- **Spec reference**: `.specify/specs/allyship-deck-experience/spec.md` (Slices 5–8 documented;

https://claude.ai/code/session_01L7pg3G4GEjUCLp2EzGzt5u