### PR TITLE
Add Capture → Keep → Tune intake flow for BARs

### DIFF
--- a/src/actions/bars.ts
+++ b/src/actions/bars.ts
@@ -1105,3 +1105,121 @@ export async function captureBarFromCanvas(
     return { error: 'Failed to capture seed. Please try again.' }
   }
 }
+
+// ---------------------------------------------------------------------------
+// TUNE BAR — Capture → Keep → Tune flow
+// ---------------------------------------------------------------------------
+
+const VALID_MOVE_TYPES = ['wakeUp', 'openUp', 'cleanUp', 'growUp', 'showUp'] as const
+type MoveType = (typeof VALID_MOVE_TYPES)[number]
+
+const VALID_ALTITUDES = ['dissatisfied', 'neutral', 'satisfied'] as const
+
+export interface TuneBarInput {
+    nation?: string              // element key (fire | water | wood | metal | earth)
+    intensity?: string           // altitude (dissatisfied | neutral | satisfied)
+    emotionalAlchemyTag?: string // charge name / feeling tag
+    moveType?: string            // wakeUp | openUp | cleanUp | growUp | showUp
+}
+
+export type TuneBarResult =
+    | { success: true; maturity: MaturityPhase }
+    | { error: string }
+
+/**
+ * Tune a BAR's three channels and advance maturity accordingly.
+ * Maturity only moves forward (never back). Channel completion determines the
+ * next maturity phase:
+ *   nation set               → context_named
+ *   intensity + alchemyTag   → elaborated
+ *   moveType set             → shared_or_acted
+ */
+export async function tuneBar(barId: string, patch: TuneBarInput): Promise<TuneBarResult> {
+    const playerId = await getPlayerId()
+    if (!playerId) return { error: 'Not logged in' }
+
+    const bar = await db.customBar.findUnique({
+        where: { id: barId },
+        select: {
+            id: true,
+            creatorId: true,
+            type: true,
+            seedMetabolization: true,
+            nation: true,
+            intensity: true,
+            emotionalAlchemyTag: true,
+            moveType: true,
+        },
+    })
+    if (!bar) return { error: 'BAR not found' }
+    if (bar.creatorId !== playerId) return { error: 'Not authorized' }
+    if (!['bar', 'charge_capture'].includes(bar.type)) {
+        return { error: 'This BAR type does not support tuning' }
+    }
+
+    // Merge patch into current state — only accept valid values
+    const nextNation = patch.nation
+        ? (ELEMENT_KEYS as readonly string[]).includes(patch.nation.toLowerCase())
+            ? patch.nation.toLowerCase()
+            : bar.nation
+        : bar.nation
+
+    const nextIntensity = patch.intensity
+        ? (VALID_ALTITUDES as readonly string[]).includes(patch.intensity)
+            ? patch.intensity
+            : bar.intensity
+        : bar.intensity
+
+    const nextAlchemyTag =
+        patch.emotionalAlchemyTag !== undefined
+            ? (patch.emotionalAlchemyTag || '').trim().slice(0, 60) || null
+            : bar.emotionalAlchemyTag
+
+    const nextMoveType = patch.moveType
+        ? (VALID_MOVE_TYPES as readonly string[]).includes(patch.moveType)
+            ? patch.moveType
+            : bar.moveType
+        : bar.moveType
+
+    // Derive target maturity from channel completion
+    let targetMaturity: MaturityPhase = 'captured'
+    if (nextNation) targetMaturity = 'context_named'
+    if (nextIntensity && nextAlchemyTag) targetMaturity = 'elaborated'
+    if (nextMoveType) targetMaturity = 'shared_or_acted'
+
+    // Maturity only moves forward — clamp to max(current, target)
+    const PHASES: MaturityPhase[] = [
+        'captured', 'context_named', 'elaborated', 'shared_or_acted', 'integrated',
+    ]
+    const currentMaturity = effectiveMaturity(parseSeedMetabolization(bar.seedMetabolization))
+    const currentIdx = PHASES.indexOf(currentMaturity)
+    const targetIdx = PHASES.indexOf(targetMaturity)
+    const nextMaturity = PHASES[Math.max(currentIdx, targetIdx)]
+
+    try {
+        await db.customBar.update({
+            where: { id: barId },
+            data: {
+                nation: nextNation,
+                intensity: nextIntensity,
+                emotionalAlchemyTag: nextAlchemyTag,
+                moveType: nextMoveType,
+                seedMetabolization: mergeSeedMetabolization(bar.seedMetabolization, {
+                    maturity: nextMaturity,
+                }),
+            },
+        })
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Unknown error'
+        console.error('[tuneBar] update failed:', message)
+        return { error: 'Failed to tune BAR. Please try again.' }
+    }
+
+    revalidatePath('/bars')
+    revalidatePath(`/bars/${barId}`)
+    revalidatePath(`/bars/${barId}/tune`)
+    revalidatePath('/bars/garden')
+    revalidatePath('/vault')
+
+    return { success: true, maturity: nextMaturity }
+}

--- a/src/actions/capture-bar.ts
+++ b/src/actions/capture-bar.ts
@@ -16,7 +16,7 @@ import { db } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 import { getCurrentPlayer } from '@/lib/auth'
 import { mergeSeedMetabolization } from '@/lib/bar-seed-metabolization/parse'
-import { addBarToHand, type HandContents, type OverflowContext } from '@/actions/hand'
+import { addBarToHandForPlayer, type HandContents, type OverflowContext } from '@/lib/hand-service'
 
 export type CaptureDestination = 'hand' | 'vault'
 
@@ -93,7 +93,7 @@ export async function captureBar(input: {
     }
 
     // destination === 'hand'
-    const handResult = await addBarToHand({ barId })
+    const handResult = await addBarToHandForPlayer(player.id, barId)
     if ('error' in handResult) {
         // Created but couldn't place — it's safely in the vault.
         return { success: true, barId, placedIn: 'vault' }

--- a/src/actions/daily-charge.ts
+++ b/src/actions/daily-charge.ts
@@ -21,7 +21,7 @@ import { db } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 import { getCurrentPlayer } from '@/lib/auth'
 import { getTodayCharge } from '@/actions/charge-capture'
-import { addBarToHand } from '@/actions/hand'
+import { addBarToHandForPlayer } from '@/lib/hand-service'
 import type { CaptureDestination } from '@/actions/capture-bar'
 import {
     mergeSeedMetabolization,
@@ -131,7 +131,7 @@ export async function applyDailyCharge(
 
         if (input.destination === 'hand') {
             // Best-effort placement; if the hand is full the BAR stays in the vault.
-            await addBarToHand({ barId })
+            await addBarToHandForPlayer(player.id, barId)
         }
 
         revalidatePath('/')

--- a/src/actions/hand.ts
+++ b/src/actions/hand.ts
@@ -16,35 +16,17 @@
 
 import { dbBase } from '@/lib/db'
 import { getCurrentPlayer } from '@/lib/auth'
+import {
+    HAND_SIZE,
+    readHandDb,
+    addBarToHandForPlayer,
+    type HandSlotBar,
+    type HandSlotDTO,
+    type HandContents,
+    type OverflowContext,
+} from '@/lib/hand-service'
 
-const HAND_SIZE = 6
-
-export type HandSlotBar = {
-    id: string
-    title: string
-    type: string
-    moveType: string | null
-}
-
-export type HandSlotDTO = {
-    slotIndex: number // 0–5
-    barId: string | null
-    isCarrying: boolean
-    bar: HandSlotBar | null
-}
-
-export type HandContents = {
-    slots: HandSlotDTO[] // always length HAND_SIZE, ordered by slotIndex
-    filledCount: number
-    size: number
-    carryingBarId: string | null
-}
-
-export type OverflowContext = {
-    newBarId: string
-    newBarTitle: string
-    currentHand: Array<{ slotIndex: number; barId: string; title: string; type: string }>
-}
+export type { HandSlotBar, HandSlotDTO, HandContents, OverflowContext }
 
 type ErrorResult = { error: string }
 
@@ -53,45 +35,11 @@ function ownedActiveBarWhere(playerId: string, barId: string) {
     return { id: barId, creatorId: playerId, status: 'active', archivedAt: null }
 }
 
-async function readHand(playerId: string): Promise<HandContents> {
-    const rows = await dbBase.handSlot.findMany({
-        where: { playerId },
-        orderBy: { slotIndex: 'asc' },
-        include: {
-            bar: { select: { id: true, title: true, type: true, moveType: true } },
-        },
-    })
-
-    const bySlot = new Map<number, (typeof rows)[number]>()
-    for (const r of rows) bySlot.set(r.slotIndex, r)
-
-    const slots: HandSlotDTO[] = []
-    for (let i = 0; i < HAND_SIZE; i++) {
-        const r = bySlot.get(i)
-        slots.push({
-            slotIndex: i,
-            barId: r?.barId ?? null,
-            isCarrying: r?.isCarrying ?? false,
-            bar: r?.bar
-                ? { id: r.bar.id, title: r.bar.title, type: r.bar.type, moveType: r.bar.moveType }
-                : null,
-        })
-    }
-
-    const carrying = rows.find((r) => r.isCarrying && r.barId)
-    return {
-        slots,
-        filledCount: slots.filter((s) => s.barId).length,
-        size: HAND_SIZE,
-        carryingBarId: carrying?.barId ?? null,
-    }
-}
-
 /** Get the player's current hand (6 slots, filled count, carrying state). */
 export async function getPlayerHand(): Promise<HandContents | ErrorResult> {
     const player = await getCurrentPlayer()
     if (!player) return { error: 'Not authenticated' }
-    return readHand(player.id)
+    return readHandDb(player.id)
 }
 
 /**
@@ -107,60 +55,7 @@ export async function addBarToHand(input: {
 > {
     const player = await getCurrentPlayer()
     if (!player) return { error: 'Not authenticated' }
-
-    const bar = await dbBase.customBar.findFirst({
-        where: ownedActiveBarWhere(player.id, input.barId),
-        select: { id: true, title: true, type: true },
-    })
-    if (!bar) return { error: 'BAR not found or not yours' }
-
-    const slots = await dbBase.handSlot.findMany({ where: { playerId: player.id } })
-
-    // Idempotent: already in hand.
-    if (slots.some((s) => s.barId === input.barId)) {
-        return { success: true, hand: await readHand(player.id) }
-    }
-
-    const usedIndexes = new Set(slots.filter((s) => s.barId).map((s) => s.slotIndex))
-    let emptyIndex = -1
-    for (let i = 0; i < HAND_SIZE; i++) {
-        if (!usedIndexes.has(i)) {
-            emptyIndex = i
-            break
-        }
-    }
-
-    if (emptyIndex === -1) {
-        // Hand full → overflow.
-        const filled = await dbBase.handSlot.findMany({
-            where: { playerId: player.id, barId: { not: null } },
-            orderBy: { slotIndex: 'asc' },
-            include: { bar: { select: { id: true, title: true, type: true } } },
-        })
-        return {
-            success: false,
-            overflow: {
-                newBarId: bar.id,
-                newBarTitle: bar.title,
-                currentHand: filled
-                    .filter((s) => s.bar)
-                    .map((s) => ({
-                        slotIndex: s.slotIndex,
-                        barId: s.bar!.id,
-                        title: s.bar!.title,
-                        type: s.bar!.type,
-                    })),
-            },
-        }
-    }
-
-    await dbBase.handSlot.upsert({
-        where: { playerId_slotIndex: { playerId: player.id, slotIndex: emptyIndex } },
-        create: { playerId: player.id, slotIndex: emptyIndex, barId: bar.id },
-        update: { barId: bar.id, isCarrying: false },
-    })
-
-    return { success: true, hand: await readHand(player.id) }
+    return addBarToHandForPlayer(player.id, input.barId)
 }
 
 /**
@@ -177,7 +72,7 @@ export async function resolveOverflow(input: {
 
     // Declined to swap → new BAR stays in the vault, hand unchanged.
     if (input.depositBarId === input.newBarId) {
-        return { success: true, hand: await readHand(player.id) }
+        return { success: true, hand: await readHandDb(player.id) }
     }
 
     const bar = await dbBase.customBar.findFirst({
@@ -197,7 +92,7 @@ export async function resolveOverflow(input: {
         data: { barId: input.newBarId, isCarrying: false },
     })
 
-    return { success: true, hand: await readHand(player.id) }
+    return { success: true, hand: await readHandDb(player.id) }
 }
 
 /** Move a hand BAR to the vault (free action). Frees its slot. */
@@ -217,7 +112,7 @@ export async function depositHandBarToVault(input: {
         data: { barId: null, isCarrying: false },
     })
 
-    return { success: true, hand: await readHand(player.id) }
+    return { success: true, hand: await readHandDb(player.id) }
 }
 
 /** Promote a vault BAR into the hand. Only allowed when an empty slot exists. */
@@ -240,7 +135,7 @@ export async function promoteVaultBarToHand(input: {
 
     const slots = await dbBase.handSlot.findMany({ where: { playerId: player.id } })
     if (slots.some((s) => s.barId === input.barId)) {
-        return { success: true, hand: await readHand(player.id) }
+        return { success: true, hand: await readHandDb(player.id) }
     }
 
     const usedIndexes = new Set(slots.filter((s) => s.barId).map((s) => s.slotIndex))
@@ -264,7 +159,7 @@ export async function promoteVaultBarToHand(input: {
         update: { barId: bar.id, isCarrying: false },
     })
 
-    return { success: true, hand: await readHand(player.id) }
+    return { success: true, hand: await readHandDb(player.id) }
 }
 
 /**
@@ -291,7 +186,7 @@ export async function setCarryingFromHand(input: {
         }
     })
 
-    return { success: true, hand: await readHand(player.id) }
+    return { success: true, hand: await readHandDb(player.id) }
 }
 
 /** Reorder slots. Applies a new (slotIndex, barId) arrangement atomically. */
@@ -330,5 +225,5 @@ export async function reorderHandSlots(input: {
         await tx.handSlot.deleteMany({ where: { playerId: player.id, slotIndex: { lt: 0 } } })
     })
 
-    return { success: true, hand: await readHand(player.id) }
+    return { success: true, hand: await readHandDb(player.id) }
 }

--- a/src/actions/hand.ts
+++ b/src/actions/hand.ts
@@ -26,8 +26,6 @@ import {
     type OverflowContext,
 } from '@/lib/hand-service'
 
-export type { HandSlotBar, HandSlotDTO, HandContents, OverflowContext }
-
 type ErrorResult = { error: string }
 
 /** A BAR is eligible for the hand if the caller owns it and it is active. */

--- a/src/actions/hand.ts
+++ b/src/actions/hand.ts
@@ -17,7 +17,7 @@
 import { dbBase } from '@/lib/db'
 import { getCurrentPlayer } from '@/lib/auth'
 
-export const HAND_SIZE = 6
+const HAND_SIZE = 6
 
 export type HandSlotBar = {
     id: string

--- a/src/app/bars/[id]/tune/page.tsx
+++ b/src/app/bars/[id]/tune/page.tsx
@@ -1,0 +1,58 @@
+import { notFound, redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
+import { db } from '@/lib/db'
+import {
+    parseSeedMetabolization,
+    effectiveMaturity,
+} from '@/lib/bar-seed-metabolization/parse'
+import { TuneBarClient } from '@/components/bars/TuneBarClient'
+
+interface TunePageProps {
+    params: Promise<{ id: string }>
+}
+
+export default async function TunePage({ params }: TunePageProps) {
+    const { id: barId } = await params
+
+    const cookieStore = await cookies()
+    const playerId =
+        cookieStore.get('bars_player_id')?.value ||
+        (process.env.NODE_ENV === 'development' ? process.env.DEV_PLAYER_ID : null)
+
+    if (!playerId) redirect('/login')
+
+    const bar = await db.customBar.findUnique({
+        where: { id: barId },
+        select: {
+            id: true,
+            title: true,
+            description: true,
+            creatorId: true,
+            type: true,
+            nation: true,
+            intensity: true,
+            emotionalAlchemyTag: true,
+            moveType: true,
+            seedMetabolization: true,
+        },
+    })
+
+    if (!bar) notFound()
+    if (bar.creatorId !== playerId) notFound()
+    if (!['bar', 'charge_capture'].includes(bar.type)) redirect(`/bars/${barId}`)
+
+    const maturity = effectiveMaturity(parseSeedMetabolization(bar.seedMetabolization))
+
+    return (
+        <TuneBarClient
+            barId={bar.id}
+            title={bar.title}
+            description={bar.description || ''}
+            initialNation={bar.nation ?? null}
+            initialIntensity={bar.intensity ?? null}
+            initialAlchemyTag={bar.emotionalAlchemyTag ?? null}
+            initialMoveType={bar.moveType ?? null}
+            initialMaturity={maturity}
+        />
+    )
+}

--- a/src/app/bars/create/page.tsx
+++ b/src/app/bars/create/page.tsx
@@ -1,9 +1,28 @@
+import { getCurrentPlayer } from '@/lib/auth'
 import { redirect } from 'next/navigation'
+import { SimpleCaptureForm } from '@/components/bars/SimpleCaptureForm'
 
 /**
  * @page /bars/create
- * @deprecated Use /bars/capture instead.
+ * @description Screen A — simple text capture. Low-friction entry point for the
+ * Capture → Keep → Tune intake flow. For the full Stories canvas, use /bars/capture.
  */
-export default function CreateBarPage() {
-  redirect('/bars/capture')
+export default async function CreateBarPage(props: {
+    searchParams: Promise<{ text?: string; prefill?: string; ref?: string }>
+}) {
+    const [player, searchParams] = await Promise.all([
+        getCurrentPlayer(),
+        props.searchParams,
+    ])
+    if (!player) redirect('/login')
+
+    const rawText = searchParams.prefill ?? searchParams.text
+    const defaultText = rawText ? decodeURIComponent(rawText) : undefined
+
+    return (
+        <SimpleCaptureForm
+            defaultText={defaultText}
+            campaignRef={searchParams.ref}
+        />
+    )
 }

--- a/src/app/bars/kept/page.tsx
+++ b/src/app/bars/kept/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+
+/**
+ * Screen B — "A seed is on the board" confirmation.
+ * Shown after captureBar() completes. Two exit paths:
+ *   - Go to garden (vault/list)
+ *   - Tune now → open the Tune screen for this BAR
+ */
+
+interface KeptPageProps {
+    searchParams: Promise<{
+        barId?: string
+        dest?: 'hand' | 'vault'
+        title?: string
+    }>
+}
+
+export default async function KeptPage({ searchParams }: KeptPageProps) {
+    const { barId, dest, title } = await searchParams
+
+    const destinationLabel = dest === 'hand' ? 'your Hand' : 'the Vault'
+    const barTitle = title ? decodeURIComponent(title).slice(0, 80) : 'A seed'
+
+    return (
+        <div
+            className="min-h-screen flex flex-col items-center justify-center px-6 gap-8"
+            style={{ background: 'var(--bars-bg-base, #0a0908)' }}
+        >
+            {/* Glyph / ambient mark */}
+            <div
+                className="w-20 h-20 rounded-full flex items-center justify-center text-3xl"
+                style={{
+                    background: 'rgba(124,58,237,0.12)',
+                    border: '1px solid rgba(124,58,237,0.3)',
+                }}
+            >
+                🌱
+            </div>
+
+            {/* Message */}
+            <div className="text-center flex flex-col gap-2 max-w-xs">
+                <p
+                    className="text-lg font-semibold leading-snug"
+                    style={{ color: 'var(--bars-text-primary, #e8e6e0)' }}
+                >
+                    A seed is on the board
+                </p>
+                <p
+                    className="text-sm leading-relaxed"
+                    style={{ color: 'var(--bars-text-secondary, #a09e98)' }}
+                >
+                    <span style={{ color: '#c4b5fd' }}>&ldquo;{barTitle}&rdquo;</span>
+                    {' '}landed in {destinationLabel}.
+                    Tune it now to name its context, charge, and move — or come back later.
+                </p>
+            </div>
+
+            {/* CTAs */}
+            <div className="flex flex-col gap-3 w-full max-w-xs">
+                {barId && (
+                    <Link
+                        href={`/bars/${barId}/tune`}
+                        className="block w-full py-3 rounded-xl text-sm font-semibold text-center transition-all"
+                        style={{
+                            background: 'rgba(124,58,237,0.6)',
+                            border: '1px solid rgba(167,139,250,0.6)',
+                            color: '#e8e6e0',
+                        }}
+                    >
+                        Tune now →
+                    </Link>
+                )}
+                <Link
+                    href="/bars/garden"
+                    className="block w-full py-3 rounded-xl text-sm text-center transition-all"
+                    style={{
+                        background: 'rgba(255,255,255,0.04)',
+                        border: '1px solid rgba(255,255,255,0.1)',
+                        color: '#a09e98',
+                    }}
+                >
+                    Go to Garden
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/src/components/bars/SimpleCaptureForm.tsx
+++ b/src/components/bars/SimpleCaptureForm.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { captureBar } from '@/actions/capture-bar'
+import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+
+const ELEMENTS: Array<{ key: ElementKey; sigil: string; label: string }> = [
+    { key: 'fire',  sigil: '火', label: 'Fire' },
+    { key: 'water', sigil: '水', label: 'Water' },
+    { key: 'wood',  sigil: '木', label: 'Wood' },
+    { key: 'metal', sigil: '金', label: 'Metal' },
+    { key: 'earth', sigil: '土', label: 'Earth' },
+]
+
+interface SimpleCaptureFormProps {
+    defaultText?: string
+    campaignRef?: string
+}
+
+export function SimpleCaptureForm({ defaultText = '', campaignRef }: SimpleCaptureFormProps) {
+    const router = useRouter()
+    const [isPending, startTransition] = useTransition()
+
+    const [content, setContent] = useState(defaultText)
+    const [element, setElement] = useState<ElementKey | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    function handleKeep() {
+        const trimmed = content.trim()
+        if (!trimmed) {
+            setError('Add a line to capture')
+            return
+        }
+        setError(null)
+        startTransition(async () => {
+            const result = await captureBar({
+                content: trimmed,
+                destination: 'vault',
+            })
+            if ('error' in result) {
+                setError(result.error)
+                return
+            }
+            const barId = result.barId
+            const titleParam = encodeURIComponent(trimmed.split('\n')[0].slice(0, 60))
+            router.push(`/bars/kept?barId=${barId}&dest=vault&title=${titleParam}`)
+        })
+    }
+
+    return (
+        <div
+            className="min-h-screen flex flex-col"
+            style={{ background: 'var(--bars-bg-base, #0a0908)' }}
+        >
+            {/* Top chrome */}
+            <div className="flex items-center gap-3 px-4 pt-5 pb-3">
+                <button
+                    onClick={() => router.back()}
+                    className="text-sm"
+                    style={{ color: 'var(--bars-text-secondary, #a09e98)' }}
+                >
+                    ← Back
+                </button>
+                <span
+                    className="text-sm font-medium"
+                    style={{ color: 'var(--bars-text-primary, #e8e6e0)' }}
+                >
+                    Capture a BAR
+                </span>
+            </div>
+
+            <div className="flex flex-col gap-5 px-4 flex-1 pb-32">
+
+                {/* Main textarea */}
+                <div
+                    className="rounded-xl overflow-hidden"
+                    style={{
+                        background: 'rgba(255,255,255,0.03)',
+                        border: element
+                            ? `1px solid ${ELEMENT_TOKENS[element].cssVarColor}55`
+                            : '1px solid rgba(255,255,255,0.08)',
+                        transition: 'border-color 0.2s',
+                    }}
+                >
+                    <textarea
+                        value={content}
+                        onChange={(e) => { setContent(e.target.value); setError(null) }}
+                        placeholder="What happened? What are you noticing? What wants to move?"
+                        rows={7}
+                        className="w-full px-4 py-4 text-sm leading-relaxed resize-none outline-none bg-transparent"
+                        style={{ color: '#e8e6e0' }}
+                        autoFocus
+                    />
+                </div>
+
+                {/* Element tint (optional) */}
+                <div>
+                    <p
+                        className="text-xs uppercase tracking-widest mb-2"
+                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                    >
+                        Field tint — optional
+                    </p>
+                    <div className="flex gap-2">
+                        {ELEMENTS.map(({ key, sigil, label }) => {
+                            const token = ELEMENT_TOKENS[key]
+                            const active = element === key
+                            return (
+                                <button
+                                    key={key}
+                                    onClick={() => setElement(active ? null : key)}
+                                    className="flex flex-col items-center gap-1 flex-1 py-2 rounded-lg transition-all duration-150"
+                                    title={label}
+                                    style={{
+                                        background: active ? token.cssVarColor + '22' : 'rgba(255,255,255,0.04)',
+                                        border: `1px solid ${active ? token.cssVarColor : 'rgba(255,255,255,0.08)'}`,
+                                    }}
+                                >
+                                    <span className="text-lg">{sigil}</span>
+                                    <span
+                                        className="text-[10px]"
+                                        style={{ color: active ? token.cssVarColor : '#6b6965' }}
+                                    >
+                                        {label}
+                                    </span>
+                                </button>
+                            )
+                        })}
+                    </div>
+                </div>
+
+                {campaignRef && (
+                    <div
+                        className="flex items-center gap-2 px-3 py-2 rounded-lg"
+                        style={{
+                            background: 'rgba(124,58,237,0.1)',
+                            border: '1px solid rgba(124,58,237,0.25)',
+                        }}
+                    >
+                        <span className="text-xs" style={{ color: '#a78bfa' }}>
+                            Campaign: {campaignRef}
+                        </span>
+                    </div>
+                )}
+
+                {error && (
+                    <p className="text-sm text-red-400">{error}</p>
+                )}
+            </div>
+
+            {/* Sticky CTAs */}
+            <div
+                className="fixed bottom-0 left-0 right-0 flex flex-col gap-2 px-4 py-4"
+                style={{
+                    background: 'linear-gradient(to top, #0a0908 80%, transparent)',
+                    borderTop: '1px solid rgba(255,255,255,0.06)',
+                }}
+            >
+                <button
+                    onClick={handleKeep}
+                    disabled={isPending || !content.trim()}
+                    className="w-full py-3 rounded-xl text-sm font-semibold transition-all duration-150"
+                    style={{
+                        background: content.trim() ? 'rgba(124,58,237,0.6)' : 'rgba(255,255,255,0.06)',
+                        border: content.trim()
+                            ? '1px solid rgba(167,139,250,0.6)'
+                            : '1px solid rgba(255,255,255,0.08)',
+                        color: content.trim() ? '#e8e6e0' : '#6b6965',
+                        opacity: isPending ? 0.6 : 1,
+                    }}
+                >
+                    {isPending ? 'Keeping…' : 'Keep · tune later'}
+                </button>
+                <button
+                    onClick={() => router.push('/bars/capture')}
+                    className="w-full py-2.5 rounded-xl text-sm text-center"
+                    style={{
+                        background: 'transparent',
+                        color: '#6b6965',
+                    }}
+                >
+                    Open canvas →
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/bars/TuneBarClient.tsx
+++ b/src/components/bars/TuneBarClient.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { CultivationCard } from '@/components/ui/CultivationCard'
+import { ELEMENT_TOKENS, type ElementKey, type CardAltitude } from '@/lib/ui/card-tokens'
+import type { AlchemyAltitude } from '@/lib/alchemy/types'
+import type { MaturityPhase } from '@/lib/bar-seed-metabolization/types'
+import { tuneBar } from '@/actions/bars'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type MoveType = 'wakeUp' | 'openUp' | 'cleanUp' | 'growUp' | 'showUp'
+
+interface TuneBarClientProps {
+    barId: string
+    title: string
+    description: string
+    initialNation: string | null
+    initialIntensity: string | null
+    initialAlchemyTag: string | null
+    initialMoveType: string | null
+    initialMaturity: MaturityPhase
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ELEMENTS: Array<{ key: ElementKey; label: string }> = [
+    { key: 'fire',   label: '火 Fire' },
+    { key: 'water',  label: '水 Water' },
+    { key: 'wood',   label: '木 Wood' },
+    { key: 'metal',  label: '金 Metal' },
+    { key: 'earth',  label: '土 Earth' },
+]
+
+const ALTITUDES: Array<{ key: CardAltitude; label: string; hint: string }> = [
+    { key: 'dissatisfied', label: 'Dissatisfied', hint: 'Something still wrong' },
+    { key: 'neutral',      label: 'Neutral',      hint: 'It is what it is' },
+    { key: 'satisfied',    label: 'Satisfied',    hint: 'This feels right' },
+]
+
+const MOVES: Array<{ key: MoveType; label: string; hint: string }> = [
+    { key: 'wakeUp',  label: 'Wake Up',  hint: 'Become aware' },
+    { key: 'openUp',  label: 'Open Up',  hint: 'Allow it in' },
+    { key: 'cleanUp', label: 'Clean Up', hint: 'Remove the obstacle' },
+    { key: 'growUp',  label: 'Grow Up',  hint: 'Develop capacity' },
+    { key: 'showUp',  label: 'Show Up',  hint: 'Act in the world' },
+]
+
+const MATURITY_LABELS: Record<MaturityPhase, string> = {
+    captured:        'Captured',
+    context_named:   'Context Named',
+    elaborated:      'Elaborated',
+    shared_or_acted: 'Ready',
+    integrated:      'Integrated',
+}
+
+const MATURITY_ORDER: MaturityPhase[] = [
+    'captured', 'context_named', 'elaborated', 'shared_or_acted', 'integrated',
+]
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function deriveProjectedMaturity(
+    nation: string | null,
+    intensity: string | null,
+    alchemyTag: string | null,
+    moveType: string | null,
+    current: MaturityPhase,
+): MaturityPhase {
+    let target: MaturityPhase = 'captured'
+    if (nation) target = 'context_named'
+    if (intensity && alchemyTag) target = 'elaborated'
+    if (moveType) target = 'shared_or_acted'
+    const cIdx = MATURITY_ORDER.indexOf(current)
+    const tIdx = MATURITY_ORDER.indexOf(target)
+    return MATURITY_ORDER[Math.max(cIdx, tIdx)]
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TuneBarClient({
+    barId,
+    title,
+    description,
+    initialNation,
+    initialIntensity,
+    initialAlchemyTag,
+    initialMoveType,
+    initialMaturity,
+}: TuneBarClientProps) {
+    const router = useRouter()
+    const [isPending, startTransition] = useTransition()
+
+    const [nation, setNation] = useState<ElementKey | null>(
+        initialNation as ElementKey | null,
+    )
+    const [intensity, setIntensity] = useState<CardAltitude | null>(
+        initialIntensity as CardAltitude | null,
+    )
+    const [alchemyTag, setAlchemyTag] = useState(initialAlchemyTag ?? '')
+    const [moveType, setMoveType] = useState<MoveType | null>(
+        initialMoveType as MoveType | null,
+    )
+    const [maturity, setMaturity] = useState<MaturityPhase>(initialMaturity)
+    const [error, setError] = useState<string | null>(null)
+    const [saved, setSaved] = useState(false)
+
+    const projectedMaturity = deriveProjectedMaturity(
+        nation, intensity, alchemyTag.trim() || null, moveType, maturity,
+    )
+    const projectedIdx = MATURITY_ORDER.indexOf(projectedMaturity)
+    const canGraduate = projectedMaturity === 'shared_or_acted' || projectedMaturity === 'integrated'
+
+    function handleSave() {
+        setError(null)
+        setSaved(false)
+        startTransition(async () => {
+            const result = await tuneBar(barId, {
+                nation: nation ?? undefined,
+                intensity: intensity ?? undefined,
+                emotionalAlchemyTag: alchemyTag.trim() || undefined,
+                moveType: moveType ?? undefined,
+            })
+            if ('error' in result) {
+                setError(result.error)
+            } else {
+                setMaturity(result.maturity)
+                setSaved(true)
+            }
+        })
+    }
+
+    function handleGraduate() {
+        router.push(`/bars/${barId}`)
+    }
+
+    return (
+        <div
+            className="min-h-screen flex flex-col"
+            style={{ background: 'var(--bars-bg-base, #0a0908)' }}
+        >
+            {/* Top chrome */}
+            <div className="flex items-center gap-3 px-4 pt-5 pb-3">
+                <button
+                    onClick={() => router.back()}
+                    className="text-sm"
+                    style={{ color: 'var(--bars-text-secondary, #a09e98)' }}
+                >
+                    ← Back
+                </button>
+                <span
+                    className="text-sm font-medium"
+                    style={{ color: 'var(--bars-text-primary, #e8e6e0)' }}
+                >
+                    Tune BAR
+                </span>
+            </div>
+
+            <div className="flex flex-col gap-6 px-4 pb-24 flex-1">
+
+                {/* Live card preview */}
+                <section>
+                    <CultivationCard
+                        element={nation ?? undefined}
+                        altitude={(intensity ?? 'neutral') as AlchemyAltitude}
+                        stage="seed"
+                        animated
+                        floating={!!nation}
+                        className="w-full max-w-sm mx-auto"
+                        aria-label={`${title} — ${nation ?? 'no element'} element card`}
+                    >
+                        <div className="p-4 flex flex-col gap-2">
+                            <p
+                                className="text-sm font-semibold leading-snug line-clamp-2"
+                                style={{ color: 'var(--bars-text-primary, #e8e6e0)' }}
+                            >
+                                {title}
+                            </p>
+                            <p
+                                className="text-xs leading-relaxed line-clamp-3"
+                                style={{ color: 'var(--bars-text-secondary, #a09e98)' }}
+                            >
+                                {description}
+                            </p>
+                            {alchemyTag && (
+                                <span
+                                    className="text-xs px-2 py-0.5 rounded-full self-start mt-1"
+                                    style={{
+                                        background: 'rgba(124,58,237,0.15)',
+                                        color: '#a78bfa',
+                                        border: '1px solid rgba(124,58,237,0.3)',
+                                    }}
+                                >
+                                    {alchemyTag}
+                                </span>
+                            )}
+                        </div>
+                    </CultivationCard>
+                </section>
+
+                {/* Maturity ladder */}
+                <section>
+                    <p
+                        className="text-xs uppercase tracking-widest mb-3"
+                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                    >
+                        Maturity
+                    </p>
+                    <div className="flex gap-1">
+                        {MATURITY_ORDER.map((phase, i) => (
+                            <div
+                                key={phase}
+                                className="flex-1 h-1.5 rounded-full transition-all duration-300"
+                                style={{
+                                    background: i <= projectedIdx
+                                        ? 'var(--bars-liminal, #7c3aed)'
+                                        : 'rgba(255,255,255,0.08)',
+                                }}
+                            />
+                        ))}
+                    </div>
+                    <p
+                        className="text-xs mt-2"
+                        style={{ color: 'var(--bars-text-secondary, #a09e98)' }}
+                    >
+                        {MATURITY_LABELS[projectedMaturity]}
+                        {projectedMaturity !== maturity && (
+                            <span style={{ color: '#a78bfa' }}> → will advance on save</span>
+                        )}
+                    </p>
+                </section>
+
+                {/* Channel 1: Element */}
+                <section>
+                    <p
+                        className="text-xs uppercase tracking-widest mb-3"
+                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                    >
+                        Element
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {ELEMENTS.map(({ key, label }) => {
+                            const token = ELEMENT_TOKENS[key]
+                            const active = nation === key
+                            return (
+                                <button
+                                    key={key}
+                                    onClick={() => setNation(active ? null : key)}
+                                    className="px-3 py-1.5 rounded-full text-sm transition-all duration-150"
+                                    style={{
+                                        background: active ? token.cssVarColor + '33' : 'rgba(255,255,255,0.05)',
+                                        border: `1px solid ${active ? token.cssVarColor : 'rgba(255,255,255,0.1)'}`,
+                                        color: active ? token.cssVarColor : '#a09e98',
+                                    }}
+                                >
+                                    {label}
+                                </button>
+                            )
+                        })}
+                    </div>
+                </section>
+
+                {/* Channel 2: Altitude */}
+                <section>
+                    <p
+                        className="text-xs uppercase tracking-widest mb-3"
+                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                    >
+                        Charge
+                    </p>
+                    <div className="flex gap-2 mb-3">
+                        {ALTITUDES.map(({ key, label }) => {
+                            const active = intensity === key
+                            return (
+                                <button
+                                    key={key}
+                                    onClick={() => setIntensity(active ? null : key)}
+                                    className="flex-1 py-2 rounded-lg text-xs transition-all duration-150"
+                                    style={{
+                                        background: active ? 'rgba(124,58,237,0.2)' : 'rgba(255,255,255,0.05)',
+                                        border: `1px solid ${active ? 'rgba(124,58,237,0.6)' : 'rgba(255,255,255,0.1)'}`,
+                                        color: active ? '#c4b5fd' : '#a09e98',
+                                    }}
+                                >
+                                    {label}
+                                </button>
+                            )
+                        })}
+                    </div>
+                    <input
+                        type="text"
+                        placeholder="Name the charge (e.g. frustration, hope, grief)"
+                        value={alchemyTag}
+                        onChange={(e) => setAlchemyTag(e.target.value)}
+                        maxLength={60}
+                        className="w-full px-3 py-2.5 rounded-lg text-sm outline-none transition-colors"
+                        style={{
+                            background: 'rgba(255,255,255,0.04)',
+                            border: alchemyTag
+                                ? '1px solid rgba(124,58,237,0.4)'
+                                : '1px solid rgba(255,255,255,0.1)',
+                            color: '#e8e6e0',
+                        }}
+                    />
+                </section>
+
+                {/* Channel 3: Move */}
+                <section>
+                    <p
+                        className="text-xs uppercase tracking-widest mb-3"
+                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                    >
+                        Move
+                    </p>
+                    <div className="flex flex-col gap-2">
+                        {MOVES.map(({ key, label, hint }) => {
+                            const active = moveType === key
+                            return (
+                                <button
+                                    key={key}
+                                    onClick={() => setMoveType(active ? null : key)}
+                                    className="flex items-center justify-between px-4 py-3 rounded-lg text-sm transition-all duration-150 text-left"
+                                    style={{
+                                        background: active ? 'rgba(124,58,237,0.2)' : 'rgba(255,255,255,0.04)',
+                                        border: `1px solid ${active ? 'rgba(124,58,237,0.6)' : 'rgba(255,255,255,0.08)'}`,
+                                        color: active ? '#c4b5fd' : '#a09e98',
+                                    }}
+                                >
+                                    <span style={{ color: active ? '#e8e6e0' : '#a09e98' }}>{label}</span>
+                                    <span className="text-xs" style={{ color: '#6b6965' }}>{hint}</span>
+                                </button>
+                            )
+                        })}
+                    </div>
+                </section>
+
+                {error && (
+                    <p className="text-sm text-red-400 text-center">{error}</p>
+                )}
+            </div>
+
+            {/* Sticky bottom CTAs */}
+            <div
+                className="fixed bottom-0 left-0 right-0 flex gap-3 px-4 py-4"
+                style={{
+                    background: 'linear-gradient(to top, #0a0908 80%, transparent)',
+                    borderTop: '1px solid rgba(255,255,255,0.06)',
+                }}
+            >
+                <button
+                    onClick={handleSave}
+                    disabled={isPending}
+                    className="flex-1 py-3 rounded-xl text-sm font-medium transition-all duration-150"
+                    style={{
+                        background: 'rgba(124,58,237,0.25)',
+                        border: '1px solid rgba(124,58,237,0.5)',
+                        color: saved ? '#86efac' : '#c4b5fd',
+                        opacity: isPending ? 0.6 : 1,
+                    }}
+                >
+                    {isPending ? 'Saving…' : saved ? 'Saved ✓' : 'Save tune'}
+                </button>
+                {canGraduate && (
+                    <button
+                        onClick={handleGraduate}
+                        className="flex-1 py-3 rounded-xl text-sm font-semibold transition-all duration-150"
+                        style={{
+                            background: 'rgba(124,58,237,0.6)',
+                            border: '1px solid rgba(167,139,250,0.6)',
+                            color: '#e8e6e0',
+                        }}
+                    >
+                        Open the BAR →
+                    </button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/lib/hand-service.ts
+++ b/src/lib/hand-service.ts
@@ -1,0 +1,139 @@
+/**
+ * Hand DB operations — no 'use server', safe to import from any server code.
+ *
+ * 'use server' files cannot cross-import each other in Turbopack.
+ * This module holds the shared constants, types, and DB helpers so both
+ * actions/hand.ts (the public server-action API) and other server actions
+ * (capture-bar, daily-charge) can use them without a cross-boundary import.
+ */
+
+import { dbBase } from '@/lib/db'
+
+export const HAND_SIZE = 6
+
+export type HandSlotBar = {
+    id: string
+    title: string
+    type: string
+    moveType: string | null
+}
+
+export type HandSlotDTO = {
+    slotIndex: number // 0–5
+    barId: string | null
+    isCarrying: boolean
+    bar: HandSlotBar | null
+}
+
+export type HandContents = {
+    slots: HandSlotDTO[] // always length HAND_SIZE, ordered by slotIndex
+    filledCount: number
+    size: number
+    carryingBarId: string | null
+}
+
+export type OverflowContext = {
+    newBarId: string
+    newBarTitle: string
+    currentHand: Array<{ slotIndex: number; barId: string; title: string; type: string }>
+}
+
+/** Read the player's current hand from the DB. */
+export async function readHandDb(playerId: string): Promise<HandContents> {
+    const rows = await dbBase.handSlot.findMany({
+        where: { playerId },
+        orderBy: { slotIndex: 'asc' },
+        include: {
+            bar: { select: { id: true, title: true, type: true, moveType: true } },
+        },
+    })
+
+    const bySlot = new Map<number, (typeof rows)[number]>()
+    for (const r of rows) bySlot.set(r.slotIndex, r)
+
+    const slots: HandSlotDTO[] = []
+    for (let i = 0; i < HAND_SIZE; i++) {
+        const r = bySlot.get(i)
+        slots.push({
+            slotIndex: i,
+            barId: r?.barId ?? null,
+            isCarrying: r?.isCarrying ?? false,
+            bar: r?.bar
+                ? { id: r.bar.id, title: r.bar.title, type: r.bar.type, moveType: r.bar.moveType }
+                : null,
+        })
+    }
+
+    const carrying = rows.find((r) => r.isCarrying && r.barId)
+    return {
+        slots,
+        filledCount: slots.filter((s) => s.barId).length,
+        size: HAND_SIZE,
+        carryingBarId: carrying?.barId ?? null,
+    }
+}
+
+/**
+ * Add a BAR to the hand for a known player. Auto-fills the lowest empty slot.
+ * Returns an OverflowContext when the hand is full.
+ */
+export async function addBarToHandForPlayer(
+    playerId: string,
+    barId: string,
+): Promise<
+    | { success: true; hand: HandContents }
+    | { success: false; overflow: OverflowContext }
+    | { error: string }
+> {
+    const bar = await dbBase.customBar.findFirst({
+        where: { id: barId, creatorId: playerId, status: 'active', archivedAt: null },
+        select: { id: true, title: true, type: true },
+    })
+    if (!bar) return { error: 'BAR not found or not yours' }
+
+    const slots = await dbBase.handSlot.findMany({ where: { playerId } })
+
+    if (slots.some((s) => s.barId === barId)) {
+        return { success: true, hand: await readHandDb(playerId) }
+    }
+
+    const usedIndexes = new Set(slots.filter((s) => s.barId).map((s) => s.slotIndex))
+    let emptyIndex = -1
+    for (let i = 0; i < HAND_SIZE; i++) {
+        if (!usedIndexes.has(i)) {
+            emptyIndex = i
+            break
+        }
+    }
+
+    if (emptyIndex === -1) {
+        const filled = await dbBase.handSlot.findMany({
+            where: { playerId, barId: { not: null } },
+            orderBy: { slotIndex: 'asc' },
+            include: { bar: { select: { id: true, title: true, type: true } } },
+        })
+        return {
+            success: false,
+            overflow: {
+                newBarId: bar.id,
+                newBarTitle: bar.title,
+                currentHand: filled
+                    .filter((s) => s.bar)
+                    .map((s) => ({
+                        slotIndex: s.slotIndex,
+                        barId: s.bar!.id,
+                        title: s.bar!.title,
+                        type: s.bar!.type,
+                    })),
+            },
+        }
+    }
+
+    await dbBase.handSlot.upsert({
+        where: { playerId_slotIndex: { playerId, slotIndex: emptyIndex } },
+        create: { playerId, slotIndex: emptyIndex, barId: bar.id },
+        update: { barId: bar.id, isCarrying: false },
+    })
+
+    return { success: true, hand: await readHandDb(playerId) }
+}


### PR DESCRIPTION
## Summary

Implements the three-screen intake flow for capturing and tuning BARs:
1. **Capture** (Screen A) — Simple text entry with optional element tint
2. **Kept** (Screen B) — Confirmation screen after capture
3. **Tune** (Screen C) — Three-channel editor for element, altitude/charge, and move

This completes the low-friction path from raw emotional capture through structured metabolization.

## Key Changes

- **`SimpleCaptureForm` component** — Minimal text capture UI with optional element field tint. Routes to `/bars/kept` confirmation after `captureBar()` succeeds.

- **`TuneBarClient` component** — Full three-channel editor with:
  - Live `CultivationCard` preview (element + altitude)
  - Maturity ladder showing progression (captured → context_named → elaborated → shared_or_acted → integrated)
  - Element selector (5 elements)
  - Altitude/Charge section (dissatisfied/neutral/satisfied + named emotion tag)
  - Move selector (wakeUp/openUp/cleanUp/growUp/showUp)
  - Sticky save/graduate CTAs with state feedback

- **`tuneBar()` server action** — Validates and persists channel updates:
  - Merges patch into current state with type validation
  - Derives target maturity from channel completion (nation → intensity+tag → moveType)
  - Advances maturity monotonically (never backward)
  - Revalidates related paths

- **`/bars/kept` page** — Confirmation screen after capture, with links to tune or go to garden.

- **`/bars/[id]/tune` page** — Server-rendered wrapper that loads bar data and hydrates `TuneBarClient`.

- **`/bars/create` refactor** — Changed from redirect to `SimpleCaptureForm` with optional prefill and campaign ref support.

## Implementation Details

- Maturity advancement is **monotonic**: `Math.max(currentIdx, targetIdx)` ensures progression never reverses
- Channel completion rules:
  - Nation set → `context_named`
  - Intensity + emotionalAlchemyTag → `elaborated`
  - MoveType set → `shared_or_acted`
- All form inputs validate against known enums (ELEMENT_KEYS, VALID_ALTITUDES, VALID_MOVE_TYPES)
- UI uses CSS custom properties for theming (--bars-bg-base, --bars-text-primary, etc.)
- Sticky bottom CTAs with gradient fade-in; "Open the BAR" button only shows when maturity ≥ shared_or_acted

https://claude.ai/code/session_01Uqdj1N2WjvVRQkbsB4wft1