### PR TITLE
Canvas gestures: fix slider, remove accidental editor open, pinch+rotate

### DIFF
--- a/.specify/specs/canvas-bar-display/CLAUDE_DESIGN_PROMPT.md
+++ b/.specify/specs/canvas-bar-display/CLAUDE_DESIGN_PROMPT.md
@@ -1,0 +1,94 @@
+# Paste this into Claude Design
+
+---
+
+Design a mobile UI for "BARs Engine" — a dark, mystical journaling app where players capture emotional moments as draggable stickers on a phone-frame canvas (like Instagram Stories). The app has a Wuxing (five-element) theme: fire, water, wood, metal, earth — each with its own gem color.
+
+**Design system:**
+- Background: `#0a0908` (warm near-black)
+- Surface: `#14151a`
+- Text: `#e8e6e0` / muted `rgba(232,226,218,0.55)`
+- Accent: `#7c3aed` (liminal purple)
+- Fonts: Jost (headings, 700), Nunito (body), Space Mono (metadata/mono)
+- Element gem colors: fire `#e05c2e` · water `#3b82c4` · wood `#2ecc71` · metal `#c0c0c0` · earth `#c8a84b`
+
+---
+
+## What to design
+
+### Screen 1A — BAR Detail Page (canvas BAR, default view)
+
+A player created a BAR on the canvas with:
+- Element: **water** (gem `#3b82c4`, subtle blue top glow)
+- Charge level: **4 out of 5** (label: "hard to shake")
+- One text sticker: *"I went quiet in the meeting again."* (Nunito 700, 27px, water blue, rotated -2°, positioned center-upper canvas)
+- One photo sticker (small polaroid-style card, slightly rotated, lower canvas)
+- Intent: "reflection"
+
+Show the full mobile detail page (390px wide), scrollable:
+
+**Top section — Canvas preview block:**
+- Phone-frame shape (border-radius 38px), 360px wide, centered, aspect ratio 392:812
+- Field background: radial blue glow at top (water element), subtle diagonal grid lines, dark gradient, vignette (stronger at bottom)
+- Text sticker rendered in position (water blue, Nunito 700)
+- Photo sticker rendered in position (polaroid-style, slightly rotated)
+- No UI chrome (no buttons, no status bar, no tool rail)
+- Feels like a "living polaroid" — not a flat screenshot
+
+**Below the canvas:**
+- Element + charge row: ◇ water · [5 dots, 4 filled in water blue] · "hard to shake" (Space Mono 10px, muted)
+- Intent line: `intent · reflection` (Space Mono 9px, very muted)
+- Thin divider
+- "Face / Back" tab strip (Nunito, small, muted tabs)
+- Face tab content: if the BAR has a written description it shows here; if not, shows a soft prompt like "Add a note to this moment →" (muted, tappable)
+- Action buttons row: "Tune →" (purple filled), "Share" (ghost), "Send" (ghost)
+- Share history section (collapsible, Space Mono labels)
+
+---
+
+### Screen 1B — BAR Detail Page (Back tab open)
+
+Same page, Back tab selected. Shows:
+- Canvas preview still visible at top (same frozen state)
+- Below: editable description textarea (dark input, placeholder "What does this moment mean to you?")
+- Tags row: pill inputs, placeholder "add tag…"
+- Save / Cancel buttons
+
+---
+
+### Screen 2 — BAR Feed Cards (side by side comparison)
+
+Show two feed cards at full width (390px), stacked:
+
+**Card A — Canvas-captured BAR (water element):**
+- Tinted background using water element frame color `#1e3a5f` at low opacity (no photo)
+- OR: if a photo exists, show the photo as card background
+- Text teaser: *"I went quiet in the meeting again."* (derived from first text sticker)
+- Small element badge: ◇ in water blue, top-right corner
+- Charge dots: 4 of 5 filled, water blue, bottom-left
+- Creator name + timestamp, Space Mono muted
+
+**Card B — Old-format BAR (no element, no canvas):**
+- Plain dark surface card
+- Text teaser from description field
+- No element badge
+- Same creator/timestamp treatment
+
+Make the two cards feel like the same family but clearly distinguishable. The canvas card should feel more alive.
+
+---
+
+### Screen 3 — Edge case: canvas BAR with no text sticker
+
+A canvas BAR that has only a photo sticker and no text. What does the feed card look like with no text to derive?
+
+Options to explore:
+- Show a placeholder like "— a moment, captured" (Space Mono, italic-style, very muted)
+- Or show just the element sigil large and centered with the element glow
+- Or show the photo as background with just the element badge overlay
+
+Design the best option.
+
+---
+
+**Tone:** Dark, ritual, contemplative. Like a spellbook crossed with a journaling app. The moments feel weighted and sacred, not casual. Subtle glows, not neon. The canvas preview should feel like looking through glass at a preserved moment.

--- a/.specify/specs/canvas-bar-display/design-brief.md
+++ b/.specify/specs/canvas-bar-display/design-brief.md
@@ -1,0 +1,133 @@
+# Claude Design Brief: Canvas BAR Display
+
+## Context
+
+BARs Engine is a mobile-first web app where players capture emotionally charged moments ("BARs") as draggable stickers on a phone-frame canvas — like an Instagram Stories composer. The canvas has a dark aesthetic with Wuxing element theming (fire/water/wood/metal/earth), each element having a distinct gem color and glow.
+
+We need to design two screens:
+1. **BAR Detail Page** — how a canvas-captured BAR looks when you open it
+2. **BAR Feed Card** — how it appears in the list/feed
+
+---
+
+## Design System
+
+**Background**: `#0a0908` (near-black, warm)
+**Surface**: `#14151a`
+**Text primary**: `#e8e6e0`
+**Text muted**: `rgba(232,226,218,0.55)`
+**Accent (liminal purple)**: `#7c3aed`
+
+**Fonts**:
+- Headings: Jost 700
+- Body/labels: Nunito
+- Metadata/mono: Space Mono
+
+**Element colors (Wuxing)**:
+| Element | Gem | Frame | Glow |
+|---------|-----|-------|------|
+| fire    | `#e05c2e` | `#7a2a12` | `rgba(224,92,46,0.55)` |
+| water   | `#3b82c4` | `#1e3a5f` | `rgba(59,130,196,0.55)` |
+| wood    | `#2ecc71` | `#1a5c35` | `rgba(46,204,113,0.55)` |
+| metal   | `#c0c0c0` | `#4a4a4a` | `rgba(192,192,192,0.45)` |
+| earth   | `#c8a84b` | `#5c4a1e` | `rgba(200,168,75,0.5)` |
+
+---
+
+## The Canvas (for reference)
+
+The existing capture canvas looks like this:
+- Phone frame: 392×812px logical, `border-radius: 38px`, dark background
+- Field background: subtle radial glow in the active element color at the top, grid lines, dark gradient
+- Vignette: `linear-gradient(180deg, rgba(6,7,10,0.55), transparent 20%, transparent 60%, rgba(6,7,10,0.94))`
+- Text stickers: Nunito 700, colored by element, `text-shadow: 0 2px 16px rgba(0,0,0,0.85)`, positioned absolutely
+- Photo stickers: rounded cards (~118×132px) with box-shadow, slightly rotated
+- Element sigils: ◆(fire) ◇(water) ◇(wood) ◇(metal) ◇(earth) — each has a distinct glyph
+
+---
+
+## Screen 1: BAR Detail Page
+
+### Current state (problem)
+The detail page at `/bars/{id}` currently shows:
+- Creator name + date
+- Face/Back tab system: Face tab = photo (if any), Back tab = description text + tags
+- Share history list
+- Action buttons (Share, Send, Grow)
+
+For canvas-captured BARs, the description is **empty**, so players see a blank shell.
+
+### What needs designing
+
+Show a **read-only canvas preview** (frozen whiteboard) as the hero of the detail page. Design the layout for:
+
+**A. The canvas preview block**
+- A scaled-down version of the canvas (phone-frame shape, same 392:812 aspect ratio)
+- Max width 360px on mobile, centered
+- Shows the frozen stickers exactly where they were placed
+- The field background glow pulses very subtly (or is static — design call)
+- No UI chrome (no tool rail, no bottom buttons, no status bar)
+- Should feel like a "polaroid" of the captured moment
+
+**B. Element + charge row** (below the canvas)
+- Left: element sigil (e.g. ◇) + element name (e.g. "water"), colored with element gem color, subtle glow
+- Right: charge level — 5 dots (●○○○○ style), filled dots colored with element gem, label like "hard to shake" (charge 4 label)
+
+**C. Intent/story line** (if present)
+- The player may have set an intent like "reflection" or "gift"
+- Shows below the element row in Space Mono 10px muted, like: `intent · reflection`
+
+**D. The rest of the page below**
+- The existing face/back tab content (description, tags) stays below — now used for players who want to add written notes to their canvas capture
+- Share history, action buttons — unchanged
+
+**Design questions to resolve:**
+1. Should the canvas preview crop to just the sticker zone (removing the black edges), or show the full phone frame with rounded corners as a decorative element?
+2. Do the element badge and charge dots live as an overlay at the bottom of the canvas frame (like a caption strip), or as a separate row beneath it?
+3. Does the detail page scroll (canvas preview is above the fold, rest scrolls), or is it a fixed layout?
+
+---
+
+## Screen 2: BAR Feed Card
+
+### Current state (problem)
+The feed at `/bars` shows BAR cards with:
+- An image (if the BAR has a photo attachment)
+- The first line of the `description` field as a text teaser
+
+Canvas-captured BARs have no `description`, so the card shows blank or missing text.
+
+### What needs designing
+
+**A. Canvas BAR card variant**
+The feed card for a canvas-captured BAR should show:
+- The first text sticker content as the teaser (e.g. "I went quiet in the meeting again.")
+- Element sigil in a small corner badge (top-right or bottom-left), colored with element gem
+- If the BAR has a photo sticker, use that as the card image (same as before)
+- If no photo, use the element color as a subtle tinted background (the element frame color at low opacity)
+
+**B. Comparison: old-format card vs canvas card**
+Design both side-by-side so we can see the family resemblance and differences.
+
+**Design questions to resolve:**
+1. Should canvas cards have a distinct visual marker so players know it was canvas-captured (vs. form-entered)? Or should they look identical?
+2. Should the element color bleed into the card background when there's no image?
+3. Where does the element sigil badge live — overlay on the card, or in the text metadata row?
+
+---
+
+## Constraints
+
+- Mobile-first: primary viewport is 390px wide
+- Dark mode only
+- The canvas preview must feel like a **living artifact** — not just a screenshot. Subtle element glow, the vignette overlay. It should feel like the moment is still present.
+- Old-format BARs must render identically to today — no regression
+
+---
+
+## Deliverables Requested
+
+1. **Detail page mockup** — mobile, showing a canvas BAR with a water-element text sticker ("I went quiet in the meeting again.") and charge level 4. Show the full page scroll.
+2. **Detail page mockup** — same page but with the face/back tab open to "Back" (showing description field, now editable/addable after the canvas).
+3. **Feed card pair** — canvas BAR card next to an old-format BAR card, same width, showing the visual difference and family resemblance.
+4. **Edge case: no text sticker** — a canvas BAR that only has a photo sticker. What does the feed card look like?

--- a/.specify/specs/canvas-bar-display/plan.md
+++ b/.specify/specs/canvas-bar-display/plan.md
@@ -1,0 +1,175 @@
+# Plan: Canvas BAR Display
+
+## Dependency order
+
+Phase 1 (data) must land first — nothing else works without the fields. Phase 2 (photo URL fix) is independent of Phase 3 (rendering) but should ship together so the read-only view shows real photos from day one. Phase 3 (renderer + detail + feed) is the visible payoff.
+
+---
+
+## Phase 1: Data layer
+
+### 1.1 Add `canvasLayout`, `nation`, `intensity` to `getBarDetail`
+
+In `src/actions/bars.ts`, find the `getBarDetail` function's Prisma query. Add the three fields to the select/include:
+
+```ts
+canvasLayout: true,
+nation: true,
+intensity: true,
+```
+
+The return type of `getBarDetail` will now include these fields. Update any TypeScript types that wrap the return value.
+
+### 1.2 New server action: `updateCanvasPhotoUrls`
+
+```ts
+export async function updateCanvasPhotoUrls(
+  barId: string,
+  updates: { itemId: string; url: string }[]
+): Promise<void> {
+  const playerId = await getPlayerId()
+  if (!playerId) return
+
+  const bar = await prisma.customBar.findFirst({
+    where: { id: barId, creatorId: playerId },
+    select: { canvasLayout: true },
+  })
+  if (!bar?.canvasLayout) return
+
+  const items = JSON.parse(bar.canvasLayout) as CanvasItem[]
+  const patched = items.map((item) => {
+    const update = updates.find((u) => u.itemId === item.id)
+    return update ? { ...item, text: update.url } : item
+  })
+
+  await prisma.customBar.update({
+    where: { id: barId },
+    data: { canvasLayout: JSON.stringify(patched) },
+  })
+}
+```
+
+### 1.3 New helper: `deriveCanvasPreviewText`
+
+```ts
+// src/lib/canvas-utils.ts
+import type { CanvasItem } from '@/actions/bars'
+
+export function deriveCanvasPreviewText(canvasLayout: string | null): string | null {
+  if (!canvasLayout) return null
+  try {
+    const items: CanvasItem[] = JSON.parse(canvasLayout)
+    const first = items.find((i) => i.type === 'text' && i.text?.trim())
+    if (!first?.text) return null
+    return first.text.trim().slice(0, 120)
+  } catch {
+    return null
+  }
+}
+```
+
+---
+
+## Phase 2: Photo URL persistence fix
+
+### 2.1 Collect upload results in `handleCapture`
+
+In `SeedCaptureWhiteboard.tsx`, `handleCapture` currently discards the return value of `uploadBarAsset`. Collect it:
+
+```ts
+const urlUpdates: { itemId: string; url: string }[] = []
+
+await Promise.allSettled(
+  mediaItems.map(async (item) => {
+    if (item.type === 'photo') {
+      const file = photoFilesRef.current.get(item.id)
+      if (!file) return
+      const { url } = await uploadBarAsset(file, { barId, side: 'front' })
+      urlUpdates.push({ itemId: item.id, url })
+    } else if (item.type === 'voice') {
+      const blob = audioFilesRef.current.get(item.id)
+      if (!blob) return
+      const file = new File([blob], 'voice-memo.webm', { type: blob.type })
+      const { url } = await uploadBarAsset(file, { barId, side: 'front' })
+      urlUpdates.push({ itemId: item.id, url })
+    }
+  })
+)
+
+if (urlUpdates.length > 0) {
+  await updateCanvasPhotoUrls(barId, urlUpdates)
+}
+```
+
+Check the return type of `uploadBarAsset` — if it doesn't return `{ url }`, adjust accordingly.
+
+---
+
+## Phase 3: Read-only renderer + integration
+
+### 3.1 `CanvasPreview` component
+
+Create `src/components/bars/CanvasPreview.tsx` as a `'use client'` component.
+
+Reuse these sub-components from `SeedCaptureWhiteboard` (extract to shared file or duplicate — duplication is fine for now):
+- `FieldBackground`
+- `Vignette`
+- `TextSticker` (with `isDragging=false`, no `onPointerDown` handler — wrap div in `pointer-events: none`)
+- Photo sticker JSX (inline, same as in BSCW but read-only)
+
+Scale logic: instead of `window.innerHeight`, use a `ResizeObserver` on a container ref to compute scale from container width:
+```ts
+const scale = containerWidth / LOGICAL_W  // capped at 1
+```
+
+The component renders at `LOGICAL_W × LOGICAL_H` logical pixels, scaled to fit container.
+
+No `TopChrome`, `ToolRail`, `BottomChrome`, `CompostNode` — this is the canvas content only.
+
+### 3.2 Detail page integration
+
+In `src/app/bars/[id]/page.tsx`:
+
+- Import `CanvasPreview` and `ELEMENT_TOKENS`
+- After `getBarDetail`, check `bar.canvasLayout`
+- When present, render above `BarFaceBackTabs`:
+
+```tsx
+{bar.canvasLayout && (
+  <div className="w-full max-w-sm mx-auto rounded-[28px] overflow-hidden">
+    <CanvasPreview
+      canvasLayout={bar.canvasLayout}
+      nation={bar.nation}
+      intensity={bar.intensity}
+    />
+  </div>
+)}
+
+{/* Element + charge badges */}
+{bar.nation && (
+  <div className="flex items-center gap-3">
+    <span>{ELEMENT_TOKENS[bar.nation as ElementKey].sigil}</span>
+    <span>{bar.nation}</span>
+    {/* charge dots from bar.intensity */}
+  </div>
+)}
+```
+
+### 3.3 Feed card fallback
+
+In `src/app/bars/page.tsx` (and any other BAR list callers):
+
+- Import `deriveCanvasPreviewText`
+- When building props for `BarCardFace`, use:
+  ```ts
+  description: bar.description || deriveCanvasPreviewText(bar.canvasLayout) || '—'
+  ```
+
+This requires `canvasLayout` to be included in the list query too. Add it to whichever Prisma query populates the bars list — select only `id, title, description, canvasLayout, assets` (don't fetch full layout for every card if the list is long; it's a TEXT column so it can be large. Consider truncating or only selecting when description is absent).
+
+Alternative: add a `canvasPreviewText` derived column computed on write — simpler for the query but requires a migration. **Skip for now**, use client-side derivation.
+
+### 3.4 Run `npm run check` + verify
+
+- `npm run check` — no type errors
+- Manual: run `cert-canvas-bar-display-v1` (8 steps in spec)

--- a/.specify/specs/canvas-bar-display/spec.md
+++ b/.specify/specs/canvas-bar-display/spec.md
@@ -1,0 +1,125 @@
+# Spec: Canvas BAR Display
+
+## Purpose
+
+BARs created via the Seed Capture Whiteboard (`/bars/capture`) are stored with a `canvasLayout` JSON field containing the full sticker positions, element tint, and charge level. None of this is currently read or rendered anywhere — the detail page (`/bars/[id]`) and feed cards (`BarCardFace`) only know about `description` and `tags`, which are empty on canvas-captured BARs. Players see a blank shell when they open a BAR they just made.
+
+This spec closes that gap: canvas-captured BARs should render their whiteboard visually on the detail page, and appear legibly in the feed.
+
+---
+
+## Design Decisions
+
+### Read-only canvas renderer (`CanvasPreview`)
+
+A new component that takes a parsed `CanvasItem[]` + `nation` + `intensity` and renders the frozen whiteboard: `FieldBackground`, element tint, stickers in their saved positions. No drag, no editing — `pointer-events: none` on all stickers. Scaled to fit its container (same `scale` logic as the live canvas but driven by container width, not `window` dimensions).
+
+This component is intentionally dumb: it only renders what it receives. It does not fetch.
+
+### Detail page
+
+`/bars/[id]` currently calls `getBarDetail()` which does **not** select `canvasLayout`, `nation`, or `intensity` from Prisma. These three fields need to be added to the query.
+
+When `canvasLayout` is present:
+- Show `CanvasPreview` at the top of the detail page, full-width, max 520px, with the phone-frame border radius.
+- Show element badge (sigil + name from `nation`) and charge dot cluster (from `intensity`) below it.
+- Keep `BarFaceBackTabs` below — still useful for canvas BARs to add a written description or tags later.
+
+When `canvasLayout` is absent (old-format BARs): detail page is unchanged.
+
+### Feed card fallback (`BarCardFace`)
+
+`BarCardFace` receives `description: string`. For canvas BARs, `description` is empty. The fix lives at the callsite in `bars/page.tsx` (and anywhere else BARs are listed): derive a text preview from the first text sticker in `canvasLayout` if `description` is absent.
+
+Helper: `deriveCanvasPreviewText(canvasLayout: string | null): string | null` — parse JSON, find first `type === 'text'` item, return its `text` (trimmed, max 120 chars). Callers pass this as `description` when the real `description` is blank.
+
+### Photo URL persistence problem
+
+Canvas photo stickers are uploaded to Vercel Blob in `handleCapture` (client-side), but the `canvasLayout` saved in the DB still has `text: "blob:..."` (ephemeral local object URL) for photo items. These URLs are meaningless in the read-only renderer.
+
+**Fix**: After uploading each photo in `handleCapture`, collect the returned permanent URL. Before navigating away (now: setting `captured` state), call a new server action `updateCanvasPhotoUrls(barId, updates: { itemId: string; url: string }[])` that patches the `canvasLayout` JSON in the DB, replacing each photo item's `text` with the real URL.
+
+`uploadBarAsset` currently returns `{ url: string }`. This return value is already available — it's just discarded.
+
+**Scope note**: Voice memo chips in `canvasLayout` have the same problem (blob URL in `text`). The same patch mechanism handles them too.
+
+### Rendering photo stickers in `CanvasPreview`
+
+Photo stickers with a real Vercel Blob URL render normally via `<img src={item.text}>`. If `item.text` is absent, null, or still a `blob:` URL (captured before this fix shipped), render a placeholder frame (same dark gradient frame as the live canvas).
+
+---
+
+## Conceptual Model
+
+```
+CustomBar
+  └─ canvasLayout (JSON string)  →  CanvasPreview component (read-only render)
+  └─ nation (element key)         →  element badge on detail page
+  └─ intensity ("1"–"5")          →  charge dots on detail page
+  └─ description (text)           →  BarFaceBackTabs (unchanged)
+  └─ assets[] (uploaded files)    →  already shown in BarFaceBackTabs
+```
+
+```
+Feed card (BarCardFace)
+  └─ description present   →  show description text (existing behavior)
+  └─ description absent    →  show deriveCanvasPreviewText(canvasLayout)
+  └─ both absent           →  show "—" placeholder
+```
+
+---
+
+## Data / API Contracts
+
+### `getBarDetail` additions
+```ts
+// src/actions/bars.ts — getBarDetail query
+select: {
+  // existing fields...
+  canvasLayout: true,   // ADD
+  nation: true,         // ADD
+  intensity: true,      // ADD
+}
+```
+
+### New server action
+```ts
+// src/actions/bars.ts
+export async function updateCanvasPhotoUrls(
+  barId: string,
+  updates: { itemId: string; url: string }[]
+): Promise<void>
+// Fetches canvasLayout from DB, parses JSON, replaces item.text for matching ids, writes back.
+// Auth-gated: only bar creator can call this.
+```
+
+### New helper
+```ts
+// src/lib/canvas-utils.ts  (or co-locate in actions/bars.ts)
+export function deriveCanvasPreviewText(canvasLayout: string | null): string | null
+```
+
+### New component
+```tsx
+// src/components/bars/CanvasPreview.tsx
+interface CanvasPreviewProps {
+  canvasLayout: string         // raw JSON string from DB
+  nation?: string | null       // ElementKey
+  intensity?: string | null    // "1"–"5"
+  className?: string
+}
+export function CanvasPreview(props: CanvasPreviewProps): JSX.Element
+```
+
+---
+
+## Verification Quest: `cert-canvas-bar-display-v1`
+
+1. Create a BAR via `/bars/capture` with at least one text sticker and one photo. Capture it → overlay shows title.
+2. Click "Tune now →". Verify the detail page shows the canvas layout (field background, text sticker, photo) — not a blank page.
+3. Verify the element badge matches the element you set on the canvas.
+4. Verify the charge level shown matches what you selected.
+5. Navigate to `/bars` (feed). Find the just-captured BAR. Verify its card shows the text from the first text sticker (not blank).
+6. Open a pre-existing old-format BAR. Verify its detail page is unchanged — description/tags still show normally.
+7. In the detail page for the canvas BAR, go to the Back tab. Verify you can add a description and save it without breaking the canvas display.
+8. Reload the canvas BAR detail page. Verify canvas still renders correctly (photo URL survived the round-trip to DB).

--- a/.specify/specs/canvas-bar-display/tasks.md
+++ b/.specify/specs/canvas-bar-display/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: Canvas BAR Display
+
+## Phase 1: Data layer
+
+### 1.1 `getBarDetail` query update
+- [ ] Add `canvasLayout: true` to Prisma select in `getBarDetail` (`src/actions/bars.ts`)
+- [ ] Add `nation: true` to same query
+- [ ] Add `intensity: true` to same query
+- [ ] Update any TypeScript return-type annotations that wrap `getBarDetail`'s result
+- [ ] Run `npm run check` — types clean
+
+### 1.2 `updateCanvasPhotoUrls` server action
+- [ ] Add `updateCanvasPhotoUrls(barId, updates)` to `src/actions/bars.ts`
+- [ ] Auth-gated: only bar creator can patch (check `creatorId === playerId`)
+- [ ] Parses `canvasLayout`, patches matching item `text` fields, writes back as JSON string
+- [ ] Export the function
+
+### 1.3 `deriveCanvasPreviewText` helper
+- [ ] Create `src/lib/canvas-utils.ts`
+- [ ] Implement `deriveCanvasPreviewText(canvasLayout: string | null): string | null`
+- [ ] Parses JSON, finds first `type === 'text'` item, returns trimmed text (max 120 chars)
+- [ ] Returns `null` on parse error or no text stickers
+- [ ] Run `npm run check`
+
+---
+
+## Phase 2: Photo URL persistence
+
+### 2.1 Collect upload URLs in `SeedCaptureWhiteboard`
+- [ ] Check `uploadBarAsset` return type — confirm it returns `{ url: string }` (or adjust)
+- [ ] In `handleCapture`: collect `{ itemId, url }` pairs from each upload result
+- [ ] After all uploads: call `updateCanvasPhotoUrls(barId, urlUpdates)` if any updates exist
+- [ ] Import `updateCanvasPhotoUrls` from `@/actions/bars`
+- [ ] Run `npm run check`
+
+---
+
+## Phase 3: Read-only renderer + integration
+
+### 3.1 `CanvasPreview` component
+- [ ] Create `src/components/bars/CanvasPreview.tsx` (`'use client'`)
+- [ ] Props: `{ canvasLayout: string; nation?: string | null; intensity?: string | null; className?: string }`
+- [ ] Parse `canvasLayout` JSON → `CanvasItem[]` (try/catch, return empty canvas on failure)
+- [ ] Scale: `ResizeObserver` on container div → `scale = containerWidth / 392` (capped at 1)
+- [ ] Render `FieldBackground` (pass `fieldTint` from `nation`) and `Vignette`
+- [ ] Render each item:
+  - `type === 'text'` → `TextSticker` with `isDragging=false`, wrapped in `pointer-events: none`
+  - `type === 'photo'` → photo div sized by `item.size ?? 1.0` scale factor, `<img>` if `item.text` is a real URL, placeholder otherwise
+  - `type === 'voice'` → `VoiceChip`-style display (no tap-to-play)
+  - `type === 'link'` → `LinkChip`-style display
+- [ ] No `TopChrome`, `ToolRail`, `BottomChrome`, `CompostNode`
+- [ ] `pointer-events: none` on the entire canvas layer
+
+### 3.2 Detail page integration
+- [ ] In `src/app/bars/[id]/page.tsx`: import `CanvasPreview`, `ELEMENT_TOKENS`, `ElementKey`
+- [ ] When `bar.canvasLayout` is present: render `<CanvasPreview>` above `BarFaceBackTabs`
+  - Container: `max-w-sm mx-auto rounded-[28px] overflow-hidden`
+- [ ] Render element + charge badge row beneath the canvas preview:
+  - Element: `ELEMENT_TOKENS[nation].sigil` + `nation` name, colored with `tok.gem`
+  - Charge: `parseInt(intensity)` filled dots (●) out of 5, colored with element gem or purple
+- [ ] Old-format BARs (no `canvasLayout`): no change to existing rendering
+- [ ] Run `npm run check`
+
+### 3.3 Feed card fallback
+- [ ] In `src/app/bars/page.tsx`: add `canvasLayout` to the Prisma query for the bars list
+- [ ] Import `deriveCanvasPreviewText` from `@/lib/canvas-utils`
+- [ ] For each BAR in the list: pass `description: bar.description || deriveCanvasPreviewText(bar.canvasLayout) || '—'` to `BarCardFace`
+- [ ] Check any other files that render `BarCardFace` with BAR data — apply same fallback
+- [ ] Run `npm run check`
+
+### 3.4 Final verification
+- [ ] `npm run check` — zero type errors
+- [ ] `npm run build` — no build errors
+- [ ] Manual: run `cert-canvas-bar-display-v1` (8 steps in spec)
+- [ ] Verify old-format BARs still render correctly
+- [ ] Verify photo stickers show real images after reload (URL persistence fix working)
+- [ ] Verify feed cards show sticker text for canvas BARs

--- a/src/components/bars/SeedCaptureWhiteboard.tsx
+++ b/src/components/bars/SeedCaptureWhiteboard.tsx
@@ -78,6 +78,21 @@ interface DragState {
   originY: number
   scale: number
   moved: boolean
+  currentX: number
+  currentY: number
+}
+
+interface GestureState {
+  pointer1Id: number
+  pointer2Id: number
+  itemId: string
+  p1Start: { x: number; y: number }
+  p2Start: { x: number; y: number }
+  p1Current: { x: number; y: number }
+  p2Current: { x: number; y: number }
+  originSize: number
+  originRot: number
+  scale: number
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -720,31 +735,6 @@ function TextEditorOverlay({
         </button>
       </div>
 
-      {/* Size slider (vertical, rotated) */}
-      <div
-        style={{
-          position: 'absolute',
-          left: 6,
-          top: '50%',
-          transform: 'translateY(-50%) rotate(-90deg)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-        }}
-      >
-        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 11, color: 'rgba(232,226,218,0.6)' }}>A</span>
-        <input
-          type="range"
-          min={16}
-          max={54}
-          step={1}
-          value={draftSize}
-          onChange={(e) => onDraftSizeChange(Number(e.target.value))}
-          style={{ width: 168 }}
-        />
-        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 20, color: 'rgba(232,226,218,0.6)' }}>A</span>
-      </div>
-
       {/* Textarea */}
       <div className="flex-1 flex items-center justify-center" style={{ padding: '0 52px' }}>
         <textarea
@@ -771,6 +761,21 @@ function TextEditorOverlay({
             textShadow: '0 2px 16px rgba(0,0,0,0.7)',
           }}
         />
+      </div>
+
+      {/* Size slider */}
+      <div className="flex items-center gap-3 px-6" style={{ paddingBottom: 4 }}>
+        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 11, color: 'rgba(232,226,218,0.5)', flexShrink: 0 }}>A</span>
+        <input
+          type="range"
+          min={12}
+          max={80}
+          step={1}
+          value={draftSize}
+          onChange={(e) => onDraftSizeChange(Number(e.target.value))}
+          style={{ flex: 1 }}
+        />
+        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 22, color: 'rgba(232,226,218,0.5)', flexShrink: 0 }}>A</span>
       </div>
 
       {/* Element colour rail */}
@@ -1195,6 +1200,7 @@ export function SeedCaptureWhiteboard({
   const router = useRouter()
   const boardRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<DragState | null>(null)
+  const gestureRef = useRef<GestureState | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const linkInputRef = useRef<HTMLInputElement>(null)
   // Map of itemId → File for photos selected but not yet uploaded
@@ -1236,6 +1242,30 @@ export function SeedCaptureWhiteboard({
       if (!boardRef.current) return
       const rect = boardRef.current.getBoundingClientRect()
       const scale = rect.width / LOGICAL_W
+
+      // Second pointer on same item while dragging → start pinch/rotate gesture
+      const existingDrag = dragRef.current
+      if (existingDrag && existingDrag.itemId === id) {
+        const item = items.find((i) => i.id === id)
+        if (!item) return
+        ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+        gestureRef.current = {
+          pointer1Id: existingDrag.pointerId,
+          pointer2Id: e.pointerId,
+          itemId: id,
+          p1Start: { x: existingDrag.currentX, y: existingDrag.currentY },
+          p2Start: { x: e.clientX, y: e.clientY },
+          p1Current: { x: existingDrag.currentX, y: existingDrag.currentY },
+          p2Current: { x: e.clientX, y: e.clientY },
+          originSize: item.size ?? (item.type === 'photo' ? 1.0 : 27),
+          originRot: item.rot,
+          scale,
+        }
+        dragRef.current = null
+        setDragId(null)
+        return
+      }
+
       const item = items.find((i) => i.id === id)
       if (!item) return
 
@@ -1249,6 +1279,8 @@ export function SeedCaptureWhiteboard({
         originY: item.y,
         scale,
         moved: false,
+        currentX: e.clientX,
+        currentY: e.clientY,
       }
       setDragId(id)
     },
@@ -1256,8 +1288,39 @@ export function SeedCaptureWhiteboard({
   )
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    // ── Gesture mode (pinch + rotate) ──────────────────────────────────────
+    const g = gestureRef.current
+    if (g) {
+      if (e.pointerId === g.pointer1Id) g.p1Current = { x: e.clientX, y: e.clientY }
+      if (e.pointerId === g.pointer2Id) g.p2Current = { x: e.clientX, y: e.clientY }
+
+      const initDist = Math.hypot(g.p2Start.x - g.p1Start.x, g.p2Start.y - g.p1Start.y)
+      const curDist  = Math.hypot(g.p2Current.x - g.p1Current.x, g.p2Current.y - g.p1Current.y)
+      const scaleFactor = initDist > 1 ? curDist / initDist : 1
+
+      const initAngle = Math.atan2(g.p2Start.y - g.p1Start.y, g.p2Start.x - g.p1Start.x)
+      const curAngle  = Math.atan2(g.p2Current.y - g.p1Current.y, g.p2Current.x - g.p1Current.x)
+      const angleDelta = (curAngle - initAngle) * (180 / Math.PI)
+
+      setItems((prev) =>
+        prev.map((it) => {
+          if (it.id !== g.itemId) return it
+          const isPhoto = it.type === 'photo'
+          const newSize = isPhoto
+            ? clamp(g.originSize * scaleFactor, 0.35, 3.5)
+            : clamp(Math.round(g.originSize * scaleFactor), 12, 80)
+          return { ...it, size: newSize, rot: g.originRot + angleDelta }
+        })
+      )
+      return
+    }
+
+    // ── Single-pointer drag ─────────────────────────────────────────────────
     const drag = dragRef.current
     if (!drag || drag.pointerId !== e.pointerId) return
+
+    drag.currentX = e.clientX
+    drag.currentY = e.clientY
 
     const dx = (e.clientX - drag.startX) / drag.scale
     const dy = (e.clientY - drag.startY) / drag.scale
@@ -1278,6 +1341,15 @@ export function SeedCaptureWhiteboard({
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
+      // ── Gesture exit ────────────────────────────────────────────────────────
+      const g = gestureRef.current
+      if (g && (e.pointerId === g.pointer1Id || e.pointerId === g.pointer2Id)) {
+        gestureRef.current = null
+        setDragId(null)
+        return
+      }
+
+      // ── Single-pointer drag end ─────────────────────────────────────────────
       const drag = dragRef.current
       if (!drag || drag.pointerId !== e.pointerId) return
 
@@ -1303,16 +1375,33 @@ export function SeedCaptureWhiteboard({
     [overTrash, items]
   )
 
-  // Empty canvas tap → new text
-  const handleCanvasTap = useCallback(
-    () => {
-      if (dragRef.current) return
-      setDraft('')
-      setDraftTint(fieldTint ?? 'none')
-      setDraftSize(30)
-      setEditing('new')
+  // Canvas background pointer-down: only used to detect second-finger gesture
+  // when the second finger lands on empty canvas rather than on a sticker
+  const handleCanvasPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      const drag = dragRef.current
+      if (!drag || !boardRef.current) return
+      const rect = boardRef.current.getBoundingClientRect()
+      const scale = rect.width / LOGICAL_W
+      const item = items.find((i) => i.id === drag.itemId)
+      if (!item) return
+      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      gestureRef.current = {
+        pointer1Id: drag.pointerId,
+        pointer2Id: e.pointerId,
+        itemId: drag.itemId,
+        p1Start: { x: drag.currentX, y: drag.currentY },
+        p2Start: { x: e.clientX, y: e.clientY },
+        p1Current: { x: drag.currentX, y: drag.currentY },
+        p2Current: { x: e.clientX, y: e.clientY },
+        originSize: item.size ?? (item.type === 'photo' ? 1.0 : 27),
+        originRot: item.rot,
+        scale,
+      }
+      dragRef.current = null
+      setDragId(null)
     },
-    [fieldTint]
+    [items]
   )
 
   // ─── Editor commit ─────────────────────────────────────────────────────────
@@ -1572,7 +1661,7 @@ export function SeedCaptureWhiteboard({
         <div
           className="absolute inset-0"
           style={{ zIndex: 10 }}
-          onPointerDown={handleCanvasTap}
+          onPointerDown={handleCanvasPointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           role="region"
@@ -1591,6 +1680,8 @@ export function SeedCaptureWhiteboard({
               )
             }
             if (item.type === 'photo') {
+              const photoW = Math.round(118 * (item.size ?? 1.0))
+              const photoH = Math.round(132 * (item.size ?? 1.0))
               return (
                 <div
                   key={item.id}
@@ -1599,8 +1690,8 @@ export function SeedCaptureWhiteboard({
                     position: 'absolute',
                     left: item.x,
                     top: item.y,
-                    width: 118,
-                    height: 132,
+                    width: photoW,
+                    height: photoH,
                     transform: `translate(-50%,-50%) rotate(${item.rot}deg) ${isDragging ? 'scale(1.04)' : ''}`,
                     borderRadius: 11,
                     background: 'linear-gradient(155deg,#2b2724,#15110e)',


### PR DESCRIPTION
## Summary

- **Slider bug fixed** — The size slider in the text editor was rotated 90° via CSS transform, which breaks touch event coordinate mapping on mobile (the browser maps touches to the pre-transform position, so the slider never responded). Replaced with a plain horizontal `<input type="range" min={12} max={80}>` placed below the element colour swatches. No transform, no ambiguity — drag left = smaller, drag right = larger, textarea updates immediately.

- **Tap-empty-canvas removed** — Tapping any empty area of the canvas no longer opens the text editor. Only the **Aa** button (new text) and tapping an existing text sticker (re-edit) trigger the editor. The canvas background pointer handler is now only active when a drag is already in progress (to catch a second finger landing on empty canvas for gesture mode).

- **Pinch-to-resize + two-finger rotate** — New `GestureState` ref tracks two simultaneous pointers. Two entry points:
  1. Second finger lands **on the same sticker** → `handleItemPointerDown` detects the existing drag and starts gesture mode
  2. Second finger lands **on empty canvas** → `handleCanvasPointerDown` catches it using the active drag's item

  On each `pointermove`, gesture branch runs first: distance ratio between the two fingers = pinch scale; angle delta of the two-finger vector = rotation. Both apply simultaneously to `item.size` and `item.rot`. Either pointer lifting exits gesture mode cleanly.

  - Text stickers: size clamped 12–80px (free, matches new slider range)
  - Photo stickers: scale factor 0.35–3.5× (renders as `118 * scale` × `132 * scale` px)

## Test plan

- [ ] In text editor: drag size slider → textarea font size updates live
- [ ] Tap empty canvas area → nothing happens
- [ ] Tap **Aa** button → text editor opens
- [ ] Tap an existing text sticker → editor reopens with that sticker's text
- [ ] Place a text sticker. One finger drag → moves it
- [ ] Two fingers on text sticker, pinch in/out → font size changes
- [ ] Two fingers on text sticker, twist → sticker rotates
- [ ] Place a photo. Two fingers pinch → photo grows/shrinks
- [ ] Two fingers twist on photo → photo rotates
- [ ] Second finger on empty canvas (while first finger holds a sticker) → gesture activates
- [ ] Drag resized/rotated sticker to compost zone → removed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt5SM4meY1EYFhCET9eCAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt5SM4meY1EYFhCET9eCAy)_