### PR TITLE
Add /awaken guided funnel: wake up → show up

### DIFF
--- a/docs/ENV_AND_VERCEL.md
+++ b/docs/ENV_AND_VERCEL.md
@@ -128,6 +128,22 @@ AI features (Book analysis, I Ching quest generation) require `OPENAI_API_KEY`. 
 3. **Verify**: Run `npm run smoke` — it checks for `OPENAI_API_KEY` presence.
 4. **Key format**: Valid keys start with `sk-` or `sk-proj-`. If rotated or expired, create a new key and update env.
 
+### RESEND_API_KEY / EMAIL_FROM (transactional email)
+
+Outbound email (Chapter One delivery, `/awaken` RSVP confirmations) sends via
+[Resend](https://resend.com) behind the single service at `src/lib/email`.
+
+| Variable | Required | Meaning |
+|----------|----------|---------|
+| `RESEND_API_KEY` | yes (to send) | Secret key from the Resend dashboard → API Keys. |
+| `EMAIL_FROM` | yes (to send) | Verified sender on your authenticated domain, e.g. `Wendell · Mastering Allyship <hello@send.masteringallyship.com>`. |
+| `EMAIL_REPLY_TO` | optional | A human inbox so replies reach a person, e.g. `wendell@masteringallyship.com`. |
+
+1. **Local**: add the three to `.env.local`.
+2. **Vercel**: Dashboard → Settings → Environment Variables (Production + Preview). Redeploy after adding.
+3. **Graceful degradation**: when `RESEND_API_KEY`/`EMAIL_FROM` are unset, sends are **logged and skipped** rather than throwing — the funnel still saves the lead, it just can't deliver yet.
+4. **Deliverability is gated on DNS**: `EMAIL_FROM`'s domain must be verified in Resend with **SPF, DKIM, and DMARC** records, or mail lands in spam. See Resend → Domains for the exact records.
+
 ### STRAND_CREATOR_PLAYER_ID (FastAPI / bars-agents)
 
 Strand and MCP-generated BARs attach to a **dedicated agent `Player`**, not an arbitrary first user.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "resend": "^6.14.0",
         "sonner": "^2.0.7",
         "zod": "^4.3.6"
       },
@@ -2276,6 +2277,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5567,6 +5574,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9206,6 +9219,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -9522,6 +9541,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
+      "integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -9989,6 +10029,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ai-sdk/openai": "^3.0.25",
         "@prisma/client": "^5.22.0",
         "@prisma/extension-accelerate": "^3.0.1",
+        "@react-email/components": "^1.0.12",
         "@types/pathfinding": "^0.1.0",
         "@vercel/blob": "^2.3.1",
         "@xyflow/react": "^12.10.1",
@@ -1966,6 +1967,357 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@react-email/body": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.3.0.tgz",
+      "integrity": "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/button": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
+      "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-block": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
+      "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-inline": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
+      "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/column": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.14.tgz",
+      "integrity": "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/components/-/components-1.0.12.tgz",
+      "integrity": "sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/body": "0.3.0",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/column": "0.0.14",
+        "@react-email/container": "0.0.16",
+        "@react-email/font": "0.0.10",
+        "@react-email/head": "0.0.13",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/html": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/markdown": "0.0.18",
+        "@react-email/preview": "0.0.14",
+        "@react-email/render": "2.0.6",
+        "@react-email/row": "0.0.13",
+        "@react-email/section": "0.0.17",
+        "@react-email/tailwind": "2.0.7",
+        "@react-email/text": "0.1.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components/node_modules/@react-email/render": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.6.tgz",
+      "integrity": "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/container": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
+      "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/font": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.10.tgz",
+      "integrity": "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/head": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.13.tgz",
+      "integrity": "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/heading": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
+      "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/hr": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
+      "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/html": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.12.tgz",
+      "integrity": "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/img": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
+      "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/link": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
+      "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/markdown": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@react-email/markdown/-/markdown-0.0.18.tgz",
+      "integrity": "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/preview": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
+      "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/row": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.13.tgz",
+      "integrity": "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/section": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.17.tgz",
+      "integrity": "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/tailwind": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-2.0.7.tgz",
+      "integrity": "sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "tailwindcss": "^4.1.18"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@react-email/body": ">=0",
+        "@react-email/button": ">=0",
+        "@react-email/code-block": ">=0",
+        "@react-email/code-inline": ">=0",
+        "@react-email/container": ">=0",
+        "@react-email/heading": ">=0",
+        "@react-email/hr": ">=0",
+        "@react-email/img": ">=0",
+        "@react-email/link": ">=0",
+        "@react-email/preview": ">=0",
+        "@react-email/text": ">=0",
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/body": {
+          "optional": true
+        },
+        "@react-email/button": {
+          "optional": true
+        },
+        "@react-email/code-block": {
+          "optional": true
+        },
+        "@react-email/code-inline": {
+          "optional": true
+        },
+        "@react-email/container": {
+          "optional": true
+        },
+        "@react-email/heading": {
+          "optional": true
+        },
+        "@react-email/hr": {
+          "optional": true
+        },
+        "@react-email/img": {
+          "optional": true
+        },
+        "@react-email/link": {
+          "optional": true
+        },
+        "@react-email/preview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-email/text": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
+      "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -2277,6 +2629,19 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -4648,6 +5013,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4725,6 +5099,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -4797,6 +5226,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6228,6 +6669,22 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6236,6 +6693,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -7106,6 +7582,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7443,6 +7928,18 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9062,6 +9559,19 @@
       "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
       "license": "MIT"
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -9155,6 +9665,15 @@
       },
       "engines": {
         "node": ">=20.11.0"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -9263,6 +9782,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -9281,6 +9815,15 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process": {
@@ -9762,6 +10305,18 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10395,8 +10950,7 @@
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "resend": "^6.14.0",
     "sonner": "^2.0.7",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "@ai-sdk/openai": "^3.0.25",
     "@prisma/client": "^5.22.0",
     "@prisma/extension-accelerate": "^3.0.1",
+    "@react-email/components": "^1.0.12",
     "@types/pathfinding": "^0.1.0",
     "@vercel/blob": "^2.3.1",
     "@xyflow/react": "^12.10.1",

--- a/prisma/migrations/20260619120000_add_funnel_signup/migration.sql
+++ b/prisma/migrations/20260619120000_add_funnel_signup/migration.sql
@@ -1,0 +1,19 @@
+-- Awaken funnel lead capture: chapter-one email signups + July weekend event RSVPs.
+-- Standalone table (no Player FK) so unauthenticated visitors can convert.
+CREATE TABLE "funnel_signups" (
+    "id"        TEXT NOT NULL,
+    "intent"    TEXT NOT NULL,
+    "email"     TEXT NOT NULL,
+    "name"      TEXT,
+    "events"    TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "source"    TEXT NOT NULL DEFAULT 'awaken',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "funnel_signups_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "funnel_signups_intent_createdAt_idx"
+    ON "funnel_signups"("intent", "createdAt");
+
+CREATE INDEX "funnel_signups_email_idx"
+    ON "funnel_signups"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4339,3 +4339,23 @@ enum NarrativeTemplateKind {
   ORIENTATION
   CUSTOM
 }
+
+/// Awaken funnel lead capture — chapter-one email signups and July weekend
+/// event RSVPs from the public /awaken guided flow. Intentionally standalone
+/// (no Player FK) so brand-new, unauthenticated visitors can convert.
+model FunnelSignup {
+  id        String   @id @default(cuid())
+  /// "chapter" (download Chapter One) | "event" (RSVP to weekend events)
+  intent    String
+  email     String
+  name      String?
+  /// Event keys the visitor RSVP'd to (empty for chapter intent).
+  events    String[] @default([])
+  /// Where the signup originated (defaults to the awaken funnel).
+  source    String   @default("awaken")
+  createdAt DateTime @default(now())
+
+  @@index([intent, createdAt])
+  @@index([email])
+  @@map("funnel_signups")
+}

--- a/src/app/api/awaken/signup/route.ts
+++ b/src/app/api/awaken/signup/route.ts
@@ -1,0 +1,69 @@
+/**
+ * @route POST /api/awaken/signup
+ * @entity CAMPAIGN
+ * @description Public lead capture for the /awaken funnel — Chapter One email
+ *   signups and July weekend event RSVPs. No auth required (brand-new visitors).
+ * @permissions public
+ * @relationships writes FunnelSignup rows
+ * @dimensions WHO:visitor, WHAT:email lead / RSVP, WHERE:awaken funnel, ENERGY:show_up
+ * @example POST /api/awaken/signup { "intent": "chapter", "email": "a@b.com" }
+ * @agentDiscoverable true
+ */
+import { NextResponse, type NextRequest } from 'next/server'
+import { db } from '@/lib/db'
+import { AWAKEN_EVENT_KEYS } from '@/lib/awaken/content'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type Body = {
+  intent?: string
+  email?: string
+  name?: string
+  events?: unknown
+}
+
+export async function POST(request: NextRequest) {
+  let body: Body
+  try {
+    body = (await request.json()) as Body
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const intent = body.intent === 'event' ? 'event' : 'chapter'
+  const email = (body.email ?? '').trim().toLowerCase()
+  const name = body.name?.trim() || null
+
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json({ ok: false, error: 'Please enter a valid email.' }, { status: 400 })
+  }
+
+  let events: string[] = []
+  if (intent === 'event') {
+    const raw = Array.isArray(body.events) ? body.events : []
+    events = raw
+      .filter((e): e is string => typeof e === 'string')
+      .filter((e) => AWAKEN_EVENT_KEYS.has(e))
+    if (events.length === 0) {
+      return NextResponse.json(
+        { ok: false, error: 'Pick at least one event to RSVP.' },
+        { status: 400 },
+      )
+    }
+  }
+
+  try {
+    await db.funnelSignup.create({
+      data: { intent, email, name, events, source: 'awaken' },
+    })
+  } catch (err) {
+    // Don't strand the visitor if persistence hiccups — log and acknowledge.
+    console.error('[awaken/signup] failed to persist', err)
+    return NextResponse.json(
+      { ok: false, error: 'Something went wrong saving that. Please try again.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ ok: true, intent, events })
+}

--- a/src/app/api/awaken/signup/route.ts
+++ b/src/app/api/awaken/signup/route.ts
@@ -12,6 +12,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { db } from '@/lib/db'
 import { AWAKEN_EVENT_KEYS } from '@/lib/awaken/content'
+import { sendChapterOneEmail } from '@/lib/email/awaken'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -52,6 +53,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // Persist first — the lead is the thing we must not lose.
   try {
     await db.funnelSignup.create({
       data: { intent, email, name, events, source: 'awaken' },
@@ -65,5 +67,17 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  return NextResponse.json({ ok: true, intent, events })
+  // Then send (decoupled): a flaky provider must not 500 the request or lose
+  // the lead. We log failures for re-send tooling and still return ok.
+  let emailed = false
+  if (intent === 'chapter') {
+    const firstName = name?.split(/\s+/)[0] || null
+    const result = await sendChapterOneEmail({ to: email, firstName })
+    emailed = result.ok && !('skipped' in result && result.skipped)
+    if (!result.ok) {
+      console.error('[awaken/signup] chapter email failed to send', { email, error: result.error })
+    }
+  }
+
+  return NextResponse.json({ ok: true, intent, events, emailed })
 }

--- a/src/app/api/awaken/signup/route.ts
+++ b/src/app/api/awaken/signup/route.ts
@@ -12,7 +12,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { db } from '@/lib/db'
 import { AWAKEN_EVENT_KEYS } from '@/lib/awaken/content'
-import { sendChapterOneEmail } from '@/lib/email/awaken'
+import { sendChapterOneEmail, sendRsvpConfirmationEmail } from '@/lib/email/awaken'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -69,14 +69,19 @@ export async function POST(request: NextRequest) {
 
   // Then send (decoupled): a flaky provider must not 500 the request or lose
   // the lead. We log failures for re-send tooling and still return ok.
+  const firstName = name?.split(/\s+/)[0] || null
   let emailed = false
-  if (intent === 'chapter') {
-    const firstName = name?.split(/\s+/)[0] || null
-    const result = await sendChapterOneEmail({ to: email, firstName })
-    emailed = result.ok && !('skipped' in result && result.skipped)
-    if (!result.ok) {
-      console.error('[awaken/signup] chapter email failed to send', { email, error: result.error })
-    }
+  const result =
+    intent === 'chapter'
+      ? await sendChapterOneEmail({ to: email, firstName })
+      : await sendRsvpConfirmationEmail({ to: email, firstName, eventKeys: events })
+  emailed = result.ok && !('skipped' in result && result.skipped)
+  if (!result.ok) {
+    console.error('[awaken/signup] confirmation email failed to send', {
+      intent,
+      email,
+      error: result.error,
+    })
   }
 
   return NextResponse.json({ ok: true, intent, events, emailed })

--- a/src/app/awaken/AwakenFlow.tsx
+++ b/src/app/awaken/AwakenFlow.tsx
@@ -1,0 +1,420 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  AWAKEN_EVENTS,
+  AWAKEN_DONATE_HREF,
+  AWAKEN_PRODUCTS_HREF,
+  AWAKEN_NONPROFIT_HREF,
+  AWAKEN_CHAPTER_FILE_HREF,
+} from '@/lib/awaken/content'
+
+type Status = 'idle' | 'loading' | 'done' | 'error'
+
+const STEPS = [
+  { id: 'wake', label: 'Wake up' },
+  { id: 'show', label: 'Show up' },
+]
+
+export function AwakenFlow() {
+  const [active, setActive] = useState('wake')
+
+  return (
+    <div className="min-h-screen bg-black text-zinc-200 font-sans">
+      <ProgressRail active={active} />
+
+      <div className="mx-auto max-w-2xl px-5 pb-32">
+        <WakeUp onInView={() => setActive('wake')} />
+        <ShowUp onInView={() => setActive('show')} />
+      </div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────── Progress rail ─────────────────────────── */
+
+function ProgressRail({ active }: { active: string }) {
+  return (
+    <div className="sticky top-14 z-20 border-b border-zinc-900 bg-black/80 backdrop-blur">
+      <div className="mx-auto flex max-w-2xl items-center gap-2 px-5 py-3">
+        {STEPS.map((s, i) => {
+          const on = s.id === active
+          return (
+            <a key={s.id} href={`#${s.id}`} className="flex flex-1 items-center gap-2">
+              <span
+                className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold transition-colors ${
+                  on
+                    ? 'bg-gradient-to-r from-green-500 to-emerald-400 text-black'
+                    : 'border border-zinc-700 text-zinc-500'
+                }`}
+              >
+                {i + 1}
+              </span>
+              <span className={`text-xs font-semibold ${on ? 'text-white' : 'text-zinc-500'}`}>
+                {s.label}
+              </span>
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────── Act I — Wake up ───────────────────────── */
+
+function WakeUp({ onInView }: { onInView: () => void }) {
+  return (
+    <section id="wake" onMouseEnter={onInView} className="pt-12">
+      <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-green-400">
+        Act I · The current state of things
+      </p>
+      <h1 className="mt-3 text-4xl font-bold leading-tight tracking-tight">
+        <span className="bg-gradient-to-r from-green-400 via-emerald-400 to-teal-400 bg-clip-text text-transparent">
+          Wake up.
+        </span>
+      </h1>
+
+      <div className="mt-6 space-y-5 text-[15px] leading-relaxed text-zinc-300">
+        <p>
+          Right now, a real thing is happening. Not an abstraction — a person, a community, and a
+          car that needs to keep running so the work can keep moving.
+        </p>
+        <p>
+          The car fund isn&apos;t charity. It&apos;s fuel. It&apos;s what turns intention into
+          showing up — to the events, to the people, to the next chapter of a story that&apos;s
+          already in motion.
+        </p>
+        <p>
+          Here&apos;s where we are today, and three honest ways you can step in. Read it, then
+          choose how you want to show up.
+        </p>
+      </div>
+
+      <div className="mt-8 grid grid-cols-3 gap-3">
+        <Stat k="Weekend" v="Jul 17–19" />
+        <Stat k="Events" v="3 nights" />
+        <Stat k="The ask" v="Show up" />
+      </div>
+
+      <a
+        href="#show"
+        className="mt-8 inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-6 py-3 font-bold text-white shadow-lg shadow-green-900/30 transition-all hover:from-green-500 hover:to-emerald-500"
+      >
+        I&apos;m awake — show me how to help ↓
+      </a>
+    </section>
+  )
+}
+
+function Stat({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-3 text-center">
+      <div className="text-[10px] uppercase tracking-widest text-zinc-500">{k}</div>
+      <div className="mt-1 text-sm font-bold text-white">{v}</div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────── Act II — Show up ──────────────────────── */
+
+function ShowUp({ onInView }: { onInView: () => void }) {
+  return (
+    <section id="show" onMouseEnter={onInView} className="pt-16">
+      <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-green-400">
+        Act II · Show up
+      </p>
+      <h2 className="mt-3 text-3xl font-bold tracking-tight text-white">Pick your move.</h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Any one of these moves the needle. Do one. Do all three.
+      </p>
+
+      <div className="mt-8 space-y-6">
+        <DonateCard />
+        <ChapterCard />
+        <EventsCard />
+      </div>
+
+      <SecondaryLinks />
+    </section>
+  )
+}
+
+/* ── Move 1: Donate ── */
+
+function DonateCard() {
+  return (
+    <Card accent="emerald" badge="Move 1" title="Fuel the car fund">
+      <p className="text-sm leading-relaxed text-zinc-300">
+        A direct contribution keeps the wheels turning. Every dollar is fuel for showing up.
+      </p>
+      <Link
+        href={AWAKEN_DONATE_HREF}
+        className="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-5 py-3 font-bold text-white transition-all hover:from-green-500 hover:to-emerald-500"
+      >
+        Donate to the car fund →
+      </Link>
+    </Card>
+  )
+}
+
+/* ── Move 2: Chapter One ── */
+
+function ChapterCard() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [error, setError] = useState('')
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('loading')
+    setError('')
+    try {
+      const res = await fetch('/api/awaken/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ intent: 'chapter', email }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.ok) throw new Error(data.error || 'Something went wrong.')
+      setStatus('done')
+    } catch (err) {
+      setStatus('error')
+      setError(err instanceof Error ? err.message : 'Something went wrong.')
+    }
+  }
+
+  return (
+    <Card accent="teal" badge="Move 2" title="Read Chapter One">
+      <p className="text-sm leading-relaxed text-zinc-300">
+        Start the story for free. Drop your email and we&apos;ll send the first chapter straight to
+        your inbox.
+      </p>
+
+      {status === 'done' ? (
+        <div className="mt-4 rounded-xl border border-teal-700/50 bg-teal-950/30 p-4">
+          <p className="text-sm font-semibold text-teal-300">You&apos;re in. ✨</p>
+          <p className="mt-1 text-xs text-zinc-400">
+            Chapter One is on its way to your inbox.
+          </p>
+          <a
+            href={AWAKEN_CHAPTER_FILE_HREF}
+            className="mt-3 inline-flex items-center text-sm font-bold text-teal-300 underline-offset-2 hover:underline"
+          >
+            Or download it now →
+          </a>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="mt-4 space-y-3">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@email.com"
+            className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-teal-500"
+          />
+          {status === 'error' && <p className="text-xs text-red-400">{error}</p>}
+          <button
+            type="submit"
+            disabled={status === 'loading'}
+            className="inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-teal-600 to-cyan-600 px-5 py-3 font-bold text-white transition-all hover:from-teal-500 hover:to-cyan-500 disabled:opacity-60"
+          >
+            {status === 'loading' ? 'Sending…' : 'Send me Chapter One →'}
+          </button>
+        </form>
+      )}
+    </Card>
+  )
+}
+
+/* ── Move 3: Events ── */
+
+function EventsCard() {
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [email, setEmail] = useState('')
+  const [name, setName] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [error, setError] = useState('')
+
+  function toggle(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (selected.size === 0) {
+      setStatus('error')
+      setError('Pick at least one event.')
+      return
+    }
+    setStatus('loading')
+    setError('')
+    try {
+      const res = await fetch('/api/awaken/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          intent: 'event',
+          email,
+          name,
+          events: Array.from(selected),
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.ok) throw new Error(data.error || 'Something went wrong.')
+      setStatus('done')
+    } catch (err) {
+      setStatus('error')
+      setError(err instanceof Error ? err.message : 'Something went wrong.')
+    }
+  }
+
+  return (
+    <Card accent="green" badge="Move 3" title="Be there · Jul 17–19">
+      <p className="text-sm leading-relaxed text-zinc-300">
+        Three gatherings the weekend of July 18th. RSVP to the ones you&apos;ll make.
+      </p>
+
+      {status === 'done' ? (
+        <div className="mt-4 rounded-xl border border-green-700/50 bg-green-950/30 p-4">
+          <p className="text-sm font-semibold text-green-300">See you there. 🎉</p>
+          <p className="mt-1 text-xs text-zinc-400">
+            You&apos;re on the list for {selected.size} event{selected.size === 1 ? '' : 's'}. Watch
+            your inbox for details.
+          </p>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="mt-4 space-y-3">
+          <div className="space-y-2">
+            {AWAKEN_EVENTS.map((ev) => {
+              const on = selected.has(ev.key)
+              return (
+                <button
+                  type="button"
+                  key={ev.key}
+                  onClick={() => toggle(ev.key)}
+                  className={`flex w-full items-start gap-3 rounded-xl border p-3 text-left transition-colors ${
+                    on
+                      ? 'border-green-500 bg-green-950/30'
+                      : 'border-zinc-800 bg-zinc-900/40 hover:border-zinc-600'
+                  }`}
+                >
+                  <span
+                    className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border text-[11px] ${
+                      on ? 'border-green-400 bg-green-400 text-black' : 'border-zinc-600 text-transparent'
+                    }`}
+                  >
+                    ✓
+                  </span>
+                  <span className="min-w-0">
+                    <span className="flex items-center gap-2">
+                      <span className="text-sm font-bold text-white">{ev.title}</span>
+                      <span className="text-[11px] font-semibold text-green-400">{ev.when}</span>
+                    </span>
+                    <span className="mt-0.5 block text-xs text-zinc-400">{ev.blurb}</span>
+                    <span className="mt-0.5 block text-[11px] text-zinc-600">{ev.where}</span>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name (optional)"
+            className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
+          />
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@email.com"
+            className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
+          />
+          {status === 'error' && <p className="text-xs text-red-400">{error}</p>}
+          <button
+            type="submit"
+            disabled={status === 'loading'}
+            className="inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-5 py-3 font-bold text-white transition-all hover:from-green-500 hover:to-emerald-500 disabled:opacity-60"
+          >
+            {status === 'loading' ? 'Reserving…' : `RSVP${selected.size ? ` to ${selected.size}` : ''} →`}
+          </button>
+        </form>
+      )}
+    </Card>
+  )
+}
+
+/* ── Secondary links: products + non-profit ── */
+
+function SecondaryLinks() {
+  return (
+    <div className="mt-12 border-t border-zinc-900 pt-8">
+      <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-zinc-500">
+        Go deeper
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Link
+          href={AWAKEN_PRODUCTS_HREF}
+          className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 transition-colors hover:border-zinc-600"
+        >
+          <div className="font-bold text-white">Explore the book, deck &amp; game</div>
+          <div className="mt-1 text-xs text-zinc-400">
+            Browse everything you can buy and support →
+          </div>
+        </Link>
+        <Link
+          href={AWAKEN_NONPROFIT_HREF}
+          className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 transition-colors hover:border-zinc-600"
+        >
+          <div className="font-bold text-white">About the non-profit</div>
+          <div className="mt-1 text-xs text-zinc-400">
+            Learn where this is headed (coming soon) →
+          </div>
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────── Shared card ───────────────────────────── */
+
+const ACCENT: Record<string, string> = {
+  emerald: 'from-green-500/15 to-emerald-500/5 border-green-800/50',
+  teal: 'from-teal-500/15 to-cyan-500/5 border-teal-800/50',
+  green: 'from-green-500/15 to-emerald-500/5 border-green-800/50',
+}
+
+function Card({
+  accent,
+  badge,
+  title,
+  children,
+}: {
+  accent: keyof typeof ACCENT | string
+  badge: string
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={`rounded-2xl border bg-gradient-to-br p-5 ${ACCENT[accent] ?? ACCENT.green}`}>
+      <div className="flex items-center gap-2">
+        <span className="rounded-full bg-black/40 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+          {badge}
+        </span>
+      </div>
+      <h3 className="mt-2 text-xl font-bold text-white">{title}</h3>
+      <div className="mt-2">{children}</div>
+    </div>
+  )
+}

--- a/src/app/awaken/AwakenFlow.tsx
+++ b/src/app/awaken/AwakenFlow.tsx
@@ -229,31 +229,16 @@ function ChapterCard() {
   )
 }
 
-/* ── Move 3: Events ── */
+/* ── Move 3: Events (RSVP on Partiful + optional list capture) ── */
 
 function EventsCard() {
-  const [selected, setSelected] = useState<Set<string>>(new Set())
   const [email, setEmail] = useState('')
   const [name, setName] = useState('')
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState('')
 
-  function toggle(key: string) {
-    setSelected((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
-  }
-
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    if (selected.size === 0) {
-      setStatus('error')
-      setError('Pick at least one event.')
-      return
-    }
     setStatus('loading')
     setError('')
     try {
@@ -264,7 +249,8 @@ function EventsCard() {
           intent: 'event',
           email,
           name,
-          events: Array.from(selected),
+          // List signup is for the whole weekend; confirmation carries all three.
+          events: AWAKEN_EVENTS.map((ev) => ev.key),
         }),
       })
       const data = await res.json()
@@ -279,78 +265,72 @@ function EventsCard() {
   return (
     <Card accent="green" badge="Move 3" title="Be there · Jul 17–19">
       <p className="text-sm leading-relaxed text-zinc-300">
-        Three gatherings the weekend of July 18th. RSVP to the ones you&apos;ll make.
+        Three gatherings the weekend of July 18th. RSVP on Partiful for the ones you&apos;ll make.
       </p>
 
-      {status === 'done' ? (
-        <div className="mt-4 rounded-xl border border-green-700/50 bg-green-950/30 p-4">
-          <p className="text-sm font-semibold text-green-300">See you there. 🎉</p>
-          <p className="mt-1 text-xs text-zinc-400">
-            You&apos;re on the list for {selected.size} event{selected.size === 1 ? '' : 's'}. Watch
-            your inbox for details.
-          </p>
-        </div>
-      ) : (
-        <form onSubmit={submit} className="mt-4 space-y-3">
-          <div className="space-y-2">
-            {AWAKEN_EVENTS.map((ev) => {
-              const on = selected.has(ev.key)
-              return (
-                <button
-                  type="button"
-                  key={ev.key}
-                  onClick={() => toggle(ev.key)}
-                  className={`flex w-full items-start gap-3 rounded-xl border p-3 text-left transition-colors ${
-                    on
-                      ? 'border-green-500 bg-green-950/30'
-                      : 'border-zinc-800 bg-zinc-900/40 hover:border-zinc-600'
-                  }`}
-                >
-                  <span
-                    className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border text-[11px] ${
-                      on ? 'border-green-400 bg-green-400 text-black' : 'border-zinc-600 text-transparent'
-                    }`}
-                  >
-                    ✓
-                  </span>
-                  <span className="min-w-0">
-                    <span className="flex items-center gap-2">
-                      <span className="text-sm font-bold text-white">{ev.title}</span>
-                      <span className="text-[11px] font-semibold text-green-400">{ev.when}</span>
-                    </span>
-                    <span className="mt-0.5 block text-xs text-zinc-400">{ev.blurb}</span>
-                    <span className="mt-0.5 block text-[11px] text-zinc-600">{ev.where}</span>
-                  </span>
-                </button>
-              )
-            })}
-          </div>
-
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Your name (optional)"
-            className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
-          />
-          <input
-            type="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@email.com"
-            className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
-          />
-          {status === 'error' && <p className="text-xs text-red-400">{error}</p>}
-          <button
-            type="submit"
-            disabled={status === 'loading'}
-            className="inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-5 py-3 font-bold text-white transition-all hover:from-green-500 hover:to-emerald-500 disabled:opacity-60"
+      <div className="mt-4 space-y-2">
+        {AWAKEN_EVENTS.map((ev) => (
+          <div
+            key={ev.key}
+            className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-3"
           >
-            {status === 'loading' ? 'Reserving…' : `RSVP${selected.size ? ` to ${selected.size}` : ''} →`}
-          </button>
-        </form>
-      )}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-white">{ev.title}</span>
+              <span className="text-[11px] font-semibold text-green-400">{ev.when}</span>
+            </div>
+            <p className="mt-0.5 text-xs text-zinc-400">{ev.blurb}</p>
+            <p className="mt-0.5 text-[11px] text-zinc-600">{ev.where}</p>
+            <a
+              href={ev.partifulUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-green-600 to-emerald-600 px-4 py-2 text-sm font-bold text-white transition-all hover:from-green-500 hover:to-emerald-500"
+            >
+              RSVP on Partiful →
+            </a>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-5 border-t border-zinc-800 pt-4">
+        {status === 'done' ? (
+          <div className="rounded-xl border border-green-700/50 bg-green-950/30 p-4">
+            <p className="text-sm font-semibold text-green-300">You&apos;re on the list. 🎉</p>
+            <p className="mt-1 text-xs text-zinc-400">
+              Check your inbox — we sent the weekend details and every RSVP link.
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="space-y-3">
+            <p className="text-sm font-semibold text-white">
+              Want reminders + the weekend details by email?
+            </p>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name (optional)"
+              className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
+            />
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@email.com"
+              className="w-full rounded-xl border border-zinc-700 bg-black px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none focus:border-green-500"
+            />
+            {status === 'error' && <p className="text-xs text-red-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={status === 'loading'}
+              className="inline-flex w-full items-center justify-center rounded-xl bg-zinc-800 px-5 py-3 font-bold text-white transition-all hover:bg-zinc-700 disabled:opacity-60"
+            >
+              {status === 'loading' ? 'Adding you…' : 'Keep me posted →'}
+            </button>
+          </form>
+        )}
+      </div>
     </Card>
   )
 }

--- a/src/app/awaken/page.tsx
+++ b/src/app/awaken/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next'
+import { AwakenFlow } from './AwakenFlow'
+
+/**
+ * @page /awaken
+ * @entity CAMPAIGN
+ * @description Public guided funnel for new visitors: wake up to the current
+ *   state of things, then show up — donate to the car fund, download Chapter
+ *   One, or RSVP to the three July 18th weekend events.
+ * @permissions public
+ * @relationships links to /event/donate, /api/awaken/signup, /launch, /nonprofit
+ * @dimensions WHO:visitor, WHAT:funnel, WHERE:campaign, ENERGY:show_up
+ * @example /awaken
+ * @agentDiscoverable true
+ */
+export const metadata: Metadata = {
+  title: 'Wake up · Show up — BARS Engine',
+  description:
+    'Learn where things stand, then choose how to show up: fuel the car fund, read Chapter One, or RSVP to the July 18th weekend events.',
+}
+
+export default function AwakenPage() {
+  return <AwakenFlow />
+}

--- a/src/app/nation/[id]/page.tsx
+++ b/src/app/nation/[id]/page.tsx
@@ -16,11 +16,9 @@ import { NationHeroBanner } from '@/components/nation/NationHeroBanner'
  * @example /nation/argyra
  * @agentDiscoverable false
  */
-export default async function NationByIdPage({ params }: { params: { id: string } }) {
-    // Await params as required in Next.js 15+ (or recent 14 changes)? Assuming yes or standard access
-    // Next 15 might require awaiting params if they are promises? Stick to standard for now.
-    // If build fails, I'll fix key access.
-    const { id } = await params // Await just in case
+export default async function NationByIdPage({ params }: { params: Promise<{ id: string }> }) {
+    // Next.js 15: route params are async and must be awaited.
+    const { id } = await params
 
     // Check if ID is a name (e.g. "Argyra") or ID.
     // Try finding by ID first, then Name.

--- a/src/app/nonprofit/page.tsx
+++ b/src/app/nonprofit/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+/**
+ * @page /nonprofit
+ * @entity CAMPAIGN
+ * @description About the non-profit — placeholder under construction. Linked
+ *   from the /awaken funnel. Real org details land here once the non-profit
+ *   work is done.
+ * @permissions public
+ * @relationships linked from /awaken
+ * @dimensions WHO:visitor, WHAT:org info, WHERE:campaign, ENERGY:learn
+ * @example /nonprofit
+ * @agentDiscoverable true
+ */
+export const metadata: Metadata = {
+  title: 'About the non-profit — coming soon',
+  description: 'Our non-profit home is being built. Check back soon.',
+}
+
+export default function NonprofitPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-black px-6 text-center text-zinc-200">
+      <div className="max-w-md space-y-6">
+        <div className="text-5xl">🏗️</div>
+        <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-green-400">
+          The non-profit
+        </p>
+        <h1 className="text-3xl font-bold text-white">Under construction</h1>
+        <p className="text-sm leading-relaxed text-zinc-400">
+          We&apos;re building the home for the non-profit story — mission, structure, and how your
+          support compounds. It&apos;s coming soon.
+        </p>
+        <p className="text-sm leading-relaxed text-zinc-400">
+          In the meantime, the most direct way to help is still the simplest one.
+        </p>
+        <div className="flex flex-col gap-3 pt-2">
+          <Link
+            href="/event/donate"
+            className="inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-6 py-3 font-bold text-white transition-all hover:from-green-500 hover:to-emerald-500"
+          >
+            Fuel the car fund →
+          </Link>
+          <Link
+            href="/awaken"
+            className="inline-flex items-center justify-center rounded-xl border border-zinc-700 px-6 py-3 font-bold text-zinc-200 transition-colors hover:border-zinc-500"
+          >
+            ← Back to all the ways to help
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -95,8 +95,15 @@ export default async function Home(props: { searchParams: Promise<{ ritualComple
 
         <div className="flex flex-col gap-4 w-full max-w-xs">
           <Link
-            href="/launch"
+            href="/awaken"
             className="w-full py-3 px-6 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 text-white font-bold rounded-lg text-center transition-all shadow-lg shadow-green-900/30"
+          >
+            Start here — wake up &amp; show up
+          </Link>
+
+          <Link
+            href="/launch"
+            className="w-full py-3 px-6 bg-zinc-900 border border-zinc-700 hover:border-zinc-500 hover:bg-zinc-800 text-zinc-200 font-bold rounded-lg text-center transition-all"
           >
             Explore the book, deck &amp; game
           </Link>

--- a/src/lib/awaken/calendar.ts
+++ b/src/lib/awaken/calendar.ts
@@ -1,0 +1,28 @@
+import type { AwakenEvent } from './content'
+
+/**
+ * Calendar links for awaken events. The events are all-day (date only, no
+ * time), so we build all-day Google Calendar template URLs. Google treats the
+ * end date as exclusive, hence the +1 day.
+ */
+
+function toYmd(d: Date): string {
+  return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(
+    d.getUTCDate(),
+  ).padStart(2, '0')}`
+}
+
+/** Google Calendar "add event" URL for an all-day awaken event. */
+export function googleCalendarUrl(event: AwakenEvent): string {
+  const start = new Date(`${event.date}T00:00:00Z`)
+  const end = new Date(start)
+  end.setUTCDate(end.getUTCDate() + 1) // all-day end is exclusive
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${toYmd(start)}/${toYmd(end)}`,
+    details: event.blurb,
+    location: event.where,
+  })
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}

--- a/src/lib/awaken/content.ts
+++ b/src/lib/awaken/content.ts
@@ -17,40 +17,47 @@ export type AwakenEvent = {
   date: string
   where: string
   blurb: string
+  /** Partiful event page — the official RSVP destination. */
+  partifulUrl: string
 }
 
 /**
- * The three events the weekend of July 18th, 2026.
- * July 18, 2026 is a Saturday, so the weekend spans Jul 17–19.
- * Titles/venues are placeholders — edit to match the real lineup.
+ * The three events the weekend of July 18th, 2026 (Jul 17–19).
+ * RSVPs are handled on Partiful (partifulUrl); /awaken links out to them.
+ *
+ * Titles + dates + Partiful URLs are confirmed. Two titles are still marked
+ * pending by the organizer, and venues/times are TBA — update `where` (and add
+ * times to the calendar links in calendar.ts) once finalized.
  */
 export const AWAKEN_EVENTS: AwakenEvent[] = [
   {
     key: 'jul17-opening-circle',
-    title: 'Opening Circle',
+    title: 'Mastering the Game of Allyship — Book Launch',
     when: 'Fri · Jul 17',
     date: '2026-07-17',
     where: 'Portland · TBA',
-    blurb:
-      'We open the weekend together — name what we are waking up to and set the intention for the work ahead.',
+    blurb: 'The launch itself — the book steps into the world. Come be there for the beginning.',
+    partifulUrl: 'https://partiful.com/e/JTEHEkp0YslfGplWK8vS',
   },
   {
+    // Title pending — organizer to finalize.
     key: 'jul18-mainstage',
-    title: 'The Main Event',
+    title: 'Book Launch Booty Shake™',
     when: 'Sat · Jul 18',
     date: '2026-07-18',
     where: 'Portland · TBA',
-    blurb:
-      'The centerpiece gathering. Story, music, and the live unveiling of where the car fund stands.',
+    blurb: 'A dance party to shake the book into the world. Bring your whole body.',
+    partifulUrl: 'https://partiful.com/e/de44COeykTCRP8qvGt3O',
   },
   {
+    // Title pending — organizer to finalize.
     key: 'jul19-send-off',
-    title: 'Send-Off Brunch',
+    title: 'Mastering the Game of Allyship — Book Launch Game',
     when: 'Sun · Jul 19',
     date: '2026-07-19',
     where: 'Portland · TBA',
-    blurb:
-      'A slower close — coffee, debrief, and the first steps each of us takes back into the world.',
+    blurb: 'Play the game the book is built on — live, together, to close the weekend.',
+    partifulUrl: 'https://partiful.com/e/eY5MfJQg7CtjdimimSxO',
   },
 ]
 

--- a/src/lib/awaken/content.ts
+++ b/src/lib/awaken/content.ts
@@ -1,0 +1,72 @@
+/**
+ * Content + config for the public /awaken guided funnel.
+ *
+ * Shared between the client flow, the server page, and the signup API so that
+ * event keys validate consistently. Copy here is intentionally editable — the
+ * non-profit owner (Wendell) can revise the narrative and event details without
+ * touching component logic.
+ */
+
+export type AwakenEvent = {
+  /** Stable key persisted on FunnelSignup.events — do not rename casually. */
+  key: string
+  title: string
+  /** Human date, e.g. "Fri · Jul 17". */
+  when: string
+  /** ISO date for sorting / calendar wiring later. */
+  date: string
+  where: string
+  blurb: string
+}
+
+/**
+ * The three events the weekend of July 18th, 2026.
+ * July 18, 2026 is a Saturday, so the weekend spans Jul 17–19.
+ * Titles/venues are placeholders — edit to match the real lineup.
+ */
+export const AWAKEN_EVENTS: AwakenEvent[] = [
+  {
+    key: 'jul17-opening-circle',
+    title: 'Opening Circle',
+    when: 'Fri · Jul 17',
+    date: '2026-07-17',
+    where: 'Portland · TBA',
+    blurb:
+      'We open the weekend together — name what we are waking up to and set the intention for the work ahead.',
+  },
+  {
+    key: 'jul18-mainstage',
+    title: 'The Main Event',
+    when: 'Sat · Jul 18',
+    date: '2026-07-18',
+    where: 'Portland · TBA',
+    blurb:
+      'The centerpiece gathering. Story, music, and the live unveiling of where the car fund stands.',
+  },
+  {
+    key: 'jul19-send-off',
+    title: 'Send-Off Brunch',
+    when: 'Sun · Jul 19',
+    date: '2026-07-19',
+    where: 'Portland · TBA',
+    blurb:
+      'A slower close — coffee, debrief, and the first steps each of us takes back into the world.',
+  },
+]
+
+export const AWAKEN_EVENT_KEYS = new Set(AWAKEN_EVENTS.map((e) => e.key))
+
+/** Where the donate CTA points. The existing /event/donate page already works. */
+export const AWAKEN_DONATE_HREF = '/event/donate'
+
+/** Where "buy products / explore the offers" points. */
+export const AWAKEN_PRODUCTS_HREF = '/launch'
+
+/** Non-profit page (currently under construction). */
+export const AWAKEN_NONPROFIT_HREF = '/nonprofit'
+
+/**
+ * Optional static asset for Chapter One. Drop a PDF at public/chapter-one.pdf
+ * and this link goes live; until then we promise delivery by email.
+ */
+export const AWAKEN_CHAPTER_FILE_HREF = '/chapter-one.pdf'

--- a/src/lib/email/awaken.ts
+++ b/src/lib/email/awaken.ts
@@ -1,6 +1,7 @@
 import { sendEmail, type SendEmailResult } from './send'
 import { ChapterOneEmail, chapterOneText } from './templates/ChapterOneEmail'
-import { AWAKEN_CHAPTER_FILE_HREF } from '@/lib/awaken/content'
+import { RsvpConfirmationEmail, rsvpConfirmationText } from './templates/RsvpConfirmationEmail'
+import { AWAKEN_CHAPTER_FILE_HREF, AWAKEN_EVENTS, type AwakenEvent } from '@/lib/awaken/content'
 
 /**
  * Awaken funnel email sends. Thin wrappers over the canonical sendEmail so the
@@ -35,5 +36,28 @@ export async function sendChapterOneEmail(opts: {
     react: ChapterOneEmail(props),
     text: chapterOneText(props),
     tags: [{ name: 'funnel', value: 'awaken-chapter' }],
+  })
+}
+
+export async function sendRsvpConfirmationEmail(opts: {
+  to: string
+  firstName?: string | null
+  /** Validated event keys the visitor RSVP'd to. */
+  eventKeys: string[]
+}): Promise<SendEmailResult> {
+  const keys = new Set(opts.eventKeys)
+  // Preserve canonical event order and drop anything unrecognized.
+  const events: AwakenEvent[] = AWAKEN_EVENTS.filter((e) => keys.has(e.key))
+  if (events.length === 0) {
+    return { ok: true, id: null, skipped: true, reason: 'no_matching_events' }
+  }
+  const homeUrl = absoluteUrl('/awaken')
+  const props = { events, homeUrl, firstName: opts.firstName ?? null }
+  return sendEmail({
+    to: opts.to,
+    subject: `You're on the list — July 17–19`,
+    react: RsvpConfirmationEmail(props),
+    text: rsvpConfirmationText(props),
+    tags: [{ name: 'funnel', value: 'awaken-rsvp' }],
   })
 }

--- a/src/lib/email/awaken.ts
+++ b/src/lib/email/awaken.ts
@@ -1,0 +1,39 @@
+import { sendEmail, type SendEmailResult } from './send'
+import { ChapterOneEmail, chapterOneText } from './templates/ChapterOneEmail'
+import { AWAKEN_CHAPTER_FILE_HREF } from '@/lib/awaken/content'
+
+/**
+ * Awaken funnel email sends. Thin wrappers over the canonical sendEmail so the
+ * route stays declarative and the absolute-URL logic lives in one place.
+ */
+
+/**
+ * Resolve an app-absolute URL for use in email (links must be absolute).
+ * Mirrors the repo convention: NEXT_PUBLIC_BASE_URL → NEXT_PUBLIC_APP_URL →
+ * VERCEL_URL, with a production fallback.
+ */
+export function absoluteUrl(path: string): string {
+  const raw =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '') ||
+    'https://bars-engine.vercel.app'
+  const base = raw.replace(/\/$/, '')
+  return path.startsWith('http') ? path : `${base}${path.startsWith('/') ? '' : '/'}${path}`
+}
+
+export async function sendChapterOneEmail(opts: {
+  to: string
+  firstName?: string | null
+}): Promise<SendEmailResult> {
+  const downloadUrl = absoluteUrl(AWAKEN_CHAPTER_FILE_HREF)
+  const homeUrl = absoluteUrl('/awaken')
+  const props = { downloadUrl, homeUrl, firstName: opts.firstName ?? null }
+  return sendEmail({
+    to: opts.to,
+    subject: 'Chapter One is yours',
+    react: ChapterOneEmail(props),
+    text: chapterOneText(props),
+    tags: [{ name: 'funnel', value: 'awaken-chapter' }],
+  })
+}

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Outbound transactional email. Import from here, not the sub-files.
+ *
+ *   import { sendEmail, isEmailConfigured } from '@/lib/email'
+ *
+ * Env contract lives in ./resend.ts. Provider is Resend, hidden behind
+ * sendEmail so it stays swappable (Sage: reversible).
+ */
+export { sendEmail } from './send'
+export type { SendEmailInput, SendEmailResult } from './send'
+export { isEmailConfigured, getEmailConfig } from './resend'

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,67 @@
+import { Resend } from 'resend'
+
+/**
+ * Resend client + email env contract — the single source of truth for outbound
+ * transactional email. Every feature sends through {@link getResend} /
+ * {@link sendEmail}; do not instantiate Resend anywhere else (Regent: one tool,
+ * one owner).
+ *
+ * Required env (set in Vercel, never committed):
+ *   RESEND_API_KEY   — secret API key from the Resend dashboard
+ *   EMAIL_FROM       — verified sender, e.g.
+ *                      "Wendell · Mastering Allyship <hello@send.masteringallyship.com>"
+ * Optional:
+ *   EMAIL_REPLY_TO   — a human inbox so replies reach a person
+ *                      (Diplomat), e.g. "wendell@masteringallyship.com"
+ *
+ * When RESEND_API_KEY is unset (local dev, previews), the layer degrades
+ * gracefully: sends are logged and no-op'd instead of throwing, so the funnel
+ * never strands a visitor over missing config.
+ */
+
+export type EmailConfig = {
+  apiKey: string
+  from: string
+  replyTo: string | null
+}
+
+/** Read + validate email env. Returns null when email is not configured. */
+export function getEmailConfig(): EmailConfig | null {
+  const apiKey = process.env.RESEND_API_KEY?.trim()
+  const from = process.env.EMAIL_FROM?.trim()
+  if (!apiKey || !from) return null
+  return {
+    apiKey,
+    from,
+    replyTo: process.env.EMAIL_REPLY_TO?.trim() || null,
+  }
+}
+
+/** True when RESEND_API_KEY + EMAIL_FROM are both present. */
+export function isEmailConfigured(): boolean {
+  return getEmailConfig() !== null
+}
+
+// Singleton, mirroring src/lib/db.ts so hot-reload doesn't spawn many clients.
+const globalForResend = globalThis as unknown as {
+  resend?: Resend
+  resendKey?: string
+}
+
+/**
+ * Return a Resend client, or null when email isn't configured. Cached per
+ * API key so a rotated key in dev picks up cleanly.
+ */
+export function getResend(): Resend | null {
+  const config = getEmailConfig()
+  if (!config) return null
+  if (globalForResend.resend && globalForResend.resendKey === config.apiKey) {
+    return globalForResend.resend
+  }
+  const client = new Resend(config.apiKey)
+  if (process.env.NODE_ENV !== 'production') {
+    globalForResend.resend = client
+    globalForResend.resendKey = config.apiKey
+  }
+  return client
+}

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react'
+import type { CreateEmailOptions } from 'resend'
+import { getResend, getEmailConfig } from './resend'
+
+/**
+ * The one canonical email send. Every feature routes through here.
+ *
+ * Design (Architect: persist-then-send): this never throws. Callers persist
+ * their record first, then call sendEmail and tolerate a non-ok result — a
+ * flaky provider must not 500 the request or lose the lead. Wire retries /
+ * re-send tooling on top of the returned result, not by catching exceptions.
+ */
+
+export type SendEmailInput = {
+  to: string | string[]
+  subject: string
+  /** Provide one of `react` or `html` (react wins if both given). */
+  react?: ReactElement
+  html?: string
+  /** Plain-text fallback — improves deliverability and accessibility. */
+  text?: string
+  /** Override the default human reply-to for this send. */
+  replyTo?: string
+  /** Optional tags for Resend analytics (e.g. funnel:awaken). */
+  tags?: { name: string; value: string }[]
+}
+
+export type SendEmailResult =
+  | { ok: true; id: string | null; skipped?: false }
+  | { ok: true; id: null; skipped: true; reason: string }
+  | { ok: false; error: string }
+
+export async function sendEmail(input: SendEmailInput): Promise<SendEmailResult> {
+  const config = getEmailConfig()
+  const resend = getResend()
+
+  // Graceful no-op when email isn't configured (local/preview). The caller's
+  // record is already saved; we just can't deliver yet.
+  if (!config || !resend) {
+    console.warn(
+      `[email] not configured (RESEND_API_KEY/EMAIL_FROM missing) — skipped "${input.subject}" to ${String(input.to)}`,
+    )
+    return { ok: true, id: null, skipped: true, reason: 'email_not_configured' }
+  }
+
+  // CreateEmailOptions is a discriminated union over the content field
+  // (react | html | text), so build exactly one variant rather than spreading.
+  const base = {
+    from: config.from,
+    to: input.to,
+    subject: input.subject,
+    replyTo: input.replyTo ?? config.replyTo ?? undefined,
+    tags: input.tags,
+  }
+  let payload: CreateEmailOptions
+  if (input.react) {
+    payload = { ...base, react: input.react }
+  } else if (input.html) {
+    payload = { ...base, html: input.html, text: input.text }
+  } else {
+    payload = { ...base, text: input.text ?? '' }
+  }
+
+  try {
+    const { data, error } = await resend.emails.send(payload)
+
+    if (error) {
+      console.error('[email] resend returned an error', error)
+      return { ok: false, error: error.message }
+    }
+    return { ok: true, id: data?.id ?? null }
+  } catch (err) {
+    console.error('[email] send threw', err)
+    return { ok: false, error: err instanceof Error ? err.message : 'unknown send error' }
+  }
+}

--- a/src/lib/email/templates/ChapterOneEmail.tsx
+++ b/src/lib/email/templates/ChapterOneEmail.tsx
@@ -1,0 +1,129 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+
+/**
+ * Chapter One delivery email. This is the first contact inside the world —
+ * a welcome over the threshold, not a download receipt (Shaman). We email a
+ * link, never an attachment (Architect: swappable, trackable). Reply-to is a
+ * human inbox, set by the email service (Diplomat).
+ *
+ * Authored copy, human voice — no AI-generated tone (Portland community).
+ */
+
+export type ChapterOneEmailProps = {
+  /** Absolute URL to read/download Chapter One. */
+  downloadUrl: string
+  /** Optional first name for a warmer greeting. */
+  firstName?: string | null
+  /** Absolute URL back to the funnel (donate / events). */
+  homeUrl: string
+}
+
+const main = { backgroundColor: '#0a0908', color: '#e8e6e0', fontFamily: 'Georgia, serif' }
+const container = { margin: '0 auto', padding: '32px 24px', maxWidth: '560px' }
+const eyebrow = {
+  fontSize: '11px',
+  letterSpacing: '3px',
+  textTransform: 'uppercase' as const,
+  color: '#34d399',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  margin: '0 0 12px',
+}
+const heading = { fontSize: '26px', lineHeight: '1.25', color: '#ffffff', margin: '0 0 16px' }
+const text = { fontSize: '16px', lineHeight: '1.7', color: '#d6d3cd', margin: '0 0 16px' }
+const button = {
+  backgroundColor: '#059669',
+  color: '#ffffff',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  fontWeight: 'bold',
+  fontSize: '15px',
+  borderRadius: '10px',
+  padding: '14px 28px',
+  textDecoration: 'none',
+  display: 'inline-block',
+}
+const hr = { borderColor: '#26241f', margin: '28px 0' }
+const muted = { fontSize: '13px', lineHeight: '1.6', color: '#8a877f', margin: '0 0 8px' }
+const link = { color: '#34d399' }
+
+export function ChapterOneEmail({ downloadUrl, firstName, homeUrl }: ChapterOneEmailProps) {
+  const greeting = firstName ? `${firstName}, you're in.` : "You're in."
+  return (
+    <Html>
+      <Head />
+      <Preview>Chapter One is yours — start reading whenever you like.</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Text style={eyebrow}>Mastering Allyship</Text>
+          <Heading style={heading}>{greeting}</Heading>
+
+          <Text style={text}>
+            Thank you for raising your hand. You just crossed from watching to walking — and the
+            first chapter is yours to take with you.
+          </Text>
+
+          <Section style={{ margin: '24px 0' }}>
+            <Button href={downloadUrl} style={button}>
+              Read Chapter One →
+            </Button>
+          </Section>
+
+          <Text style={text}>
+            It opens the story we&apos;re all standing inside right now. Read it slowly. There&apos;s
+            no rush and no test at the end.
+          </Text>
+
+          <Hr style={hr} />
+
+          <Text style={muted}>
+            When you&apos;re ready for the next step — fueling the car fund or finding us in person
+            the weekend of July 18th — it all lives here:{' '}
+            <Link href={homeUrl} style={link}>
+              everything you can do
+            </Link>
+            .
+          </Text>
+          <Text style={muted}>
+            This isn&apos;t an automated list. Just reply to this email and it reaches a real person.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+/** Plain-text fallback — improves deliverability and serves text-only clients. */
+export function chapterOneText({ downloadUrl, firstName, homeUrl }: ChapterOneEmailProps): string {
+  const greeting = firstName ? `${firstName}, you're in.` : "You're in."
+  return [
+    'MASTERING ALLYSHIP',
+    '',
+    greeting,
+    '',
+    'Thank you for raising your hand. You just crossed from watching to walking,',
+    'and the first chapter is yours to take with you.',
+    '',
+    `Read Chapter One: ${downloadUrl}`,
+    '',
+    'It opens the story we are all standing inside right now. Read it slowly.',
+    'There is no rush and no test at the end.',
+    '',
+    `When you are ready for the next step — fueling the car fund or finding us in`,
+    `person the weekend of July 18th — it all lives here: ${homeUrl}`,
+    '',
+    'This is not an automated list. Just reply to this email and it reaches a real person.',
+  ].join('\n')
+}
+
+export default ChapterOneEmail

--- a/src/lib/email/templates/RsvpConfirmationEmail.tsx
+++ b/src/lib/email/templates/RsvpConfirmationEmail.tsx
@@ -91,8 +91,9 @@ export function RsvpConfirmationEmail({ events, firstName, homeUrl }: RsvpConfir
           <Heading style={heading}>{greeting}</Heading>
 
           <Text style={text}>
-            Thank you for showing up — really. Here&apos;s what you&apos;re in for. Add each one to
-            your calendar so the weekend stays real between now and then.
+            Thank you for showing up — really. Here&apos;s the weekend. RSVP on Partiful for the
+            ones you&apos;ll make, and drop them on your calendar so they stay real between now and
+            then.
           </Text>
 
           {events.map((ev) => (
@@ -100,9 +101,14 @@ export function RsvpConfirmationEmail({ events, firstName, homeUrl }: RsvpConfir
               <Text style={eventWhen}>{ev.when}</Text>
               <Text style={eventTitle}>{ev.title}</Text>
               <Text style={eventMeta}>{ev.where}</Text>
-              <Link href={googleCalendarUrl(ev)} style={calLink}>
-                + Add to calendar
+              <Link href={ev.partifulUrl} style={calLink}>
+                RSVP on Partiful →
               </Link>
+              <Text style={{ ...eventMeta, margin: '6px 0 0' }}>
+                <Link href={googleCalendarUrl(ev)} style={calLink}>
+                  + Add to calendar
+                </Link>
+              </Text>
             </Section>
           ))}
 
@@ -136,13 +142,14 @@ export function rsvpConfirmationText({
     '',
     greeting,
     '',
-    'Thank you for showing up. Here is what you are in for — add each one to your',
-    'calendar so the weekend stays real between now and then.',
+    'Thank you for showing up. Here is the weekend — RSVP on Partiful for the ones',
+    'you will make, and drop them on your calendar so they stay real.',
     '',
   ]
   for (const ev of events) {
     lines.push(`${ev.when} — ${ev.title}`)
     lines.push(`  ${ev.where}`)
+    lines.push(`  RSVP on Partiful: ${ev.partifulUrl}`)
     lines.push(`  Add to calendar: ${googleCalendarUrl(ev)}`)
     lines.push('')
   }

--- a/src/lib/email/templates/RsvpConfirmationEmail.tsx
+++ b/src/lib/email/templates/RsvpConfirmationEmail.tsx
@@ -1,0 +1,155 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import type { AwakenEvent } from '@/lib/awaken/content'
+import { googleCalendarUrl } from '@/lib/awaken/calendar'
+
+/**
+ * RSVP confirmation for the July 17–19 weekend. Confirms what they signed up
+ * for, hands them add-to-calendar links so the commitment sticks (Diplomat:
+ * connect onward, screen → in-person), and keeps a human reply-to.
+ *
+ * Authored copy, human voice — no AI-generated tone (Portland community).
+ */
+
+export type RsvpConfirmationEmailProps = {
+  /** The events the visitor actually RSVP'd to (already filtered/validated). */
+  events: AwakenEvent[]
+  firstName?: string | null
+  /** Absolute URL back to the funnel. */
+  homeUrl: string
+}
+
+const main = { backgroundColor: '#0a0908', color: '#e8e6e0', fontFamily: 'Georgia, serif' }
+const container = { margin: '0 auto', padding: '32px 24px', maxWidth: '560px' }
+const eyebrow = {
+  fontSize: '11px',
+  letterSpacing: '3px',
+  textTransform: 'uppercase' as const,
+  color: '#34d399',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  margin: '0 0 12px',
+}
+const heading = { fontSize: '26px', lineHeight: '1.25', color: '#ffffff', margin: '0 0 16px' }
+const text = { fontSize: '16px', lineHeight: '1.7', color: '#d6d3cd', margin: '0 0 16px' }
+const card = {
+  border: '1px solid #26241f',
+  borderRadius: '12px',
+  padding: '16px 18px',
+  margin: '0 0 12px',
+}
+const eventWhen = {
+  fontSize: '12px',
+  letterSpacing: '1px',
+  textTransform: 'uppercase' as const,
+  color: '#34d399',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  margin: '0 0 4px',
+}
+const eventTitle = { fontSize: '18px', color: '#ffffff', margin: '0 0 4px' }
+const eventMeta = { fontSize: '13px', color: '#8a877f', margin: '0 0 10px' }
+const calLink = {
+  fontSize: '13px',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  color: '#34d399',
+  textDecoration: 'none',
+}
+const hr = { borderColor: '#26241f', margin: '28px 0' }
+const muted = { fontSize: '13px', lineHeight: '1.6', color: '#8a877f', margin: '0 0 8px' }
+const button = {
+  backgroundColor: '#059669',
+  color: '#ffffff',
+  fontFamily: 'Helvetica, Arial, sans-serif',
+  fontWeight: 'bold',
+  fontSize: '15px',
+  borderRadius: '10px',
+  padding: '14px 28px',
+  textDecoration: 'none',
+  display: 'inline-block',
+}
+
+export function RsvpConfirmationEmail({ events, firstName, homeUrl }: RsvpConfirmationEmailProps) {
+  const greeting = firstName ? `${firstName}, you're on the list.` : "You're on the list."
+  const count = events.length
+  return (
+    <Html>
+      <Head />
+      <Preview>{`You're confirmed for ${count} event${count === 1 ? '' : 's'} the weekend of July 18th.`}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Text style={eyebrow}>Mastering Allyship · Jul 17–19</Text>
+          <Heading style={heading}>{greeting}</Heading>
+
+          <Text style={text}>
+            Thank you for showing up — really. Here&apos;s what you&apos;re in for. Add each one to
+            your calendar so the weekend stays real between now and then.
+          </Text>
+
+          {events.map((ev) => (
+            <Section key={ev.key} style={card}>
+              <Text style={eventWhen}>{ev.when}</Text>
+              <Text style={eventTitle}>{ev.title}</Text>
+              <Text style={eventMeta}>{ev.where}</Text>
+              <Link href={googleCalendarUrl(ev)} style={calLink}>
+                + Add to calendar
+              </Link>
+            </Section>
+          ))}
+
+          <Hr style={hr} />
+
+          <Section style={{ margin: '8px 0 20px' }}>
+            <Button href={homeUrl} style={button}>
+              See everything for the weekend →
+            </Button>
+          </Section>
+
+          <Text style={muted}>
+            Plans change — if you can&apos;t make one, no guilt. Just reply to this email and let us
+            know. It reaches a real person.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+/** Plain-text fallback — improves deliverability and serves text-only clients. */
+export function rsvpConfirmationText({
+  events,
+  firstName,
+  homeUrl,
+}: RsvpConfirmationEmailProps): string {
+  const greeting = firstName ? `${firstName}, you're on the list.` : "You're on the list."
+  const lines = [
+    'MASTERING ALLYSHIP · JUL 17–19',
+    '',
+    greeting,
+    '',
+    'Thank you for showing up. Here is what you are in for — add each one to your',
+    'calendar so the weekend stays real between now and then.',
+    '',
+  ]
+  for (const ev of events) {
+    lines.push(`${ev.when} — ${ev.title}`)
+    lines.push(`  ${ev.where}`)
+    lines.push(`  Add to calendar: ${googleCalendarUrl(ev)}`)
+    lines.push('')
+  }
+  lines.push(`See everything for the weekend: ${homeUrl}`)
+  lines.push('')
+  lines.push('Plans change — if you cannot make one, no guilt. Just reply to this email.')
+  return lines.join('\n')
+}
+
+export default RsvpConfirmationEmail


### PR DESCRIPTION
## What this is

An end-to-end flow for a brand-new visitor moving from **learning the current state of things** to **showing up** with a concrete action.

## The flow: `/awaken`

**Act I — Wake up:** narrative about the current state of things (the car fund as fuel, not charity), with the weekend framed up front and a clear hand-off to action.

**Act II — Show up:** three concrete moves, each working end-to-end:
1. **Fuel the car fund** → links into the existing `/event/donate` page (real payment links).
2. **Read Chapter One** → email-capture form; persists the lead and confirms delivery. Drop a PDF at `public/chapter-one.pdf` and the instant-download link goes live too.
3. **Be there · Jul 17–19** → pick from the three weekend events (checkboxes) + name/email → RSVP saved.

Plus secondary links: "Explore the book, deck & game" → `/launch`, and "About the non-profit" → `/nonprofit` (under-construction placeholder).

## Changes

- `src/app/awaken/` — server page + `AwakenFlow` client component (sticky progress rail, two acts, three action cards).
- `src/app/api/awaken/signup/route.ts` — public, no-auth lead capture (chapter signups + event RSVPs) with email + event-key validation.
- `FunnelSignup` Prisma model + migration (`20260619120000_add_funnel_signup`) — standalone, no Player FK, so unauthenticated visitors convert without an account.
- `src/lib/awaken/content.ts` — editable copy + the three event definitions (Fri Jul 17 / Sat Jul 18 / Sun Jul 19). **Titles/venues are placeholders** — edit this one file to set the real lineup.
- `src/app/nonprofit/page.tsx` — under-construction page.
- Home page: prominent **"Start here — wake up & show up"** CTA so new visitors land in the flow.
- Fixes a **pre-existing Next.js 15 build blocker** in `nation/[id]/page.tsx` (route `params` must be typed as a `Promise`) so the project builds.

## Verification

`tsc --noEmit`, eslint (0 errors), route validation, the precommit `check`, and a full `next build` webpack compile all pass.

## Follow-ups / notes

- **Email delivery isn't wired yet.** Signups are *captured* (stored in `funnel_signups`) and the UI promises "check your inbox," but no provider actually sends Chapter One or RSVP confirmations. Wiring an email provider is the next step to fully close the loop.
- The migration ships as hand-written SQL (matching the existing migration format) since this environment has no database; apply via `migrate deploy` on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X372LCZKWsn2TXy7Gk8pW6)_