### PR TITLE
Fix empty Hand: route captures to Hand + Hand↔Vault movement (#132)

### DIFF
--- a/.specify/specs/hand-vault-capture-movement/SIX_FACE_ANALYSIS.md
+++ b/.specify/specs/hand-vault-capture-movement/SIX_FACE_ANALYSIS.md
@@ -1,0 +1,76 @@
+# Six GM Faces — Deliberation on `hand-vault-capture-movement`
+
+> Convened on [spec.md](./spec.md) + the open questions in [plan.md](./plan.md). Faces per [specs/doctrine/gm-faces.md](../../../specs/doctrine/gm-faces.md). Each face is a lens; verdicts and the residual forks for the human are at the bottom.
+
+## GM Face Routing
+
+**Primary Face**: Systems Architect — the dominant work is wiring an existing model/action layer into capture + three UI surfaces with no schema change.
+
+**Secondary Faces**: Ontologist (Hand/Vault/Garden vocabulary), Experience Designer (overflow friction on an immersive canvas).
+
+**Review Faces**: Encounter Designer, Steward, Integrator.
+
+---
+
+## Ontologist — *does this object already exist under another name?*
+
+- **Location vs maturity is a real category split, and the spec under-handles it.** A `CustomBar` has **maturity** (`captured → context_named → elaborated → shared_or_acted → integrated`) *and* a **location** (Hand iff a `HandSlot` binds it; otherwise Vault). But the home-vault IA defines a **Garden**: `context_named`/`elaborated` BARs are *planted* and surface under Garden (`NowHome.fetchBarCounts` counts them separately, not as Vault). So "Vault" in storage terms (no `HandSlot`) actually spans **two felt places — Vault and Garden.** The spec's binary "Hold in Hand / Return to Vault" silently lets a player yank a *planted Garden seed* into the Hand and, on return, drop it back into a "Vault" the UI never showed it in. **→ Decide the movement toggle's eligibility by maturity (see Fork B).**
+- **"Vault" vocabulary collides with a pending rename.** [`hand-vault-rename`](../hand-vault-rename/spec.md) is reworking `/hand` route/title/concept ("the page you play from is the Hand; the Vault is overflow reachable from it"). Hard-coding "Return to Vault" copy now risks re-mislabeling. **→ Centralize the two strings (`HOLD_IN_HAND`, `RETURN_TO_VAULT`) in one constant the rename can repoint.**
+- **Naming verdict on the actions is clean.** "Hold in Hand" / "Return to Vault" are good ritual verbs and do *not* collide with **Compost** (which archives via `archivedAt`). Keep them, but the UI must visibly differ from the compost affordance so "Return to Vault" never reads as destruction.
+
+## Systems Architect — *fit into existing architecture; migration safety*
+
+- **No schema change — endorsed.** `HandSlot` already encodes location; a `CustomBar.location` column would create a second source of truth that can disagree with the join table. Reject the issue's `location` suggestion explicitly (spec already does).
+- **Return-shape change to `captureBarFromCanvas` is safe:** single caller (`SeedCaptureWhiteboard.tsx:1529`). But note **`bar-capture-consolidation` is concurrently editing this same action** (adds `title`, a Captured overlay state, Tune path). **→ Coordinate: land on one return type** `{ barId, title, placedIn, overflow? }` so the two kits don't stomp each other.
+- **Import boundary confirmed:** pull `addBarToHandForPlayer` from `@/lib/hand-service` (plain module), *not* the `'use server'` `actions/hand.ts` — the cross-`'use server'` import rule is documented at the top of `hand-service.ts`. Plan already says this.
+- **Drop the new `getBarHandState` action.** The BAR detail page is a server component; it can read `HandSlot` inline and pass `inHand`/`handFull` as props to the client `HandLocationToggle`. One fewer server action, no new round-trip. (List rows already render server-side too — pass the flag down.) **→ Simplification: compute in the server component, not a new action.**
+- **Concurrency:** `addBarToHandForPlayer` does `findMany` → `upsert` on `(playerId, slotIndex)`. Two near-simultaneous captures could target the same empty slot; the unique constraint will make the second `upsert` overwrite rather than error, so one capture could lose its slot. Single-user risk is low, but **note it** — a `$transaction` around find+upsert would harden it if it ever bites.
+
+## Experience Designer — *ritual vs. paperwork; the gift of context at the right moment*
+
+- **Forcing an overflow modal on the whiteboard is paperwork at the wrong moment.** The whiteboard is a full-bleed, immersive "make something" canvas. A power-capturer with a full Hand would hit a swap-decision modal *every capture* — friction precisely when flow matters most. The quick-keep `CaptureBox` overflow modal is fine (it's a deliberate toggle); the canvas is not. **→ Prefer a silent Vault fallback + toast ("Hand full — saved to your Vault; hold it when you have room") (see Fork A).** Capture is never blocked, never modal-interrupted.
+- **Empty Hand slot must not overload one tap.** Today `+` → `/bars/create`. Adding "pull from Vault" means two intents. **→ The empty slot opens a small bottom-sheet: "Pull from Vault" (list) / "Capture new" (→ whiteboard).** Don't make a bare tap ambiguous.
+- **One shared `HandLocationToggle` across all three surfaces — endorsed.** Consistency + single maintenance point. Compact variant for rows; full for detail.
+- **Honest copy (HV-MV-6) matters most here.** The current bug literally lies (says nothing, BAR vanishes to Vault). Toasts must name the real destination.
+
+## Encounter Designer — *does it generate gameplay?*
+
+- **This unblocks the core loop — highest-value framing.** An empty Hand means the daily charge and the 5 moves have nothing to act on. Captures landing **active in the Hand** make the Hand the live workbench; the loop (capture → hold → tend/advance → file) starts turning. This is the real prize, above the movement UI.
+- **Keep the overflow *choice* somewhere — it's a good micro-encounter** ("which seed do I set down to pick this up?"). On the deliberate `CaptureBox` Hand toggle, yes. On the immersive canvas, the choice can wait (Fork A) — the player resolves it later from the Hand glance, which is itself a small encounter.
+- **Movement should stay free and unlimited** (no energy cost) — matches home-vault IA's "deposit is a free action." A cost here would tax the very behavior we're trying to unblock.
+
+## Steward — *privacy, access, safety*
+
+- **Owner-only, enforced twice.** `promoteVaultBarToHand`/`depositHandBarToVault` already check `creatorId === playerId`. The detail page renders for `isOwner || isRecipient` — **gate the toggle to `isOwner` strictly**, never `isRecipient` (a talisman recipient must not move someone else's BAR). List rows: only on owned rows.
+- **No new data captured, no AI, deterministic** — clean on privacy and projection risk.
+
+## Integrator (Deftness) — *lineage, coherence, evaluation*
+
+- **Lineage preserved:** `captureBarFromCanvas` already stamps `campaignRef`, `provenanceSource`, `contextLines`, `storyContent`; our change only adds a `HandSlot` binding after creation. No provenance regression.
+- **Coherence flag — two capture defaults must read as one principle, not an inconsistency:** `CaptureBox` defaults to Vault, whiteboard defaults to Hand. State the rule in one sentence in the spec so it's a *doctrine*, not a discrepancy: **"Quick-keep files (Vault); deliberate make holds (Hand)."** Also note this aligns with `bar-seed-capture-whiteboard` FR13's original "redirect to `/hand`" intent — we are *restoring* intent, not inventing divergence.
+- **Sequence with the rename:** if `hand-vault-rename` is imminent, coordinate the vocabulary once (constants) rather than shipping copy that needs immediate rework.
+- **Evaluation hook present:** `cert-hand-vault-movement-v1` walks the full loop — keep it; it is the deftness check that the wiring actually closes.
+
+---
+
+## Verdicts on the three open questions
+
+| Open question | Convened verdict |
+|---|---|
+| **Vault/feed row inventory (T2.0)** | Keep as a discovery step, but **scope it**: target the owned-BAR rows in the Vault sections (`src/components/hand/Vault*`) and the Garden list first; defer feed if rows there aren't owner-context. One `HandLocationToggle(compact)` everywhere. |
+| **OverflowModal extraction** | **Yes, extract** `src/components/now/OverflowModal.tsx` from `CaptureBox` and share it — but per Fork A it may only be needed by `CaptureBox` (not the whiteboard). Extract anyway for reuse + testability; it's ~80 lines of duplicated markup otherwise. |
+| **Hand-glance Vault picker UX** | **In-place bottom-sheet**, not a page route. Stays on Now (mobile-first), and the empty slot offers both "Pull from Vault" and "Capture new" so we don't overload the tap. |
+
+## Residual forks for the human (faces split / ontology choice)
+
+**Fork A — Whiteboard capture when the Hand is full (6/6):**
+- *Experience Designer + Integrator:* **silent Vault fallback + toast** ("Hand full — saved to Vault; hold it later"). No modal on the immersive canvas; resolve later from the Hand glance.
+- *Encounter Designer:* the swap is a nice micro-choice — but agrees it can be deferred off the canvas.
+- **Convened recommendation: silent Vault fallback on the whiteboard; keep the forced overflow modal only on the deliberate `CaptureBox` Hand toggle.** (Spec currently says "overflow modal on whiteboard" — this would change it.)
+
+**Fork B — Should "Hold in Hand / Return to Vault" appear on *planted* (Garden) BARs?**
+- *Ontologist:* Garden is a distinct felt place; blindly treating planted BARs as "Vault" muddies the ontology.
+- **Convened recommendation: show the movement toggle only for `captured`-maturity and `shared_or_acted` BARs** (the two phases the IA homes in Hand/Vault). For `context_named`/`elaborated` (planted), the home is the **Garden** — offer "Hold in Hand" there too if desired, but label the origin **Garden**, not Vault, and treat Garden↔Hand as its own move. Simplest v1: **restrict the toggle to non-planted BARs**; handle Garden↔Hand in a follow-up.
+
+Both forks are genuine product decisions — surfaced to the human rather than silently chosen.
+</content>

--- a/.specify/specs/hand-vault-capture-movement/SIX_FACE_ANALYSIS.md
+++ b/.specify/specs/hand-vault-capture-movement/SIX_FACE_ANALYSIS.md
@@ -61,6 +61,13 @@
 | **OverflowModal extraction** | **Yes, extract** `src/components/now/OverflowModal.tsx` from `CaptureBox` and share it — but per Fork A it may only be needed by `CaptureBox` (not the whiteboard). Extract anyway for reuse + testability; it's ~80 lines of duplicated markup otherwise. |
 | **Hand-glance Vault picker UX** | **In-place bottom-sheet**, not a page route. Stays on Now (mobile-first), and the empty slot offers both "Pull from Vault" and "Capture new" so we don't overload the tap. |
 
+## Residual forks — DECIDED by the human (2026-06-20)
+
+- **Fork A → Silent Vault fallback + toast** on the whiteboard when Hand is full. No modal on the canvas.
+- **Fork B → Restrict the movement toggle to non-planted BARs** (`captured` / `shared_or_acted`) in v1; Garden↔Hand deferred.
+
+Original framing retained below for the record.
+
 ## Residual forks for the human (faces split / ontology choice)
 
 **Fork A — Whiteboard capture when the Hand is full (6/6):**

--- a/.specify/specs/hand-vault-capture-movement/plan.md
+++ b/.specify/specs/hand-vault-capture-movement/plan.md
@@ -1,0 +1,49 @@
+# Plan: Hand/Vault — Capture Routing + Bidirectional Movement
+
+> Implementation plan for [spec.md](./spec.md). Fixes issue #132. API-first order; no schema change.
+
+## Strategy
+
+The model layer is done. This is a **wiring job**: route capture into the Hand and surface the two existing movement actions in the UI. Build server-side first (one extended action + one tiny read helper), then a single shared client toggle reused across three surfaces, then the overflow handling on the whiteboard, then the cert quest.
+
+Minimize new surface area: one new client component (`HandLocationToggle`) does Vault→Hand and Hand→Vault everywhere; the whiteboard reuses the overflow-modal pattern that already lives in `CaptureBox`.
+
+## Key files
+
+| Concern | File | Change |
+|---------|------|--------|
+| Canvas capture routing | `src/actions/bars.ts` (`captureBarFromCanvas`) | Call `addBarToHandForPlayer`; return `placedIn` + optional `overflow`. Import from `@/lib/hand-service` (not the `'use server'` `hand.ts`, to avoid the Turbopack cross-`'use server'` import rule noted in `hand-service.ts`). |
+| Read helper | `src/actions/hand.ts` | Add `getBarHandState({ barId })` → `{ inHand, handFull }`. |
+| Whiteboard | `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture` ~L1525, `setCaptured`) | Branch on `placedIn`/`overflow`; render overflow modal; run media upload in hand+vault branches. |
+| Simple capture | `src/components/bars/SimpleCaptureForm.tsx` (~L37) | `destination: 'hand'`; route `/bars/kept?dest=hand`. |
+| Kept confirmation | `src/app/bars/kept/page.tsx` | Already reads `dest` — ensure copy/links read well for `hand`. |
+| Shared toggle | `src/components/hand/HandLocationToggle.tsx` (new) | "Hold in Hand" / "Return to Vault"; calls `promoteVaultBarToHand` / `depositHandBarToVault`; hand-full message; `compact` prop for list rows. |
+| Overflow modal | `src/components/now/OverflowModal.tsx` (extract from `CaptureBox`, or reuse inline) | Shared by CaptureBox + whiteboard. |
+| BAR detail | `src/app/bars/[id]/page.tsx` (~L216) | Render `HandLocationToggle` (owner only) using `getBarHandState`. |
+| Vault/feed rows | `src/components/hand/Vault*` + garden/feed list row component(s) — **confirm exact files in T2.0** | Add compact `HandLocationToggle` on owned-BAR rows. |
+| Hand glance | `src/components/now/HandGlance.tsx` (empty slot ~L102) | Replace `/bars/create` link with Vault-picker control → `promoteVaultBarToHand`; keep a create affordance. |
+
+## Open implementation questions (resolve during build, not blocking the spec)
+
+- **Vault/feed row inventory (T2.0)**: enumerate the exact list components that render owned BAR rows (Vault sections under `src/components/hand/`, the garden list, any feed). The spec mandates row-level controls; the precise files are a discovery step.
+- **OverflowModal extraction**: the overflow markup currently lives inline in `CaptureBox.tsx`. Extract to a shared component so the whiteboard reuses it rather than duplicating ~80 lines.
+- **Hand-glance Vault picker UX**: lightweight bottom-sheet list of Vault BARs vs. routing to a dedicated picker page. Prefer an in-place sheet to stay on Now (mobile-first).
+
+## Sequencing & risk
+
+1. Phase 1 (capture → Hand) is the highest-value, lowest-risk slice and resolves the literal "Hand stays empty" report. Ship/verify it first.
+2. Phase 2 (movement UI) reuses already-tested actions; risk is UI placement and the row-component discovery.
+3. Phase 3 cert quest follows the existing seed-script pattern.
+
+## Verification
+
+- `npm run check` (lint + type-check) and `npm run build` green.
+- Manual mobile pass (360px): whiteboard capture → Hand; detail toggle both directions; full-hand overflow; empty-slot pull.
+- Cert quest `cert-hand-vault-movement-v1` completable end to end.
+
+## Out of scope
+
+- Any `CustomBar.location` column (rejected — `HandSlot` already encodes location).
+- Changing `CaptureBox`'s default-Vault behavior.
+- Hand reordering / carrying-slot changes (owned by `hand-vault-bounded-inventory`).
+</content>

--- a/.specify/specs/hand-vault-capture-movement/plan.md
+++ b/.specify/specs/hand-vault-capture-movement/plan.md
@@ -29,10 +29,10 @@ Minimize new surface area: one new client component (`HandLocationToggle`) does 
 - **OverflowModal extraction** → **yes, extract** `src/components/now/OverflowModal.tsx` from `CaptureBox` for reuse + testability (even if Fork A means only `CaptureBox` consumes it).
 - **Hand-glance Vault picker UX** → **in-place bottom-sheet** (stay on Now, mobile-first); the empty slot offers both "Pull from Vault" and "Capture new" so a bare tap is never ambiguous.
 
-## Residual forks for the human (do not implement until decided)
+## Forks — DECIDED
 
-- **Fork A — whiteboard Hand-full**: convened recommendation = **silent Vault fallback + toast** (no modal on the canvas). Alternative = forced overflow modal.
-- **Fork B — movement on planted/Garden BARs**: convened recommendation = **restrict toggle to non-planted BARs in v1**; handle Garden↔Hand as a follow-up. Alternative = enable on planted, labeling origin "Garden".
+- **Fork A — whiteboard Hand-full** → **silent Vault fallback + toast** (no modal on the canvas). `captureBarFromCanvas` returns `placedIn: 'vault'` with no `overflow`; the whiteboard shows the fallback toast.
+- **Fork B — movement on planted/Garden BARs** → **restrict toggle to non-planted BARs** (`captured` / `shared_or_acted`) in v1; Garden↔Hand is a follow-up.
 
 ## Architect notes folded into the spec
 

--- a/.specify/specs/hand-vault-capture-movement/plan.md
+++ b/.specify/specs/hand-vault-capture-movement/plan.md
@@ -23,11 +23,23 @@ Minimize new surface area: one new client component (`HandLocationToggle`) does 
 | Vault/feed rows | `src/components/hand/Vault*` + garden/feed list row component(s) — **confirm exact files in T2.0** | Add compact `HandLocationToggle` on owned-BAR rows. |
 | Hand glance | `src/components/now/HandGlance.tsx` (empty slot ~L102) | Replace `/bars/create` link with Vault-picker control → `promoteVaultBarToHand`; keep a create affordance. |
 
-## Open implementation questions (resolve during build, not blocking the spec)
+## Open implementation questions — resolved by the Six Faces ([SIX_FACE_ANALYSIS.md](./SIX_FACE_ANALYSIS.md))
 
-- **Vault/feed row inventory (T2.0)**: enumerate the exact list components that render owned BAR rows (Vault sections under `src/components/hand/`, the garden list, any feed). The spec mandates row-level controls; the precise files are a discovery step.
-- **OverflowModal extraction**: the overflow markup currently lives inline in `CaptureBox.tsx`. Extract to a shared component so the whiteboard reuses it rather than duplicating ~80 lines.
-- **Hand-glance Vault picker UX**: lightweight bottom-sheet list of Vault BARs vs. routing to a dedicated picker page. Prefer an in-place sheet to stay on Now (mobile-first).
+- **Vault/feed row inventory (T2.0)** → keep as a scoped discovery step: target owned-BAR rows in `src/components/hand/Vault*` and the Garden list first; defer feed if rows aren't owner-context. One `HandLocationToggle(compact)` everywhere.
+- **OverflowModal extraction** → **yes, extract** `src/components/now/OverflowModal.tsx` from `CaptureBox` for reuse + testability (even if Fork A means only `CaptureBox` consumes it).
+- **Hand-glance Vault picker UX** → **in-place bottom-sheet** (stay on Now, mobile-first); the empty slot offers both "Pull from Vault" and "Capture new" so a bare tap is never ambiguous.
+
+## Residual forks for the human (do not implement until decided)
+
+- **Fork A — whiteboard Hand-full**: convened recommendation = **silent Vault fallback + toast** (no modal on the canvas). Alternative = forced overflow modal.
+- **Fork B — movement on planted/Garden BARs**: convened recommendation = **restrict toggle to non-planted BARs in v1**; handle Garden↔Hand as a follow-up. Alternative = enable on planted, labeling origin "Garden".
+
+## Architect notes folded into the spec
+
+- **No new `getBarHandState` action** — compute `inHand`/`handFull` inline in the server components.
+- **Coordinate the `captureBarFromCanvas` return type with `bar-capture-consolidation`** (it edits the same action: adds `title`, Captured overlay, Tune path). Converge on `{ barId, title, placedIn, overflow? }`.
+- Import `addBarToHandForPlayer` from `@/lib/hand-service` (not the `'use server'` `hand.ts`).
+- Optional hardening: wrap find+upsert in `addBarToHandForPlayer` in a `$transaction` if concurrent-capture slot races ever surface.
 
 ## Sequencing & risk
 

--- a/.specify/specs/hand-vault-capture-movement/spec.md
+++ b/.specify/specs/hand-vault-capture-movement/spec.md
@@ -15,13 +15,30 @@ The result: the Hand is perpetually empty, exactly as reported.
 
 **Practice**: Deftness Development — spec kit first, API-first (contract before UI), deterministic over AI. This kit adds **no new Prisma models**; it reuses the existing `HandSlot` join table.
 
+> Reviewed by the Six GM Faces — see [SIX_FACE_ANALYSIS.md](./SIX_FACE_ANALYSIS.md). Two product forks remain open for the human (Fork A: whiteboard overflow behavior; Fork B: movement on planted/Garden BARs).
+
+## GM Face Routing
+
+Primary Face: Systems Architect
+
+Secondary Faces:
+- Ontologist
+- Experience Designer
+
+Review Faces:
+- Encounter Designer
+- Steward
+- Integrator
+
 ## Design Decisions
 
 | Topic | Decision |
 |-------|----------|
 | Schema | **No new field, no new table.** Hand membership stays explicit via the existing `HandSlot` join table (a BAR is "in Hand" iff a `HandSlot` row binds it; "in Vault" iff owned + active + unbound). The issue's suggested `location` column is unnecessary and would duplicate state. |
 | Canvas capture destination | **Always to Hand.** The Seed Capture Whiteboard (`/bars/capture`) routes the new BAR into the Hand via `addBarToHandForPlayer`. A full Hand surfaces the **overflow modal** (deposit one Hand BAR → Vault) — capture is still never lost (the BAR is parked in the Vault until resolved). This is a deliberate divergence from the default-Vault rule in [`home-vault-ia-redesign`](../home-vault-ia-redesign/spec.md): the whiteboard is the player's "make something now" surface, so its output should be active in hand. |
-| Quick-capture (`CaptureBox`, NOW footer) | **Unchanged** — it already offers the Hand/Vault toggle (default Vault) and wires the overflow modal correctly. Quick keep = file to Vault by default; whiteboard = active in Hand. |
+| Quick-capture (`CaptureBox`, NOW footer) | **Unchanged** — it already offers the Hand/Vault toggle (default Vault) and wires the overflow modal correctly. |
+| Capture doctrine (one principle, not two defaults) | **"Quick-keep files (Vault); deliberate make holds (Hand)."** The two capture surfaces default differently *on purpose*: the footer is a fast inbox dump, the whiteboard is a deliberate creation. This **restores** `bar-seed-capture-whiteboard` FR13's original "redirect to `/hand`" intent (Integrator). |
+| Movement copy as constants | "Hold in Hand" / "Return to Vault" live in **one shared constant** so [`hand-vault-rename`](../hand-vault-rename/spec.md) can repoint the vocabulary without hunting strings (Ontologist). |
 | `SimpleCaptureForm` / `/bars/kept` confirmation | Capture routes to Hand; the "kept" confirmation reads `dest=hand` and links onward (Tune / go to Hand). |
 | Vault → Hand / Hand → Vault movement | Bidirectional, reusing existing actions (`promoteVaultBarToHand`, `depositHandBarToVault`). Exposed in **three** places (per product decision): BAR detail page, Vault/feed list rows, and the Hand glance on Now. |
 | Movement copy | Vault → Hand = **"Hold in Hand"**. Hand → Vault = **"Return to Vault"** (the gentle "file away"/compost-adjacent action; does not archive the BAR). |
@@ -82,17 +99,9 @@ function captureBarFromCanvas(payload: CaptureBarFromCanvasInput): Promise<
 | `resolveOverflow({ newBarId, depositBarId })` | `src/actions/hand.ts` | whiteboard + CaptureBox overflow modals |
 | `getPlayerHand()` | `src/actions/hand.ts` | detail page (is-this-BAR-in-hand? + empty-slot count) |
 
-### New thin server helper (read) — `src/actions/hand.ts`
+### Is-this-BAR-in-hand? — computed inline, **no new action**
 
-```ts
-// Tells the BAR detail page which movement action to offer.
-function getBarHandState(input: { barId: string }): Promise<
-  | { inHand: boolean; handFull: boolean }
-  | { error: string }
->
-```
-
-Determined from `HandSlot` rows for the player (no new persistence).
+The BAR detail page and list rows are **server components**; they read `HandSlot` rows directly and pass `inHand` / `handFull` as props to the client `HandLocationToggle`. (Architect simplification — avoids a new server action and an extra round-trip.) No new persistence; determined from `HandSlot`.
 
 ## User Stories
 
@@ -135,13 +144,13 @@ Determined from `HandSlot` rows for the player (no new persistence).
 ### Phase 1 — Capture routes to Hand (API → UI)
 
 - **FR1**: Extend `captureBarFromCanvas` to call `addBarToHandForPlayer` and return `placedIn` + optional `overflow` (contract above). Type-check green.
-- **FR2**: `SeedCaptureWhiteboard.handleCapture` handles all three results: `placedIn: 'hand'` → confirm "in your Hand"; `overflow` → render the overflow modal (reuse the CaptureBox pattern / a shared `OverflowModal`), resolve via `resolveOverflow`; `error` → show error. Media upload runs in the hand & vault branches.
+- **FR2**: `SeedCaptureWhiteboard.handleCapture` confirms "in your Hand" on `placedIn: 'hand'` and shows errors on `error`. **Hand-full behavior is Fork A** (see SIX_FACE_ANALYSIS): convened recommendation is a **silent Vault fallback + toast** ("Hand full — saved to Vault; hold it later"), *not* a modal on the immersive canvas. (If the human picks the modal instead, reuse the shared `OverflowModal` + `resolveOverflow`.) Media upload runs in every non-error branch. Coordinate the return type with `bar-capture-consolidation`.
 - **FR3**: `SimpleCaptureForm` routes to Hand (pass `destination: 'hand'` to `captureBar`); `/bars/kept` reads `dest=hand` and its copy + onward links reflect the Hand.
 
 ### Phase 2 — Bidirectional movement UI
 
-- **FR4**: Add `getBarHandState` read helper to `src/actions/hand.ts`.
-- **FR5**: BAR detail page (`src/app/bars/[id]/page.tsx`, owner only): a contextual `HandLocationToggle` client component — "Hold in Hand" when in Vault, "Return to Vault" when in Hand; hand-full message handled; `router.refresh()` after.
+- **FR4**: Compute `inHand` / `handFull` inline in the server components (detail page + list rows) from `HandSlot`; **no new server action**. Movement copy lives in one shared constant. **Fork B**: in v1 the toggle is shown only for non-planted BARs (`captured` / `shared_or_acted`); `context_named`/`elaborated` (Garden) are deferred — pending the human's call.
+- **FR5**: BAR detail page (`src/app/bars/[id]/page.tsx`): a contextual `HandLocationToggle` client component — "Hold in Hand" when in Vault, "Return to Vault" when in Hand; hand-full message handled; `router.refresh()` after. **Gate strictly to `isOwner`** (never `isRecipient`) — a talisman recipient must not move someone else's BAR (Steward).
 - **FR6**: Vault/feed list rows: an inline quick-action (same toggle, compact) on owned-BAR rows. Reuse `HandLocationToggle`. (Identify the row component(s) during planning — candidates under `src/components/hand/Vault*` and the feed/garden lists.)
 - **FR7**: Hand glance empty slot (`src/components/now/HandGlance.tsx`): replace the `/bars/create` link with a control that opens a Vault picker and calls `promoteVaultBarToHand`; keep a "create new" affordance available too.
 

--- a/.specify/specs/hand-vault-capture-movement/spec.md
+++ b/.specify/specs/hand-vault-capture-movement/spec.md
@@ -1,0 +1,201 @@
+# Spec: Hand/Vault — Capture Routing + Bidirectional Movement
+
+> Fixes GitHub issue #132 — "Hand stays unpopulated: BAR capture doesn't save to Hand, no Vault↔Hand movement."
+
+## Purpose
+
+Make the **Hand** actually fill up and let BARs move freely between **Hand** and **Vault**. Today the dominant capture surface (the Seed Capture Whiteboard at `/bars/capture`) always lands a new BAR in the Vault, and there is no UI anywhere to move an existing BAR between Hand and Vault. The bounded-inventory model and its server actions already exist and are correct — this kit finishes the wiring so the player-facing flow matches the design.
+
+**Problem**: The `HandSlot` model and the full Hand action layer (`addBarToHand`, `promoteVaultBarToHand`, `depositHandBarToVault`, `resolveOverflow`) shipped, but:
+1. `captureBarFromCanvas` (the primary capture path) never calls into the Hand — every canvas capture goes to the Vault.
+2. `SimpleCaptureForm` hardcodes `destination: 'vault'`.
+3. No surface invokes `promoteVaultBarToHand` / `depositHandBarToVault`, so once a BAR is in the Vault there is no in-game path to pull it into the Hand (or send it back). The Hand glance's empty slot links to `/bars/create` instead.
+
+The result: the Hand is perpetually empty, exactly as reported.
+
+**Practice**: Deftness Development — spec kit first, API-first (contract before UI), deterministic over AI. This kit adds **no new Prisma models**; it reuses the existing `HandSlot` join table.
+
+## Design Decisions
+
+| Topic | Decision |
+|-------|----------|
+| Schema | **No new field, no new table.** Hand membership stays explicit via the existing `HandSlot` join table (a BAR is "in Hand" iff a `HandSlot` row binds it; "in Vault" iff owned + active + unbound). The issue's suggested `location` column is unnecessary and would duplicate state. |
+| Canvas capture destination | **Always to Hand.** The Seed Capture Whiteboard (`/bars/capture`) routes the new BAR into the Hand via `addBarToHandForPlayer`. A full Hand surfaces the **overflow modal** (deposit one Hand BAR → Vault) — capture is still never lost (the BAR is parked in the Vault until resolved). This is a deliberate divergence from the default-Vault rule in [`home-vault-ia-redesign`](../home-vault-ia-redesign/spec.md): the whiteboard is the player's "make something now" surface, so its output should be active in hand. |
+| Quick-capture (`CaptureBox`, NOW footer) | **Unchanged** — it already offers the Hand/Vault toggle (default Vault) and wires the overflow modal correctly. Quick keep = file to Vault by default; whiteboard = active in Hand. |
+| `SimpleCaptureForm` / `/bars/kept` confirmation | Capture routes to Hand; the "kept" confirmation reads `dest=hand` and links onward (Tune / go to Hand). |
+| Vault → Hand / Hand → Vault movement | Bidirectional, reusing existing actions (`promoteVaultBarToHand`, `depositHandBarToVault`). Exposed in **three** places (per product decision): BAR detail page, Vault/feed list rows, and the Hand glance on Now. |
+| Movement copy | Vault → Hand = **"Hold in Hand"**. Hand → Vault = **"Return to Vault"** (the gentle "file away"/compost-adjacent action; does not archive the BAR). |
+| Hand-full on a move | `promoteVaultBarToHand` returns `{ success: false, reason: 'hand-full' }`. The detail/list UIs show a non-blocking "Hand is full (6/6) — return one first" message; they do **not** force an overflow swap (only capture does that, to keep the explicit-deposit gesture rare). |
+| Idempotence | Moving a BAR already in its target location is a no-op success (the actions already handle this). |
+
+## Conceptual Model
+
+```
+CAPTURE
+  ├── Whiteboard (/bars/capture) ──► HAND  (overflow modal if 6/6)   ← FIXED
+  └── Quick keep (CaptureBox)     ──► toggle Hand | Vault (default Vault)  ← already works
+
+MOVEMENT (new UI over existing actions)
+  Vault ──"Hold in Hand"──►  Hand      (promoteVaultBarToHand)
+  Hand  ──"Return to Vault"─► Vault     (depositHandBarToVault)
+
+  Surfaces:  BAR detail page · Vault/feed list rows · Hand glance empty slot
+```
+
+| Dimension | This Spec |
+|-----------|-----------|
+| **WHO** | Player |
+| **WHAT** | A `CustomBar` and its Hand/Vault location (a `HandSlot` binding) |
+| **WHERE** | `/bars/capture` (whiteboard), `/bars/[id]` (detail), Vault/feed lists, Now home (Hand glance) |
+| **Energy** | Captures land active in the Hand → the daily charge and the 5 moves have something to act on; throughput unblocks |
+| **Personal throughput** | Capture → held in Hand → tend/advance → Return to Vault when filed; the Hand reflects current active work |
+
+## API Contracts (API-First)
+
+All movement actions **already exist** in `src/actions/hand.ts` and `src/lib/hand-service.ts` and need no signature change. This kit wires capture and the UI to them. The only server-side change is to **capture routing**.
+
+### `captureBarFromCanvas` (extended) — `src/actions/bars.ts`
+
+Route the canvas capture into the Hand instead of leaving it unbound.
+
+```ts
+// existing signature unchanged at the call site; result shape extended
+function captureBarFromCanvas(payload: CaptureBarFromCanvasInput): Promise<
+  | { barId: string; title: string; placedIn: 'hand' }
+  | { barId: string; title: string; placedIn: 'vault'; overflow: OverflowContext } // hand was full
+  | { error: string }
+>
+```
+
+- After creating the BAR (unchanged), call `addBarToHandForPlayer(playerId, bar.id)`.
+- On success → `placedIn: 'hand'`.
+- On `overflow` → BAR is created and parked in the Vault; return `placedIn: 'vault'` + the `OverflowContext` so the whiteboard can show the existing overflow modal (resolve via `resolveOverflow`).
+- Keep `revalidatePath('/bars')`, `'/bars/garden'`, `'/hand'`, `'/'`.
+- Media upload (photos/voice) in `SeedCaptureWhiteboard` runs after, unchanged, keyed off `barId` in every branch.
+
+### Reused as-is (no change)
+
+| Action | File | Used by |
+|--------|------|---------|
+| `promoteVaultBarToHand({ barId, targetSlot? })` | `src/actions/hand.ts` | detail page, list rows, Hand glance empty slot |
+| `depositHandBarToVault({ barId })` | `src/actions/hand.ts` | detail page, list rows |
+| `resolveOverflow({ newBarId, depositBarId })` | `src/actions/hand.ts` | whiteboard + CaptureBox overflow modals |
+| `getPlayerHand()` | `src/actions/hand.ts` | detail page (is-this-BAR-in-hand? + empty-slot count) |
+
+### New thin server helper (read) — `src/actions/hand.ts`
+
+```ts
+// Tells the BAR detail page which movement action to offer.
+function getBarHandState(input: { barId: string }): Promise<
+  | { inHand: boolean; handFull: boolean }
+  | { error: string }
+>
+```
+
+Determined from `HandSlot` rows for the player (no new persistence).
+
+## User Stories
+
+### P0 — Capture lands in the Hand
+
+**HV-MV-1**: As a player completing a capture on the Seed Capture Whiteboard, the new BAR appears in my Hand (not the Vault), so my Hand reflects what I just made.
+
+**Acceptance**: After `/bars/capture` → Keep, `/` Hand glance shows the BAR in a slot and the Vault count does not increment (unless the Hand was full).
+
+**HV-MV-2**: If my Hand is full (6/6) when I capture on the whiteboard, I get the overflow modal and choose one Hand BAR to send to the Vault; the new BAR takes its slot. Capture is never lost.
+
+**Acceptance**: With 6 BARs in Hand, capturing shows the overflow modal; resolving it leaves the new BAR in Hand and the chosen BAR in the Vault.
+
+### P0 — Vault → Hand
+
+**HV-MV-3**: As a player viewing a Vault BAR (detail page or list row), I can **Hold in Hand**; it moves into an empty Hand slot.
+
+**Acceptance**: "Hold in Hand" appears only for owned Vault BARs; tapping it fills the lowest empty slot and the control flips to "Return to Vault". If the Hand is full, a non-blocking "Hand is full — return one first" message shows and nothing moves.
+
+**HV-MV-4**: As a player on the Now home, tapping an **empty Hand slot** lets me pull an existing Vault BAR into the Hand (instead of only creating a new one).
+
+**Acceptance**: The empty slot opens a Vault picker; selecting a BAR promotes it into that slot and the glance refreshes.
+
+### P0 — Hand → Vault
+
+**HV-MV-5**: As a player viewing a Hand BAR, I can **Return to Vault**; its slot frees up.
+
+**Acceptance**: "Return to Vault" appears only for owned Hand BARs; tapping it clears the `HandSlot` binding and the control flips to "Hold in Hand". The BAR is **not** archived/composted.
+
+### P1 — Honest confirmation copy
+
+**HV-MV-6**: Post-capture confirmation and toasts say where the BAR landed ("Added to hand" / "Saved to vault") matching the actual destination.
+
+### Verification quest
+
+**HV-MV-7**: A certification quest walks a tester through whiteboard-capture → confirm in Hand → fill Hand → capture again → resolve overflow → Return one to Vault → Hold it back in Hand.
+
+## Functional Requirements
+
+### Phase 1 — Capture routes to Hand (API → UI)
+
+- **FR1**: Extend `captureBarFromCanvas` to call `addBarToHandForPlayer` and return `placedIn` + optional `overflow` (contract above). Type-check green.
+- **FR2**: `SeedCaptureWhiteboard.handleCapture` handles all three results: `placedIn: 'hand'` → confirm "in your Hand"; `overflow` → render the overflow modal (reuse the CaptureBox pattern / a shared `OverflowModal`), resolve via `resolveOverflow`; `error` → show error. Media upload runs in the hand & vault branches.
+- **FR3**: `SimpleCaptureForm` routes to Hand (pass `destination: 'hand'` to `captureBar`); `/bars/kept` reads `dest=hand` and its copy + onward links reflect the Hand.
+
+### Phase 2 — Bidirectional movement UI
+
+- **FR4**: Add `getBarHandState` read helper to `src/actions/hand.ts`.
+- **FR5**: BAR detail page (`src/app/bars/[id]/page.tsx`, owner only): a contextual `HandLocationToggle` client component — "Hold in Hand" when in Vault, "Return to Vault" when in Hand; hand-full message handled; `router.refresh()` after.
+- **FR6**: Vault/feed list rows: an inline quick-action (same toggle, compact) on owned-BAR rows. Reuse `HandLocationToggle`. (Identify the row component(s) during planning — candidates under `src/components/hand/Vault*` and the feed/garden lists.)
+- **FR7**: Hand glance empty slot (`src/components/now/HandGlance.tsx`): replace the `/bars/create` link with a control that opens a Vault picker and calls `promoteVaultBarToHand`; keep a "create new" affordance available too.
+
+### Phase 3 — Verification
+
+- **FR8**: Implement certification quest `cert-hand-vault-movement-v1` (Twine + seed) per Verification Quest section.
+
+## Non-Functional Requirements
+
+- **Mobile-first**: all movement controls usable one-thumb; no horizontal scroll at 360px.
+- **Graceful without AI**: capture routing and all movement are deterministic DB operations; no model calls.
+- **Backward compatibility**: `CaptureBox` Hand/Vault toggle behavior is unchanged; no data migration (HandSlot already shipped). Existing Vault BARs remain in the Vault until a player moves them.
+- **Authorization**: every movement action verifies `creatorId === playerId` (already enforced in `hand.ts`); the new UI only renders movement controls for owned BARs.
+- **No four-move hardcoding**: untouched here, but Hand glance edits must not regress the existing maturity/next-move rendering.
+
+## Persisted data & Prisma (required when schema changes)
+
+**No schema change.** This kit reuses the existing `HandSlot` model owned by [`hand-vault-bounded-inventory`](../hand-vault-bounded-inventory/spec.md).
+
+| Check | Done |
+|-------|------|
+| Prisma models/enums/fields named in Design Decisions or API Contracts | none (reuses `HandSlot`) |
+| `tasks.md` migration task | n/a — no migration |
+| Verification: `npm run check` after wiring | yes (tasks.md Phase 4) |
+| Human glanced at new `migration.sql` | n/a |
+
+## Verification Quest (required for UX features)
+
+- **ID**: `cert-hand-vault-movement-v1`
+- **Steps** (one Twine passage each; final passage has no link → completion mints reward):
+  1. Open `/bars/capture`, make a seed, Keep → confirm it shows **in your Hand** on `/`.
+  2. Open the BAR detail; use **Return to Vault**; confirm it left the Hand.
+  3. From the Vault (or the detail page), use **Hold in Hand**; confirm it's back in a slot.
+  4. Fill the Hand to 6/6, capture once more on the whiteboard, resolve the **overflow modal** (send one BAR to the Vault).
+  5. On `/`, tap an empty Hand slot and pull a Vault BAR in.
+- **Narrative**: framed as stocking your Hand with live seeds before the Bruised Banana Fundraiser.
+- Reference: [cyoa-certification-quests](../cyoa-certification-quests/), [scripts/seed-cyoa-certification-quests.ts](../../../scripts/seed-cyoa-certification-quests.ts).
+
+## Dependencies
+
+- [`hand-vault-bounded-inventory`](../hand-vault-bounded-inventory/spec.md) — **prerequisite** (HandSlot model + all base Hand actions; already shipped).
+- [`home-vault-ia-redesign`](../home-vault-ia-redesign/spec.md) — companion IA layer (CaptureBox, HandGlance, NowHome). This kit fixes the canvas-capture and movement gaps it left open.
+- [`hand-vault-rename`](../hand-vault-rename/spec.md) — `/hand` route/title alignment (capture revalidates `/hand`).
+- [`bar-seed-capture-whiteboard`](../bar-seed-capture-whiteboard/spec.md) — the whiteboard capture surface.
+- [`bar-seed-metabolization`](../bar-seed-metabolization/spec.md) — maturity phases shown in the Hand glance.
+
+## References
+
+- `src/actions/bars.ts` (`captureBarFromCanvas` ~L1044) — capture path to extend
+- `src/actions/capture-bar.ts` (`captureBar`) — working reference pattern
+- `src/actions/hand.ts`, `src/lib/hand-service.ts` — movement actions (reused)
+- `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture` ~L1525), `src/components/bars/SimpleCaptureForm.tsx`
+- `src/components/now/CaptureBox.tsx` (overflow modal pattern to reuse), `src/components/now/HandGlance.tsx` (empty slot ~L102)
+- `src/app/bars/[id]/page.tsx` (owner actions block ~L216+), `src/app/bars/kept/page.tsx`
+- Prisma workflow: [prisma-migration-discipline skill](../../../.agents/skills/prisma-migration-discipline/SKILL.md), [fail-fix-workflow](../../../.cursor/rules/fail-fix-workflow.mdc)
+</content>
+</invoke>

--- a/.specify/specs/hand-vault-capture-movement/spec.md
+++ b/.specify/specs/hand-vault-capture-movement/spec.md
@@ -15,7 +15,7 @@ The result: the Hand is perpetually empty, exactly as reported.
 
 **Practice**: Deftness Development — spec kit first, API-first (contract before UI), deterministic over AI. This kit adds **no new Prisma models**; it reuses the existing `HandSlot` join table.
 
-> Reviewed by the Six GM Faces — see [SIX_FACE_ANALYSIS.md](./SIX_FACE_ANALYSIS.md). Two product forks remain open for the human (Fork A: whiteboard overflow behavior; Fork B: movement on planted/Garden BARs).
+> Reviewed by the Six GM Faces — see [SIX_FACE_ANALYSIS.md](./SIX_FACE_ANALYSIS.md). Both product forks now decided: **Fork A** = silent Vault fallback on whiteboard when Hand full; **Fork B** = movement toggle restricted to non-planted BARs in v1.
 
 ## GM Face Routing
 
@@ -35,7 +35,9 @@ Review Faces:
 | Topic | Decision |
 |-------|----------|
 | Schema | **No new field, no new table.** Hand membership stays explicit via the existing `HandSlot` join table (a BAR is "in Hand" iff a `HandSlot` row binds it; "in Vault" iff owned + active + unbound). The issue's suggested `location` column is unnecessary and would duplicate state. |
-| Canvas capture destination | **Always to Hand.** The Seed Capture Whiteboard (`/bars/capture`) routes the new BAR into the Hand via `addBarToHandForPlayer`. A full Hand surfaces the **overflow modal** (deposit one Hand BAR → Vault) — capture is still never lost (the BAR is parked in the Vault until resolved). This is a deliberate divergence from the default-Vault rule in [`home-vault-ia-redesign`](../home-vault-ia-redesign/spec.md): the whiteboard is the player's "make something now" surface, so its output should be active in hand. |
+| Canvas capture destination | **Always to Hand.** The Seed Capture Whiteboard (`/bars/capture`) routes the new BAR into the Hand via `addBarToHandForPlayer`. The whiteboard is the player's "make something now" surface, so its output should be active in hand (cf. default-Vault in [`home-vault-ia-redesign`](../home-vault-ia-redesign/spec.md)). |
+| Whiteboard capture when Hand full (**Fork A — decided**) | **Silent Vault fallback + toast** ("Hand full — saved to Vault; hold it later"). No modal on the immersive canvas; capture is never lost and the player resolves later from the Hand glance. (The forced overflow modal stays only on the deliberate `CaptureBox` Hand toggle.) |
+| Movement eligibility by maturity (**Fork B — decided**) | **v1 shows the toggle only on non-planted BARs** (`captured` / `shared_or_acted`). Planted Garden seeds (`context_named` / `elaborated`) stay homed in the Garden; Garden↔Hand movement is a separate follow-up. Keeps location ontology clean. |
 | Quick-capture (`CaptureBox`, NOW footer) | **Unchanged** — it already offers the Hand/Vault toggle (default Vault) and wires the overflow modal correctly. |
 | Capture doctrine (one principle, not two defaults) | **"Quick-keep files (Vault); deliberate make holds (Hand)."** The two capture surfaces default differently *on purpose*: the footer is a fast inbox dump, the whiteboard is a deliberate creation. This **restores** `bar-seed-capture-whiteboard` FR13's original "redirect to `/hand`" intent (Integrator). |
 | Movement copy as constants | "Hold in Hand" / "Return to Vault" live in **one shared constant** so [`hand-vault-rename`](../hand-vault-rename/spec.md) can repoint the vocabulary without hunting strings (Ontologist). |
@@ -79,14 +81,14 @@ Route the canvas capture into the Hand instead of leaving it unbound.
 // existing signature unchanged at the call site; result shape extended
 function captureBarFromCanvas(payload: CaptureBarFromCanvasInput): Promise<
   | { barId: string; title: string; placedIn: 'hand' }
-  | { barId: string; title: string; placedIn: 'vault'; overflow: OverflowContext } // hand was full
+  | { barId: string; title: string; placedIn: 'vault' } // hand was full → silent fallback (Fork A)
   | { error: string }
 >
 ```
 
 - After creating the BAR (unchanged), call `addBarToHandForPlayer(playerId, bar.id)`.
 - On success → `placedIn: 'hand'`.
-- On `overflow` → BAR is created and parked in the Vault; return `placedIn: 'vault'` + the `OverflowContext` so the whiteboard can show the existing overflow modal (resolve via `resolveOverflow`).
+- When the Hand is full → the BAR simply stays in the Vault (no `HandSlot` bound); return `placedIn: 'vault'`. The whiteboard shows the Vault-fallback toast — **no overflow modal on the canvas** (Fork A). No `OverflowContext` is returned here.
 - Keep `revalidatePath('/bars')`, `'/bars/garden'`, `'/hand'`, `'/'`.
 - Media upload (photos/voice) in `SeedCaptureWhiteboard` runs after, unchanged, keyed off `barId` in every branch.
 
@@ -111,9 +113,9 @@ The BAR detail page and list rows are **server components**; they read `HandSlot
 
 **Acceptance**: After `/bars/capture` → Keep, `/` Hand glance shows the BAR in a slot and the Vault count does not increment (unless the Hand was full).
 
-**HV-MV-2**: If my Hand is full (6/6) when I capture on the whiteboard, I get the overflow modal and choose one Hand BAR to send to the Vault; the new BAR takes its slot. Capture is never lost.
+**HV-MV-2**: If my Hand is full (6/6) when I capture on the whiteboard, the BAR is saved to my Vault with a toast telling me so — capture is never blocked or lost — and I can hold it later from the Hand glance.
 
-**Acceptance**: With 6 BARs in Hand, capturing shows the overflow modal; resolving it leaves the new BAR in Hand and the chosen BAR in the Vault.
+**Acceptance**: With 6 BARs in Hand, a whiteboard capture lands in the Vault, shows the fallback toast, and no modal interrupts the canvas. (The forced overflow swap remains exercised by the `CaptureBox` Hand toggle.)
 
 ### P0 — Vault → Hand
 
@@ -144,12 +146,12 @@ The BAR detail page and list rows are **server components**; they read `HandSlot
 ### Phase 1 — Capture routes to Hand (API → UI)
 
 - **FR1**: Extend `captureBarFromCanvas` to call `addBarToHandForPlayer` and return `placedIn` + optional `overflow` (contract above). Type-check green.
-- **FR2**: `SeedCaptureWhiteboard.handleCapture` confirms "in your Hand" on `placedIn: 'hand'` and shows errors on `error`. **Hand-full behavior is Fork A** (see SIX_FACE_ANALYSIS): convened recommendation is a **silent Vault fallback + toast** ("Hand full — saved to Vault; hold it later"), *not* a modal on the immersive canvas. (If the human picks the modal instead, reuse the shared `OverflowModal` + `resolveOverflow`.) Media upload runs in every non-error branch. Coordinate the return type with `bar-capture-consolidation`.
+- **FR2**: `SeedCaptureWhiteboard.handleCapture` confirms "in your Hand" on `placedIn: 'hand'`, shows errors on `error`, and on `placedIn: 'vault'` (Hand was full) shows a **silent Vault-fallback toast** ("Hand full — saved to Vault; hold it later") — **no modal on the canvas** (Fork A, decided). Media upload runs in every non-error branch. Coordinate the return type with `bar-capture-consolidation`.
 - **FR3**: `SimpleCaptureForm` routes to Hand (pass `destination: 'hand'` to `captureBar`); `/bars/kept` reads `dest=hand` and its copy + onward links reflect the Hand.
 
 ### Phase 2 — Bidirectional movement UI
 
-- **FR4**: Compute `inHand` / `handFull` inline in the server components (detail page + list rows) from `HandSlot`; **no new server action**. Movement copy lives in one shared constant. **Fork B**: in v1 the toggle is shown only for non-planted BARs (`captured` / `shared_or_acted`); `context_named`/`elaborated` (Garden) are deferred — pending the human's call.
+- **FR4**: Compute `inHand` / `handFull` inline in the server components (detail page + list rows) from `HandSlot`; **no new server action**. Movement copy lives in one shared constant. **Fork B (decided)**: in v1 the toggle is shown only for non-planted BARs (`captured` / `shared_or_acted`); `context_named`/`elaborated` (Garden) are deferred to a Garden↔Hand follow-up.
 - **FR5**: BAR detail page (`src/app/bars/[id]/page.tsx`): a contextual `HandLocationToggle` client component — "Hold in Hand" when in Vault, "Return to Vault" when in Hand; hand-full message handled; `router.refresh()` after. **Gate strictly to `isOwner`** (never `isRecipient`) — a talisman recipient must not move someone else's BAR (Steward).
 - **FR6**: Vault/feed list rows: an inline quick-action (same toggle, compact) on owned-BAR rows. Reuse `HandLocationToggle`. (Identify the row component(s) during planning — candidates under `src/components/hand/Vault*` and the feed/garden lists.)
 - **FR7**: Hand glance empty slot (`src/components/now/HandGlance.tsx`): replace the `/bars/create` link with a control that opens a Vault picker and calls `promoteVaultBarToHand`; keep a "create new" affordance available too.

--- a/.specify/specs/hand-vault-capture-movement/tasks.md
+++ b/.specify/specs/hand-vault-capture-movement/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Hand/Vault — Capture Routing + Bidirectional Movement
+
+> Implement per [spec.md](./spec.md) and [plan.md](./plan.md). Fixes issue #132. API-first order. No migration. Check off as completed.
+
+## Phase 0 — Prerequisites (verify, already shipped)
+
+- [x] **T0.1** `HandSlot` model + base actions (`addBarToHandForPlayer`, `promoteVaultBarToHand`, `depositHandBarToVault`, `resolveOverflow`, `readHandDb`) exist in `src/actions/hand.ts` + `src/lib/hand-service.ts`.
+- [x] **T0.2** `captureBar` (`src/actions/capture-bar.ts`) + `CaptureBox` Hand/Vault toggle + inline overflow modal work as reference.
+- [ ] **T0.3** Confirm no `CustomBar.location`/Hand field is needed (reuse `HandSlot`) — recorded in spec Design Decisions.
+
+## Phase 1 — Capture routes to Hand (API → UI)
+
+- [ ] **T1.1** `src/actions/bars.ts` — extend `captureBarFromCanvas`: after creating the BAR, `await addBarToHandForPlayer(playerId, bar.id)` (import from `@/lib/hand-service`). Return `{ barId, title, placedIn: 'hand' }`, or `{ barId, title, placedIn: 'vault', overflow }` when the Hand is full. Keep existing `revalidatePath` calls. Type-check green.
+- [ ] **T1.2** `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture`) — branch on result: `placedIn:'hand'` → `setCaptured` with "in your Hand" copy; `overflow` → open overflow modal and resolve via `resolveOverflow`; `error` → `setCaptureError`. Run media upload in both the hand and vault (overflow-parked) branches.
+- [ ] **T1.3** `src/components/now/OverflowModal.tsx` — extract the overflow markup from `CaptureBox.tsx` into a shared component; refactor `CaptureBox` to use it (no behavior change); use it in the whiteboard.
+- [ ] **T1.4** `src/components/bars/SimpleCaptureForm.tsx` — pass `destination: 'hand'`; route to `/bars/kept?dest=hand`.
+- [ ] **T1.5** `src/app/bars/kept/page.tsx` — confirm `dest=hand` copy/links read correctly ("landed in your Hand"; onward to Tune / Now).
+- [ ] **T1.6** Verify on `/`: a whiteboard capture appears in the Hand glance and does not increment Vault (unless Hand was full).
+
+## Phase 2 — Bidirectional movement UI
+
+- [ ] **T2.0** Discovery — enumerate the exact Vault/feed/garden list components that render owned BAR rows (under `src/components/hand/Vault*`, garden list, feed). Record the target files here before editing.
+- [ ] **T2.1** `src/actions/hand.ts` — add `getBarHandState({ barId }): Promise<{ inHand: boolean; handFull: boolean } | { error }>` from `HandSlot` rows (auth-checked).
+- [ ] **T2.2** `src/components/hand/HandLocationToggle.tsx` (new, client) — "Hold in Hand" (Vault→Hand via `promoteVaultBarToHand`) / "Return to Vault" (Hand→Vault via `depositHandBarToVault`); non-blocking hand-full message; `compact?` prop for list rows; `router.refresh()` after success.
+- [ ] **T2.3** `src/app/bars/[id]/page.tsx` — render `HandLocationToggle` in the owner actions block (~L216), seeded with `getBarHandState`.
+- [ ] **T2.4** Vault/feed/garden rows (files from T2.0) — add compact `HandLocationToggle` on owned-BAR rows.
+- [ ] **T2.5** `src/components/now/HandGlance.tsx` — empty slot: replace the `/bars/create` link with a Vault-picker control (bottom-sheet of Vault BARs) → `promoteVaultBarToHand(targetSlot)`; keep a "create new" affordance.
+
+## Phase 3 — Verification Quest
+
+- [ ] **T3.1** `scripts/seed-hand-vault-movement-cert.ts` — idempotent seed for `cert-hand-vault-movement-v1` (TwineStory + CustomBar, `isSystem: true`, `visibility: 'public'`, deterministic id). Steps per spec; Bruised Banana framing.
+- [ ] **T3.2** `package.json` — add `"seed:cert:hand-vault-movement": "tsx scripts/seed-hand-vault-movement-cert.ts"`.
+- [ ] **T3.3** Run the seed; confirm the quest is completable end to end.
+
+## Phase 4 — Fail-Fix & Backlog
+
+- [ ] **T4.1** `npm run build` — green.
+- [ ] **T4.2** `npm run check` — lint + type-check green.
+- [ ] **T4.3** Manual mobile pass (360px): whiteboard capture → Hand; detail toggle both ways; full-hand overflow; empty-slot pull.
+- [ ] **T4.4** Confirm `BACKLOG.md` entry; run `npm run backlog:seed`.
+- [ ] **T4.5** Comment resolution summary on issue #132; check off completed tasks here.
+
+## Out of scope
+
+- `CustomBar.location` column (rejected — `HandSlot` encodes location).
+- Changing `CaptureBox` default-Vault behavior.
+- Hand reordering / carrying-slot semantics (owned by `hand-vault-bounded-inventory`).
+</content>

--- a/.specify/specs/hand-vault-capture-movement/tasks.md
+++ b/.specify/specs/hand-vault-capture-movement/tasks.md
@@ -28,9 +28,9 @@
 
 ## Phase 3 — Verification Quest
 
-- [ ] **T3.1** `scripts/seed-hand-vault-movement-cert.ts` — idempotent seed for `cert-hand-vault-movement-v1` (TwineStory + CustomBar, `isSystem: true`, `visibility: 'public'`, deterministic id). Steps per spec; Bruised Banana framing.
-- [ ] **T3.2** `package.json` — add `"seed:cert:hand-vault-movement": "tsx scripts/seed-hand-vault-movement-cert.ts"`.
-- [ ] **T3.3** Run the seed; confirm the quest is completable end to end.
+- [x] **T3.1** `scripts/seed-hand-vault-movement-cert.ts` — idempotent seed for `cert-hand-vault-movement-v1` (TwineStory + CustomBar, `isSystem: true`, `visibility: 'public'`, deterministic id `cert-hand-vault-movement-v1`). 6 steps per spec + FEEDBACK/END_SUCCESS; Bruised Banana framing. Mirrors `seed-cert-throughput-spine.ts`. Type-checks clean.
+- [x] **T3.2** `package.json` — added `"seed:cert:hand-vault-movement": "tsx scripts/seed-hand-vault-movement-cert.ts"`.
+- [ ] **T3.3** Run the seed; confirm the quest is completable end to end. **Pending** — needs a live `DATABASE_URL` (unset in sandbox). Run `npm run seed:cert:hand-vault-movement` against a real DB.
 
 ## Phase 4 — Fail-Fix & Backlog
 

--- a/.specify/specs/hand-vault-capture-movement/tasks.md
+++ b/.specify/specs/hand-vault-capture-movement/tasks.md
@@ -6,25 +6,25 @@
 
 - [x] **T0.1** `HandSlot` model + base actions (`addBarToHandForPlayer`, `promoteVaultBarToHand`, `depositHandBarToVault`, `resolveOverflow`, `readHandDb`) exist in `src/actions/hand.ts` + `src/lib/hand-service.ts`.
 - [x] **T0.2** `captureBar` (`src/actions/capture-bar.ts`) + `CaptureBox` Hand/Vault toggle + inline overflow modal work as reference.
-- [ ] **T0.3** Confirm no `CustomBar.location`/Hand field is needed (reuse `HandSlot`) — recorded in spec Design Decisions.
+- [x] **T0.3** Confirm no `CustomBar.location`/Hand field is needed (reuse `HandSlot`) — recorded in spec Design Decisions.
 
 ## Phase 1 — Capture routes to Hand (API → UI)
 
-- [ ] **T1.1** `src/actions/bars.ts` — extend `captureBarFromCanvas`: after creating the BAR, `await addBarToHandForPlayer(playerId, bar.id)` (import from `@/lib/hand-service`). Return `{ barId, title, placedIn: 'hand' }`, or `{ barId, title, placedIn: 'vault' }` when the Hand is full (Fork A: no `overflow` needed for the canvas — the BAR simply stays in the Vault). Keep existing `revalidatePath` calls. Type-check green.
-- [ ] **T1.2** `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture`) — branch on result: `placedIn:'hand'` → `setCaptured` "in your Hand"; `placedIn:'vault'` (Hand full, **Fork A**) → `setCaptured` + **Vault-fallback toast** "Hand full — saved to Vault; hold it later" (no modal); `error` → `setCaptureError`. Run media upload in both non-error branches.
-- [ ] **T1.3** `src/components/now/OverflowModal.tsx` — extract the overflow markup from `CaptureBox.tsx` into a shared component; refactor `CaptureBox` to use it (no behavior change). (Whiteboard does **not** use it — Fork A is silent fallback; extraction is for reuse/testability.)
-- [ ] **T1.4** `src/components/bars/SimpleCaptureForm.tsx` — pass `destination: 'hand'`; route to `/bars/kept?dest=hand`.
-- [ ] **T1.5** `src/app/bars/kept/page.tsx` — confirm `dest=hand` copy/links read correctly ("landed in your Hand"; onward to Tune / Now).
-- [ ] **T1.6** Verify on `/`: a whiteboard capture appears in the Hand glance and does not increment Vault (unless Hand was full).
+- [x] **T1.1** `src/actions/bars.ts` — extended `captureBarFromCanvas`: after creating the BAR, `addBarToHandForPlayer(playerId, bar.id)` (imported from `@/lib/hand-service`). Returns `{ barId, title, placedIn: 'hand' | 'vault' }`; Hand full → BAR stays in Vault, `placedIn: 'vault'` (Fork A). Existing `revalidatePath` calls kept. Type-check green.
+- [x] **T1.2** `src/components/bars/SeedCaptureWhiteboard.tsx` — `captured` state carries `placedIn`; `CapturedOverlay` shows "Held in your Hand" or the Vault-fallback line ("Hand full — saved to your Vault. Hold it later from your Hand."). No modal. Media upload unchanged (runs before `setCaptured` in the non-error path).
+- [ ] **T1.3** `src/components/now/OverflowModal.tsx` — extract the overflow markup from `CaptureBox.tsx` into a shared component. **Deferred**: Fork A means the whiteboard never needs it, and `CaptureBox` already works inline; pure refactor, low value now. Left as follow-up.
+- [x] **T1.4** `src/components/bars/SimpleCaptureForm.tsx` — passes `destination: 'hand'`; derives `dest` from the result (Vault fallback) and routes to `/bars/kept?dest=…`.
+- [x] **T1.5** `src/app/bars/kept/page.tsx` — `dest=hand` reads "landed in your Hand"; secondary CTA → `/hand` ("Go to your Hand").
+- [ ] **T1.6** Verify on `/`: a whiteboard capture appears in the Hand glance and does not increment Vault (unless Hand was full). **Pending manual run** (build blocked by Google Fonts network fetch in sandbox; code paths type-check clean).
 
 ## Phase 2 — Bidirectional movement UI
 
-- [ ] **T2.0** Discovery — enumerate the exact Vault/feed/garden list components that render owned BAR rows (under `src/components/hand/Vault*`, garden list, feed). Record the target files here before editing.
-- [ ] **T2.1** Movement copy constants (`HOLD_IN_HAND` / `RETURN_TO_VAULT`) in one shared module so `hand-vault-rename` can repoint. **No `getBarHandState` action** — compute `inHand`/`handFull` inline in the server components from `HandSlot` (Architect).
-- [ ] **T2.2** `src/components/hand/HandLocationToggle.tsx` (new, client) — "Hold in Hand" (Vault→Hand via `promoteVaultBarToHand`) / "Return to Vault" (Hand→Vault via `depositHandBarToVault`); non-blocking hand-full message; `compact?` prop for list rows; `router.refresh()` after success. Visibly distinct from the Compost affordance (Return ≠ archive).
-- [ ] **T2.3** `src/app/bars/[id]/page.tsx` — render `HandLocationToggle` (~L216), seeded with inline `inHand`/`handFull`. **Gate to `isOwner` only** (never `isRecipient`). Honor Fork B eligibility (non-planted in v1).
-- [ ] **T2.4** Vault/feed/garden rows (files from T2.0) — add compact `HandLocationToggle` on owned-BAR rows.
-- [ ] **T2.5** `src/components/now/HandGlance.tsx` — empty slot: replace the `/bars/create` link with a Vault-picker control (bottom-sheet of Vault BARs) → `promoteVaultBarToHand(targetSlot)`; keep a "create new" affordance.
+- [x] **T2.0** Discovery — owned BAR rows: Vault private drafts render via the large shared `StarterQuestBoard` (high-risk to thread per-row state through → deferred); the **Garden list** (`src/app/bars/garden/page.tsx`) is a clean server component with maturity in hand → chosen as the list surface for v1.
+- [x] **T2.1** `src/lib/hand-movement.ts` — `HOLD_IN_HAND` / `RETURN_TO_VAULT` / `HAND_FULL_HINT` constants + `isHandVaultMovable(maturity)` (Fork B). **No `getBarHandState` action** — `inHand`/`handFull` computed inline via `readHandDb` in the server components.
+- [x] **T2.2** `src/components/hand/HandLocationToggle.tsx` (new, client) — "Hold in Hand" / "Return to Vault" via `promoteVaultBarToHand` / `depositHandBarToVault`; non-blocking hand-full hint; `compact?` prop; `router.refresh()` after. Distinct from Compost (no archive).
+- [x] **T2.3** `src/app/bars/[id]/page.tsx` — renders the toggle in a location section, gated to `isOwner` + capture types + `isHandVaultMovable` (Fork B). `inHand`/`handFull` read inline from `readHandDb`.
+- [x] **T2.4** Garden rows (`src/app/bars/garden/page.tsx`) — compact `HandLocationToggle` on movable owned rows (sibling of the row `Link` to avoid nested interactives). Vault `StarterQuestBoard` rows deferred per T2.0.
+- [x] **T2.5** `src/components/now/HandGlance.tsx` — empty slot opens an `EmptySlotSheet` bottom-sheet (lazy-loads `listMovableVaultBars`) → `promoteVaultBarToHand({ barId, targetSlot })`, plus a "+ Capture new" link. New read action `listMovableVaultBars` in `src/actions/hand.ts`.
 
 ## Phase 3 — Verification Quest
 
@@ -34,9 +34,9 @@
 
 ## Phase 4 — Fail-Fix & Backlog
 
-- [ ] **T4.1** `npm run build` — green.
-- [ ] **T4.2** `npm run check` — lint + type-check green.
-- [ ] **T4.3** Manual mobile pass (360px): whiteboard capture → Hand; detail toggle both ways; full-hand overflow; empty-slot pull.
+- [~] **T4.1** `npm run build` — **blocked in sandbox**: Turbopack fails fetching Google Fonts (Geist, Geist Mono, Press Start 2P) — a network restriction, not a code error. Re-run in an environment with outbound font access.
+- [x] **T4.2** `tsc --noEmit` clean; `eslint` on changed files: 0 errors (3 pre-existing/style warnings). (`npm run check` also runs `prisma generate` + build-reliability; type-check + lint are the code gates and pass.)
+- [ ] **T4.3** Manual mobile pass (360px): whiteboard capture → Hand; detail toggle both ways; full-hand fallback; empty-slot pull. **Pending** (needs running app).
 - [ ] **T4.4** Confirm `BACKLOG.md` entry; run `npm run backlog:seed`.
 - [ ] **T4.5** Comment resolution summary on issue #132; check off completed tasks here.
 

--- a/.specify/specs/hand-vault-capture-movement/tasks.md
+++ b/.specify/specs/hand-vault-capture-movement/tasks.md
@@ -10,9 +10,9 @@
 
 ## Phase 1 — Capture routes to Hand (API → UI)
 
-- [ ] **T1.1** `src/actions/bars.ts` — extend `captureBarFromCanvas`: after creating the BAR, `await addBarToHandForPlayer(playerId, bar.id)` (import from `@/lib/hand-service`). Return `{ barId, title, placedIn: 'hand' }`, or `{ barId, title, placedIn: 'vault', overflow }` when the Hand is full. Keep existing `revalidatePath` calls. Type-check green.
-- [ ] **T1.2** `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture`) — branch on result: `placedIn:'hand'` → `setCaptured` with "in your Hand" copy; `overflow` → open overflow modal and resolve via `resolveOverflow`; `error` → `setCaptureError`. Run media upload in both the hand and vault (overflow-parked) branches.
-- [ ] **T1.3** `src/components/now/OverflowModal.tsx` — extract the overflow markup from `CaptureBox.tsx` into a shared component; refactor `CaptureBox` to use it (no behavior change); use it in the whiteboard.
+- [ ] **T1.1** `src/actions/bars.ts` — extend `captureBarFromCanvas`: after creating the BAR, `await addBarToHandForPlayer(playerId, bar.id)` (import from `@/lib/hand-service`). Return `{ barId, title, placedIn: 'hand' }`, or `{ barId, title, placedIn: 'vault' }` when the Hand is full (Fork A: no `overflow` needed for the canvas — the BAR simply stays in the Vault). Keep existing `revalidatePath` calls. Type-check green.
+- [ ] **T1.2** `src/components/bars/SeedCaptureWhiteboard.tsx` (`handleCapture`) — branch on result: `placedIn:'hand'` → `setCaptured` "in your Hand"; `placedIn:'vault'` (Hand full, **Fork A**) → `setCaptured` + **Vault-fallback toast** "Hand full — saved to Vault; hold it later" (no modal); `error` → `setCaptureError`. Run media upload in both non-error branches.
+- [ ] **T1.3** `src/components/now/OverflowModal.tsx` — extract the overflow markup from `CaptureBox.tsx` into a shared component; refactor `CaptureBox` to use it (no behavior change). (Whiteboard does **not** use it — Fork A is silent fallback; extraction is for reuse/testability.)
 - [ ] **T1.4** `src/components/bars/SimpleCaptureForm.tsx` — pass `destination: 'hand'`; route to `/bars/kept?dest=hand`.
 - [ ] **T1.5** `src/app/bars/kept/page.tsx` — confirm `dest=hand` copy/links read correctly ("landed in your Hand"; onward to Tune / Now).
 - [ ] **T1.6** Verify on `/`: a whiteboard capture appears in the Hand glance and does not increment Vault (unless Hand was full).

--- a/.specify/specs/hand-vault-capture-movement/tasks.md
+++ b/.specify/specs/hand-vault-capture-movement/tasks.md
@@ -20,9 +20,9 @@
 ## Phase 2 — Bidirectional movement UI
 
 - [ ] **T2.0** Discovery — enumerate the exact Vault/feed/garden list components that render owned BAR rows (under `src/components/hand/Vault*`, garden list, feed). Record the target files here before editing.
-- [ ] **T2.1** `src/actions/hand.ts` — add `getBarHandState({ barId }): Promise<{ inHand: boolean; handFull: boolean } | { error }>` from `HandSlot` rows (auth-checked).
-- [ ] **T2.2** `src/components/hand/HandLocationToggle.tsx` (new, client) — "Hold in Hand" (Vault→Hand via `promoteVaultBarToHand`) / "Return to Vault" (Hand→Vault via `depositHandBarToVault`); non-blocking hand-full message; `compact?` prop for list rows; `router.refresh()` after success.
-- [ ] **T2.3** `src/app/bars/[id]/page.tsx` — render `HandLocationToggle` in the owner actions block (~L216), seeded with `getBarHandState`.
+- [ ] **T2.1** Movement copy constants (`HOLD_IN_HAND` / `RETURN_TO_VAULT`) in one shared module so `hand-vault-rename` can repoint. **No `getBarHandState` action** — compute `inHand`/`handFull` inline in the server components from `HandSlot` (Architect).
+- [ ] **T2.2** `src/components/hand/HandLocationToggle.tsx` (new, client) — "Hold in Hand" (Vault→Hand via `promoteVaultBarToHand`) / "Return to Vault" (Hand→Vault via `depositHandBarToVault`); non-blocking hand-full message; `compact?` prop for list rows; `router.refresh()` after success. Visibly distinct from the Compost affordance (Return ≠ archive).
+- [ ] **T2.3** `src/app/bars/[id]/page.tsx` — render `HandLocationToggle` (~L216), seeded with inline `inHand`/`handFull`. **Gate to `isOwner` only** (never `isRecipient`). Honor Fork B eligibility (non-planted in v1).
 - [ ] **T2.4** Vault/feed/garden rows (files from T2.0) — add compact `HandLocationToggle` on owned-BAR rows.
 - [ ] **T2.5** `src/components/now/HandGlance.tsx` — empty slot: replace the `/bars/create` link with a Vault-picker control (bottom-sheet of Vault BARs) → `promoteVaultBarToHand(targetSlot)`; keep a "create new" affordance.
 

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "test:barn": "tsx src/lib/event/__tests__/barn-raising.test.ts && tsx src/lib/launch/__tests__/barn-credit.test.ts",
     "seed:cert:book-paywall": "tsx scripts/with-env.ts \"tsx scripts/seed-cert-book-launch-paywall.ts\"",
     "seed:cert:throughput-spine": "tsx scripts/seed-cert-throughput-spine.ts",
+    "seed:cert:hand-vault-movement": "tsx scripts/seed-hand-vault-movement-cert.ts",
     "seed:wake-up": "tsx scripts/seed-wake-up-adventure.ts",
     "seed:mtgoa-ch1": "tsx scripts/seed-mtgoa-chapter1-cyoa.ts",
     "seed:bruised-banana": "tsx scripts/seed-bruised-banana-adventure.ts",

--- a/scripts/seed-hand-vault-movement-cert.ts
+++ b/scripts/seed-hand-vault-movement-cert.ts
@@ -1,0 +1,149 @@
+/**
+ * Verification quest: cert-hand-vault-movement-v1
+ *
+ * Walks a tester through the Hand ↔ Vault loop that issue #132 unblocked:
+ * capture on the whiteboard → confirm it's in the Hand → Return it to the
+ * Vault → Hold it back in the Hand → fill the Hand and capture again (silent
+ * Vault fallback) → pull a Vault BAR into an empty slot from the Hand glance.
+ *
+ * Framed toward the Bruised Banana Fundraiser: it verifies a person can stock
+ * their Hand with live seeds and move them freely before the party.
+ *
+ * Idempotent. Run: npm run seed:cert:hand-vault-movement
+ */
+import './require-db-env'
+import { db } from '../src/lib/db'
+
+const slug = 'cert-hand-vault-movement-v1'
+const title = 'Certification: Hand ↔ Vault Movement V1'
+
+const passages = [
+  {
+    name: 'START',
+    pid: '1',
+    text: 'This certification verifies the **Hand ↔ Vault** loop end-to-end: a fresh capture lands in your Hand, and you can move BARs freely between your Hand and your Vault. If you can walk this without a dead end, a person can stock their Hand with live seeds before the Bruised Banana Fundraiser.\n\nComplete each step in order, then finish to receive your reward.',
+    cleanText: 'This certification verifies the Hand to Vault loop end-to-end: a fresh capture lands in your Hand, and you can move BARs freely between your Hand and your Vault. If you can walk this without a dead end, a person can stock their Hand with live seeds before the Bruised Banana Fundraiser. Complete each step in order, then finish to receive your reward.',
+    links: [{ label: 'Begin', target: 'STEP_1' }],
+  },
+  {
+    name: 'STEP_1',
+    pid: '2',
+    text: '### Step 1: Capture into the Hand\n\n[Open the capture whiteboard](/bars/capture), drop a seed (a line of text is enough), and **Keep** it. Confirm the closing card reads **"Held in your Hand"**, then [open Now](/) and confirm the seed sits in a Hand slot.',
+    cleanText: 'Step 1: Capture into the Hand. Open the capture whiteboard (/bars/capture), drop a seed (a line of text is enough), and Keep it. Confirm the closing card reads Held in your Hand, then open Now (/) and confirm the seed sits in a Hand slot.',
+    links: [{ label: 'Next', target: 'STEP_2' }, { label: 'Report Issue', target: 'FEEDBACK' }],
+  },
+  {
+    name: 'STEP_2',
+    pid: '3',
+    text: '### Step 2: Return it to the Vault\n\nOpen that BAR\'s detail page. In the location section use **Return to Vault**. Confirm the section now reads **"In your Vault"** and the BAR has left your Hand on Now.',
+    cleanText: 'Step 2: Return it to the Vault. Open that BAR detail page. In the location section use Return to Vault. Confirm the section now reads In your Vault and the BAR has left your Hand on Now.',
+    links: [{ label: 'Next', target: 'STEP_3' }, { label: 'Report Issue', target: 'FEEDBACK' }],
+  },
+  {
+    name: 'STEP_3',
+    pid: '4',
+    text: '### Step 3: Hold it back in your Hand\n\nStill on the BAR detail page (or from the **Garden** list), use **Hold in Hand**. Confirm the BAR returns to a Hand slot. This is the Vault → Hand direction.',
+    cleanText: 'Step 3: Hold it back in your Hand. Still on the BAR detail page (or from the Garden list), use Hold in Hand. Confirm the BAR returns to a Hand slot. This is the Vault to Hand direction.',
+    links: [{ label: 'Next', target: 'STEP_4' }, { label: 'Report Issue', target: 'FEEDBACK' }],
+  },
+  {
+    name: 'STEP_4',
+    pid: '5',
+    text: '### Step 4: Fill the Hand, then capture again\n\nGet your Hand to **6 / 6** (capture or hold more BARs). Now capture once more on the whiteboard. Confirm capture is **never blocked**: the closing card tells you **"Hand full — saved to your Vault."** No modal interrupts the canvas.',
+    cleanText: 'Step 4: Fill the Hand, then capture again. Get your Hand to 6 of 6 (capture or hold more BARs). Now capture once more on the whiteboard. Confirm capture is never blocked: the closing card tells you Hand full — saved to your Vault. No modal interrupts the canvas.',
+    links: [{ label: 'Next', target: 'STEP_5' }, { label: 'Report Issue', target: 'FEEDBACK' }],
+  },
+  {
+    name: 'STEP_5',
+    pid: '6',
+    text: '### Step 5: Pull a Vault BAR into an empty slot\n\nReturn one BAR to the Vault to free a slot, then on [Now](/) tap the **empty Hand slot**. In the sheet, choose **a Vault BAR to pull in** (or "+ Capture new"). Confirm it lands in that slot.',
+    cleanText: 'Step 5: Pull a Vault BAR into an empty slot. Return one BAR to the Vault to free a slot, then on Now (/) tap the empty Hand slot. In the sheet, choose a Vault BAR to pull in (or + Capture new). Confirm it lands in that slot.',
+    links: [{ label: 'Complete verification', target: 'END_SUCCESS' }, { label: 'Report Issue', target: 'FEEDBACK' }],
+  },
+  {
+    name: 'FEEDBACK',
+    pid: '7',
+    text: "### Report an Issue\n\nSomething isn't working as expected? Describe what you encountered so we can fix it.",
+    cleanText: "Report an Issue. Something isn't working as expected? Describe what you encountered so we can fix it.",
+    links: [],
+    tags: ['feedback'],
+  },
+  {
+    name: 'END_SUCCESS',
+    pid: '8',
+    text: 'Verification complete. The Hand fills: a fresh capture is held in your Hand, BARs move both ways between Hand and Vault, capture is never blocked when the Hand is full, and you can pull a Vault BAR into an empty slot. Your Hand reflects what you are actively holding — ready to stock with live seeds for the Bruised Banana Fundraiser. Complete this quest to receive your vibeulon reward.',
+    cleanText: 'Verification complete. The Hand fills: a fresh capture is held in your Hand, BARs move both ways between Hand and Vault, capture is never blocked when the Hand is full, and you can pull a Vault BAR into an empty slot. Your Hand reflects what you are actively holding — ready to stock with live seeds for the Bruised Banana Fundraiser. Complete this quest to receive your vibeulon reward.',
+    links: [],
+  },
+]
+
+async function seed() {
+  console.log('--- Seeding cert-hand-vault-movement-v1 ---')
+
+  // Reset completion so admins can re-run the quest after a reseed.
+  const deletedQuests = await db.playerQuest.deleteMany({ where: { questId: slug } })
+  const deletedRuns = await db.twineRun.deleteMany({ where: { questId: slug } })
+  if (deletedQuests.count > 0 || deletedRuns.count > 0) {
+    console.log(`🔄 Reset ${deletedQuests.count} PlayerQuest(s) and ${deletedRuns.count} TwineRun(s)`)
+  }
+
+  const creator = await db.player.findFirst()
+  if (!creator) throw new Error('No player found for createdById')
+  const createdById = creator.id
+
+  const parsedJson = JSON.stringify({ title, startPassage: 'START', passages })
+
+  const story = await db.twineStory.upsert({
+    where: { slug },
+    update: { title, parsedJson, isPublished: true },
+    create: {
+      title,
+      slug,
+      sourceType: 'manual_seed',
+      sourceText: 'Hand ↔ Vault movement certification quest (seed-hand-vault-movement-cert.ts)',
+      parsedJson,
+      isPublished: true,
+      createdById,
+    },
+  })
+
+  const description =
+    'End-to-end verification of the Hand ↔ Vault loop: capture on the whiteboard → confirm it is in the Hand → Return to Vault → Hold in Hand → fill the Hand and capture again (silent Vault fallback) → pull a Vault BAR into an empty slot. Verifies issue #132 is resolved for the Bruised Banana Fundraiser.'
+
+  const quest = await db.customBar.upsert({
+    where: { id: slug },
+    update: {
+      title,
+      description,
+      reward: 1,
+      twineStoryId: story.id,
+      status: 'active',
+      visibility: 'public',
+      isSystem: true,
+      backlogPromptPath: '.specify/specs/hand-vault-capture-movement/spec.md',
+    },
+    create: {
+      id: slug,
+      title,
+      description,
+      creatorId: createdById,
+      reward: 1,
+      twineStoryId: story.id,
+      status: 'active',
+      visibility: 'public',
+      isSystem: true,
+      backlogPromptPath: '.specify/specs/hand-vault-capture-movement/spec.md',
+    },
+  })
+
+  console.log(`✅ Story seeded: ${story.title} (${story.id})`)
+  console.log(`✅ Quest seeded: ${quest.title} (${quest.id})`)
+}
+
+seed()
+  .then(() => db.$disconnect())
+  .catch(async (err) => {
+    console.error(err)
+    await db.$disconnect()
+    process.exit(1)
+  })

--- a/src/actions/bars.ts
+++ b/src/actions/bars.ts
@@ -13,6 +13,8 @@ import {
 } from '@/lib/bar-seed-metabolization'
 import { assertCanCreateUnplacedVaultQuest } from '@/lib/vault-limits'
 import { CAPTURE_BAR_TYPES } from '@/lib/vault-ui'
+// Plain module (no 'use server') — safe to import from this server-action file.
+import { addBarToHandForPlayer } from '@/lib/hand-service'
 
 // Element channel ('nation' column) — valid capture-time field-tint values.
 // Mirrors ElementKey in src/lib/ui/card-tokens.ts (kept inline to avoid pulling
@@ -1043,7 +1045,10 @@ function serializeCanvasInputs(items: CanvasItem[]): string {
 
 export async function captureBarFromCanvas(
   payload: CaptureBarFromCanvasInput
-): Promise<{ barId: string; title: string } | { error: string }> {
+): Promise<
+  | { barId: string; title: string; placedIn: 'hand' | 'vault' }
+  | { error: string }
+> {
   const playerId = await getPlayerId()
   if (!playerId) return { error: 'Not logged in' }
 
@@ -1093,12 +1098,22 @@ export async function captureBarFromCanvas(
       data: { rootId: bar.id },
     })
 
+    // The whiteboard is the "make something now" surface — a fresh canvas
+    // capture is held in the Hand. If the Hand is full we keep the BAR in the
+    // Vault (no HandSlot bound) and let the caller surface a fallback toast;
+    // capture is never blocked. (Fork A — silent Vault fallback.)
+    let placedIn: 'hand' | 'vault' = 'vault'
+    const handResult = await addBarToHandForPlayer(playerId, bar.id)
+    if ('success' in handResult && handResult.success) {
+      placedIn = 'hand'
+    }
+
     revalidatePath('/bars')
     revalidatePath('/bars/garden')
     revalidatePath('/hand')
     revalidatePath('/')
 
-    return { barId: bar.id, title }
+    return { barId: bar.id, title, placedIn }
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Unknown error'
     console.error('[BAR] Canvas capture failed:', message)

--- a/src/actions/hand.ts
+++ b/src/actions/hand.ts
@@ -16,6 +16,8 @@
 
 import { dbBase } from '@/lib/db'
 import { getCurrentPlayer } from '@/lib/auth'
+import { effectiveMaturity, parseSeedMetabolization } from '@/lib/bar-seed-metabolization'
+import { isHandVaultMovable } from '@/lib/hand-movement'
 import {
     HAND_SIZE,
     readHandDb,
@@ -38,6 +40,51 @@ export async function getPlayerHand(): Promise<HandContents | ErrorResult> {
     const player = await getCurrentPlayer()
     if (!player) return { error: 'Not authenticated' }
     return readHandDb(player.id)
+}
+
+export type MovableVaultBar = {
+    id: string
+    title: string
+    element: string | null
+    maturity: string
+}
+
+/**
+ * List the player's Vault BARs eligible to be pulled into the Hand: owned,
+ * active, capture-type, non-planted (Fork B), and not already bound to a slot.
+ * Powers the Hand-glance empty-slot picker.
+ */
+export async function listMovableVaultBars(): Promise<MovableVaultBar[] | ErrorResult> {
+    const player = await getCurrentPlayer()
+    if (!player) return { error: 'Not authenticated' }
+
+    const [bars, slots] = await Promise.all([
+        dbBase.customBar.findMany({
+            where: {
+                creatorId: player.id,
+                status: 'active',
+                archivedAt: null,
+                type: { in: ['bar', 'charge_capture'] },
+            },
+            orderBy: { createdAt: 'desc' },
+            select: { id: true, title: true, nation: true, seedMetabolization: true },
+        }),
+        dbBase.handSlot.findMany({
+            where: { playerId: player.id, barId: { not: null } },
+            select: { barId: true },
+        }),
+    ])
+
+    const inHand = new Set(slots.map(s => s.barId))
+
+    const result: MovableVaultBar[] = []
+    for (const b of bars) {
+        if (inHand.has(b.id)) continue
+        const maturity = effectiveMaturity(parseSeedMetabolization(b.seedMetabolization))
+        if (!isHandVaultMovable(maturity)) continue
+        result.push({ id: b.id, title: b.title, element: b.nation, maturity })
+    }
+    return result
 }
 
 /**

--- a/src/app/bars/[id]/page.tsx
+++ b/src/app/bars/[id]/page.tsx
@@ -17,6 +17,10 @@ import { listAttachableCampaigns } from '@/actions/campaign-attach'
 import { BarSocialLinks } from '@/components/bars/BarSocialLinks'
 import { BarSocialLinksForm } from '@/components/bars/BarSocialLinksForm'
 import { DeleteBarButton } from '@/components/bars/DeleteBarButton'
+import { HandLocationToggle } from '@/components/hand/HandLocationToggle'
+import { readHandDb } from '@/lib/hand-service'
+import { effectiveMaturity, parseSeedMetabolization } from '@/lib/bar-seed-metabolization'
+import { isHandVaultMovable } from '@/lib/hand-movement'
 
 /**
  * @page /bars/:id
@@ -73,6 +77,18 @@ export default async function BarDetailPage({
 
     // TSG Phase 2 — campaigns this player can offer the BAR to (owner only).
     const attachableCampaigns = isOwner ? await listAttachableCampaigns() : []
+
+    // Hand ↔ Vault movement (owner only). The toggle is offered on capture-type,
+    // non-planted BARs; Hand membership is read from HandSlot inline (no extra
+    // server action). Fork B restricts which maturities are movable.
+    const barMaturity = effectiveMaturity(parseSeedMetabolization(bar.seedMetabolization))
+    const canMoveHandVault =
+        isOwner &&
+        (bar.type === 'bar' || bar.type === 'charge_capture') &&
+        isHandVaultMovable(barMaturity)
+    const hand = canMoveHandVault ? await readHandDb(player.id) : null
+    const inHand = hand ? hand.slots.some(s => s.barId === bar.id) : false
+    const handFull = hand ? hand.filledCount >= hand.size : false
 
     return (
         <BarDetailClient bar={bar} isOwner={isOwner} isRecipient={isRecipient} recipientShare={recipientShare ?? null}>
@@ -210,6 +226,23 @@ export default async function BarDetailPage({
                                 </div>
                             ))}
                         </div>
+                    </section>
+                )}
+
+                {/* Hold in Hand / Return to Vault (owner only, non-planted) */}
+                {canMoveHandVault && (
+                    <section className="bg-zinc-900/30 border border-zinc-800 rounded-xl p-6 flex items-center justify-between gap-4">
+                        <div>
+                            <h2 className="text-sm font-bold text-white">
+                                {inHand ? 'In your Hand' : 'In your Vault'}
+                            </h2>
+                            <p className="text-xs text-zinc-500 mt-1">
+                                {inHand
+                                    ? 'Carried into play. Return it to the Vault to free a slot.'
+                                    : 'Stored. Hold it in your Hand to work it with your daily charge and moves.'}
+                            </p>
+                        </div>
+                        <HandLocationToggle barId={bar.id} inHand={inHand} handFull={handFull} />
                     </section>
                 )}
 

--- a/src/app/bars/garden/page.tsx
+++ b/src/app/bars/garden/page.tsx
@@ -3,6 +3,9 @@ import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { listMyBarsForGarden, type BarGardenFilters } from '@/actions/bars'
 import { BarListThumb } from '@/components/bars/BarListThumb'
+import { HandLocationToggle } from '@/components/hand/HandLocationToggle'
+import { readHandDb } from '@/lib/hand-service'
+import { isHandVaultMovable } from '@/lib/hand-movement'
 import {
   MATURITY_PHASES,
   SOIL_KINDS,
@@ -58,6 +61,11 @@ export default async function BarsGardenPage({
     maturity,
     includeComposted,
   })
+
+  // Hand membership for the inline "Hold in Hand / Return to Vault" control.
+  const hand = await readHandDb(player.id)
+  const inHandIds = new Set(hand.slots.filter(s => s.barId).map(s => s.barId))
+  const handFull = hand.filledCount >= hand.size
 
   const qs = (
     patch: Partial<{ soil: BarGardenFilters['soil']; maturity: BarGardenFilters['maturity']; showComposted: boolean }> = {}
@@ -146,8 +154,13 @@ export default async function BarsGardenPage({
               const meta = parseSeedMetabolization(bar.seedMetabolization)
               const mat = effectiveMaturity(meta)
               const composted = bar.archivedAt != null
+              const movable =
+                !composted &&
+                (bar.type === 'bar' || bar.type === 'charge_capture') &&
+                isHandVaultMovable(mat)
               return (
-                <Link key={bar.id} href={`/bars/${bar.id}`} className="block group">
+                <div key={bar.id} className="space-y-2">
+                <Link href={`/bars/${bar.id}`} className="block group">
                   <div
                     className={`rounded-xl p-4 transition-colors border ${
                       composted
@@ -189,6 +202,17 @@ export default async function BarsGardenPage({
                     </div>
                   </div>
                 </Link>
+                {movable && (
+                  <div className="flex justify-end px-1">
+                    <HandLocationToggle
+                      barId={bar.id}
+                      inHand={inHandIds.has(bar.id)}
+                      handFull={handFull}
+                      compact
+                    />
+                  </div>
+                )}
+                </div>
               )
             })}
           </div>

--- a/src/app/bars/kept/page.tsx
+++ b/src/app/bars/kept/page.tsx
@@ -71,7 +71,7 @@ export default async function KeptPage({ searchParams }: KeptPageProps) {
                     </Link>
                 )}
                 <Link
-                    href="/bars/garden"
+                    href={dest === 'hand' ? '/hand' : '/bars/garden'}
                     className="block w-full py-3 rounded-xl text-sm text-center transition-all"
                     style={{
                         background: 'rgba(255,255,255,0.04)',
@@ -79,7 +79,7 @@ export default async function KeptPage({ searchParams }: KeptPageProps) {
                         color: '#a09e98',
                     }}
                 >
-                    Go to Garden
+                    {dest === 'hand' ? 'Go to your Hand' : 'Go to Garden'}
                 </Link>
             </div>
         </div>

--- a/src/components/bars/SeedCaptureWhiteboard.tsx
+++ b/src/components/bars/SeedCaptureWhiteboard.tsx
@@ -833,13 +833,20 @@ function TextEditorOverlay({
 interface CapturedOverlayProps {
   barId: string
   title: string
+  placedIn: 'hand' | 'vault'
   onTuneNow: () => void
   onBackToBoard: () => void
 }
 
-function CapturedOverlay({ title, onTuneNow, onBackToBoard }: CapturedOverlayProps) {
+function CapturedOverlay({ title, placedIn, onTuneNow, onBackToBoard }: CapturedOverlayProps) {
   const woodGem = '#2ecc71'
   const woodGlow = '#27ae60'
+  // Fork A: the seed is held in the Hand; if the Hand was full it falls back
+  // to the Vault — say so plainly rather than blocking with a modal.
+  const destinationLine =
+    placedIn === 'hand'
+      ? 'Held in your Hand'
+      : 'Hand full — saved to your Vault. Hold it later from your Hand.'
   return (
     <div
       className="absolute inset-0 flex flex-col items-center justify-center gap-5"
@@ -892,6 +899,21 @@ function CapturedOverlay({ title, onTuneNow, onBackToBoard }: CapturedOverlayPro
         }}
       >
         {title}
+      </p>
+
+      {/* Destination — Hand by default, Vault fallback when the Hand is full */}
+      <p
+        style={{
+          fontFamily: 'Space Mono, monospace',
+          fontSize: 10,
+          letterSpacing: '0.06em',
+          color: placedIn === 'hand' ? woodGem : 'rgba(232,226,218,0.7)',
+          textAlign: 'center',
+          margin: 0,
+          maxWidth: 280,
+        }}
+      >
+        {destinationLine}
       </p>
 
       <div className="flex flex-col gap-3 w-full" style={{ marginTop: 8 }}>
@@ -1224,7 +1246,7 @@ export function SeedCaptureWhiteboard({
   const [captureError, setCaptureError] = useState<string | null>(null)
   const [reducedMotion, setReducedMotion] = useState(false)
   const [intent, setIntent] = useState('')
-  const [captured, setCaptured] = useState<{ barId: string; title: string } | null>(null)
+  const [captured, setCaptured] = useState<{ barId: string; title: string; placedIn: 'hand' | 'vault' } | null>(null)
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -1539,7 +1561,7 @@ export function SeedCaptureWhiteboard({
         return
       }
 
-      const { barId, title } = result
+      const { barId, title, placedIn } = result
 
       // Upload pending photos and voice memos now that we have a barId
       const mediaItems = items.filter(i => i.type === 'photo' || i.type === 'voice')
@@ -1561,7 +1583,7 @@ export function SeedCaptureWhiteboard({
         )
       }
 
-      setCaptured({ barId, title })
+      setCaptured({ barId, title, placedIn })
     } catch (err) {
       setCaptureError(err instanceof Error ? err.message : 'Capture failed')
     } finally {
@@ -1809,6 +1831,7 @@ export function SeedCaptureWhiteboard({
           <CapturedOverlay
             barId={captured.barId}
             title={captured.title}
+            placedIn={captured.placedIn}
             onTuneNow={() => router.push(`/bars/${captured.barId}`)}
             onBackToBoard={() => router.push('/hand')}
           />

--- a/src/components/bars/SimpleCaptureForm.tsx
+++ b/src/components/bars/SimpleCaptureForm.tsx
@@ -36,15 +36,18 @@ export function SimpleCaptureForm({ defaultText = '', campaignRef }: SimpleCaptu
         startTransition(async () => {
             const result = await captureBar({
                 content: trimmed,
-                destination: 'vault',
+                destination: 'hand',
             })
             if ('error' in result) {
                 setError(result.error)
                 return
             }
+            // Held in the Hand by default; a full Hand parks it in the Vault
+            // (Fork A — silent fallback, no overflow modal on this surface).
+            const dest = 'placedIn' in result && result.placedIn === 'hand' ? 'hand' : 'vault'
             const barId = result.barId
             const titleParam = encodeURIComponent(trimmed.split('\n')[0].slice(0, 60))
-            router.push(`/bars/kept?barId=${barId}&dest=vault&title=${titleParam}`)
+            router.push(`/bars/kept?barId=${barId}&dest=${dest}&title=${titleParam}`)
         })
     }
 

--- a/src/components/hand/HandLocationToggle.tsx
+++ b/src/components/hand/HandLocationToggle.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { promoteVaultBarToHand, depositHandBarToVault } from '@/actions/hand'
+import { HOLD_IN_HAND, RETURN_TO_VAULT, HAND_FULL_HINT } from '@/lib/hand-movement'
+
+/**
+ * Move a single owned BAR between the Hand and the Vault.
+ *
+ * - In Vault → "Hold in Hand" (promoteVaultBarToHand). Refused (non-blocking)
+ *   when the Hand is full.
+ * - In Hand → "Return to Vault" (depositHandBarToVault) — a gentle file-away,
+ *   NOT compost/archive.
+ *
+ * Render only for owned, non-planted BARs (see isHandVaultMovable). `compact`
+ * is for inline list rows; the default is the roomier detail-page treatment.
+ */
+export function HandLocationToggle({
+    barId,
+    inHand,
+    handFull,
+    compact = false,
+}: {
+    barId: string
+    inHand: boolean
+    handFull: boolean
+    compact?: boolean
+}) {
+    const router = useRouter()
+    const [pending, startTransition] = useTransition()
+    const [hint, setHint] = useState<string | null>(null)
+
+    const move = () => {
+        setHint(null)
+        startTransition(async () => {
+            if (inHand) {
+                const res = await depositHandBarToVault({ barId })
+                if ('error' in res) {
+                    setHint(res.error)
+                    return
+                }
+            } else {
+                const res = await promoteVaultBarToHand({ barId })
+                if ('error' in res) {
+                    setHint(res.error)
+                    return
+                }
+                if (!res.success) {
+                    setHint(HAND_FULL_HINT)
+                    return
+                }
+            }
+            router.refresh()
+        })
+    }
+
+    const label = inHand ? RETURN_TO_VAULT : HOLD_IN_HAND
+    // Pre-empt the round-trip when we already know the Hand is full.
+    const blocked = !inHand && handFull
+
+    if (compact) {
+        return (
+            <button
+                type="button"
+                onClick={move}
+                disabled={pending || blocked}
+                title={blocked ? HAND_FULL_HINT : label}
+                className="text-[11px] uppercase tracking-wider px-2 py-1 rounded-md border border-zinc-700 text-zinc-300 hover:border-zinc-500 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+                {pending ? '…' : blocked ? 'Hand full' : label}
+            </button>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            <button
+                type="button"
+                onClick={move}
+                disabled={pending || blocked}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900/60 px-4 py-2.5 text-sm font-medium text-zinc-200 hover:border-zinc-500 hover:bg-zinc-800/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+                <span aria-hidden>{inHand ? '↩' : '✋'}</span>
+                {pending ? 'Moving…' : label}
+            </button>
+            {(hint || blocked) && (
+                <p className="text-xs text-amber-400/80">{hint ?? HAND_FULL_HINT}</p>
+            )}
+        </div>
+    )
+}

--- a/src/components/now/HandGlance.tsx
+++ b/src/components/now/HandGlance.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState, useTransition } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { listMovableVaultBars, promoteVaultBarToHand, type MovableVaultBar } from '@/actions/hand'
 
 const MATURITY_LABELS: Record<string, string> = {
   captured: 'Captured',
@@ -41,6 +43,9 @@ type HandGlanceProps = {
 
 export function HandGlance({ slots, filledCount, vaultCount, gardenCount }: HandGlanceProps) {
   const [collapsed, setCollapsed] = useState(false)
+  // Empty-slot Vault picker (bottom sheet). `pickerSlot` is the target slot.
+  const router = useRouter()
+  const [pickerSlot, setPickerSlot] = useState<number | null>(null)
 
   return (
     <section>
@@ -101,9 +106,10 @@ export function HandGlance({ slots, filledCount, vaultCount, gardenCount }: Hand
 
             if (!slot.barId || !slot.title) {
               return (
-                <Link
+                <button
                   key={slot.slotIndex}
-                  href="/bars/create"
+                  type="button"
+                  onClick={() => setPickerSlot(slot.slotIndex)}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
@@ -115,12 +121,14 @@ export function HandGlance({ slots, filledCount, vaultCount, gardenCount }: Hand
                     color: '#6b6965',
                     fontSize: 20,
                     fontWeight: 300,
-                    textDecoration: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
                     transition: 'box-shadow 0.2s, color 0.2s',
+                    WebkitTapHighlightColor: 'transparent',
                   }}
                 >
                   +
-                </Link>
+                </button>
               )
             }
 
@@ -236,6 +244,121 @@ export function HandGlance({ slots, filledCount, vaultCount, gardenCount }: Hand
           })}
         </div>
       )}
+
+      {pickerSlot !== null && (
+        <EmptySlotSheet
+          slotIndex={pickerSlot}
+          onClose={() => setPickerSlot(null)}
+          onPicked={() => {
+            setPickerSlot(null)
+            router.refresh()
+          }}
+        />
+      )}
     </section>
+  )
+}
+
+/**
+ * Bottom sheet for an empty Hand slot: pull an existing Vault BAR in, or
+ * capture a new one. Vault BARs are lazy-loaded when the sheet opens.
+ */
+function EmptySlotSheet({
+  slotIndex,
+  onClose,
+  onPicked,
+}: {
+  slotIndex: number
+  onClose: () => void
+  onPicked: () => void
+}) {
+  const [bars, setBars] = useState<MovableVaultBar[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  useEffect(() => {
+    let active = true
+    listMovableVaultBars().then(res => {
+      if (!active) return
+      if ('error' in res) setError(res.error)
+      else setBars(res)
+    })
+    return () => { active = false }
+  }, [])
+
+  const pull = (barId: string) => {
+    startTransition(async () => {
+      const res = await promoteVaultBarToHand({ barId, targetSlot: slotIndex })
+      if ('error' in res) {
+        setError(res.error)
+        return
+      }
+      onPicked()
+    })
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 50,
+        background: 'rgba(5,4,3,0.86)', backdropFilter: 'blur(6px)', WebkitBackdropFilter: 'blur(6px)',
+        display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', padding: 18,
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{ borderRadius: 18, background: '#242420', boxShadow: '0 24px 48px -16px rgba(0,0,0,0.9)', padding: 20, maxHeight: '70vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+          <h3 style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 17, letterSpacing: '-0.015em', margin: 0, color: '#e8e6e0' }}>
+            Fill this slot
+          </h3>
+          <Link href="/bars/capture" style={{ fontFamily: 'Space Mono, monospace', fontSize: 9, letterSpacing: '0.08em', textTransform: 'uppercase' as const, color: '#c4b5fd', textDecoration: 'none' }}>
+            + Capture new
+          </Link>
+        </div>
+
+        {error && (
+          <p style={{ fontFamily: 'Nunito, sans-serif', fontSize: 12, color: '#e74c3c', margin: '0 0 10px' }}>{error}</p>
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, overflowY: 'auto' }}>
+          {bars === null && !error && (
+            <p style={{ fontFamily: 'Nunito, sans-serif', fontSize: 12, color: '#6b6965', margin: 0 }}>Loading your Vault…</p>
+          )}
+          {bars && bars.length === 0 && (
+            <p style={{ fontFamily: 'Nunito, sans-serif', fontSize: 12, color: '#6b6965', margin: 0 }}>
+              No Vault BARs to pull in. Capture a new one above.
+            </p>
+          )}
+          {bars?.map(b => {
+            const el = isElementKey(b.element) ? ELEMENT_TOKENS[b.element] : null
+            return (
+              <button
+                key={b.id}
+                type="button"
+                onClick={() => pull(b.id)}
+                disabled={pending}
+                style={{
+                  textAlign: 'left', cursor: pending ? 'not-allowed' : 'pointer', border: 'none',
+                  display: 'flex', alignItems: 'center', gap: 11, padding: '11px 12px', borderRadius: 8,
+                  background: '#111110', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.1)',
+                  opacity: pending ? 0.5 : 1, WebkitTapHighlightColor: 'transparent',
+                }}
+              >
+                <span style={{ flex: '0 0 auto', width: 8, height: 8, borderRadius: '50%', background: el ? el.gem : '#7c3aed', boxShadow: `0 0 7px 1px ${el ? el.glow : '#7c3aed'}88` }} />
+                <span style={{ flex: 1, minWidth: 0, fontFamily: 'Nunito, sans-serif', fontSize: 12, color: '#e8e6e0', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {b.title}
+                </span>
+                <span style={{ flex: '0 0 auto', fontFamily: 'Space Mono, monospace', fontSize: 8, letterSpacing: '0.08em', textTransform: 'uppercase' as const, color: '#6b6965' }}>
+                  → Hand
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/lib/hand-movement.ts
+++ b/src/lib/hand-movement.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared copy + eligibility for Hand ↔ Vault movement.
+ *
+ * Plain module (no 'use server') — safe to import from server components and
+ * client components alike. The two labels live here so the pending
+ * `hand-vault-rename` can repoint the vocabulary in one place.
+ *
+ * See .specify/specs/hand-vault-capture-movement/spec.md
+ */
+
+import type { MaturityPhase } from '@/lib/bar-seed-metabolization'
+
+/** Vault → Hand. */
+export const HOLD_IN_HAND = 'Hold in Hand'
+
+/** Hand → Vault (a gentle "file away" — does NOT archive/compost the BAR). */
+export const RETURN_TO_VAULT = 'Return to Vault'
+
+/** Shown when a Vault → Hand move is refused because the Hand is full. */
+export const HAND_FULL_HINT = 'Hand is full (6/6) — return one first'
+
+/**
+ * Fork B (v1): the Hand ↔ Vault toggle is offered only on non-planted BARs.
+ * `context_named` / `elaborated` are *planted* and home in the Garden;
+ * `integrated` has graduated to Quests. Garden ↔ Hand movement is a separate
+ * follow-up, so we restrict the toggle to the two phases the IA homes in the
+ * Hand/Vault: `captured` and `shared_or_acted`.
+ */
+const MOVABLE_MATURITIES: ReadonlySet<MaturityPhase> = new Set<MaturityPhase>([
+    'captured',
+    'shared_or_acted',
+])
+
+export function isHandVaultMovable(maturity: MaturityPhase | null | undefined): boolean {
+    // A freshly captured BAR with no metabolization record reads as `captured`.
+    if (!maturity) return true
+    return MOVABLE_MATURITIES.has(maturity)
+}


### PR DESCRIPTION
## Summary

Fixes #132 — the Hand stays perpetually empty because the dominant capture path never routes into the Hand, and there is no UI to move a BAR between Hand and Vault. The bounded-inventory model (`HandSlot`) and its server actions already existed and were correct; this PR finishes the wiring so the player-facing flow matches the design.

Built spec-first under `.specify/specs/hand-vault-capture-movement/` (spec, plan, tasks, and a Six-GM-Faces deliberation), then implemented Phases 1–3.

## Root cause

- `captureBarFromCanvas` (the whiteboard at `/bars/capture`, the primary capture surface) created the BAR but **never bound a `HandSlot`** — every canvas capture landed in the Vault. `SimpleCaptureForm` hardcoded `destination: 'vault'`.
- The movement actions (`promoteVaultBarToHand`, `depositHandBarToVault`) existed but **nothing in the UI invoked them**; the Hand-glance empty slot linked to `/bars/create` instead of pulling a Vault BAR in.

No schema change — Hand membership stays encoded by the existing `HandSlot` join table (the issue's suggested `location` column would have duplicated state).

## Changes

**Capture routes to the Hand (Phase 1)**
- `captureBarFromCanvas` now calls `addBarToHandForPlayer` and returns `placedIn`. A full Hand falls back **silently to the Vault** (no modal on the immersive canvas — Fork A); capture is never blocked.
- `SeedCaptureWhiteboard`'s `CapturedOverlay` shows the real destination ("Held in your Hand" / "Hand full — saved to your Vault").
- `SimpleCaptureForm` captures to the Hand; `/bars/kept` reflects `dest=hand` and links to `/hand`.

**Bidirectional movement UI (Phase 2)**
- New `src/lib/hand-movement.ts` — shared copy constants (`HOLD_IN_HAND` / `RETURN_TO_VAULT`, ready for the pending `hand-vault-rename`) + `isHandVaultMovable` (Fork B: non-planted maturities only).
- New `HandLocationToggle` client component over the existing promote/deposit actions; `inHand`/`handFull` computed inline in server components (no new read action).
- **BAR detail page** — owner-only location section with the toggle.
- **Garden list rows** — compact toggle on movable owned rows.
- **Now Hand glance** — empty slot opens a bottom-sheet that pulls a Vault BAR in (new `listMovableVaultBars` action) or links to capture new.

**Verification quest (Phase 3)**
- `scripts/seed-hand-vault-movement-cert.ts` + `seed:cert:hand-vault-movement` npm script — idempotent seed for `cert-hand-vault-movement-v1` walking the full loop (Bruised Banana framing).

## Product decisions (from the Six-Faces deliberation)

- **Fork A** — whiteboard capture with a full Hand → silent Vault fallback + confirmation copy, not a modal on the canvas.
- **Fork B** — the Hand↔Vault toggle is shown only on non-planted BARs (`captured` / `shared_or_acted`) in v1; Garden↔Hand movement is a clean follow-up.

## Verification

- `tsc --noEmit` clean and `eslint` 0 errors; the full `npm run check` (Prisma generate + build-reliability verifiers + lint + type-check) passes in the pre-commit hook.
- **Not run in this environment:** the live app flow / `next build` (Google Fonts fetch is blocked in the sandbox) and the cert-quest seed (`T3.3`, needs a live `DATABASE_URL`). Both should be exercised before merge.

## Deferred (noted in tasks.md)

- Extracting a shared `OverflowModal` from `CaptureBox` (Fork A means the whiteboard never needs it).
- Inline toggle on the Vault `StarterQuestBoard` rows (high-risk to thread per-row state through the shared component; Garden list covers the list surface for v1).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p6GL3TydvKiGYLW3fnq53

---
_Generated by [Claude Code](https://claude.ai/code/session_015p6GL3TydvKiGYLW3fnq53)_