### PR TITLE
Add Inner Garden Shaman bridge

### DIFF
--- a/.specify/specs/six-guide-calrunia-orientation/BARS_CALRUNIA_WORLD_MECHANICS.md
+++ b/.specify/specs/six-guide-calrunia-orientation/BARS_CALRUNIA_WORLD_MECHANICS.md
@@ -1,0 +1,682 @@
+# BARs and Calrunia World Mechanics
+
+> Companion artifacts:
+> - [GUIDE_CAMPAIGN_MATRIX.md](./GUIDE_CAMPAIGN_MATRIX.md) defines the six Guide campaigns as game types, player fantasies, core loops, and unlock paths.
+> - [CALRUNIAN_OPPOSITION_MATRIX.md](./CALRUNIAN_OPPOSITION_MATRIX.md) grounds each Guide's heroic opposition in existing Calrunia lore and world logic.
+> - [INNER_GARDEN_IMPLEMENTATION_RESEARCH.md](./INNER_GARDEN_IMPLEMENTATION_RESEARCH.md) maps the six game types onto the inner-garden systems already present in bars-engine.
+>
+> This document answers the production question underneath both: how do BARs let outer-world player behavior affect inner-world Calrunian play?
+
+## Producer Frame
+
+This project has already spent real time and money building a large set of systems. The pre-production mandate is therefore:
+
+> Do not invent a new game layer until the existing bars-engine pieces have been turned into playable loops.
+
+The core pieces already in the engine:
+
+- `CustomBar`: the universal object for notes, charges, quests, invitations, offers, evidence, and campaign artifacts.
+- `HandSlot`: a bounded six-slot in-world inventory.
+- Vault / Garden maturity: captured BARs mature from raw capture into contextualized, elaborated, shared, acted, and integrated material.
+- Move Generator: turns BARs into move-ready action.
+- Emotional Alchemy / 3-2-1: metabolizes charge.
+- Superpower translation: turns allyship cards into personalized quests.
+- Campaigns / Instances: outer-world causes and inner-world play spaces.
+- Milestones / Needs / Contributions: real-world campaign impact.
+- Gameboard Aid Offers: offers of help attached to campaign slots.
+- I Ching / Hexagram context: oracle/pattern layer.
+- Nations / Archetypes / Sects: identity, terrain, discipline.
+
+The design problem:
+
+> How do outer-world player actions affect inner-world Calrunian play, and how does inner-world play return as changed outer-world behavior?
+
+The answer should be built around BARs.
+
+## BARs As The Membrane Object
+
+BARs are the object that can exist on both sides of the portal.
+
+| Outer-World Meaning | Calrunian Meaning | Existing Engine Support |
+|---------------------|------------------|-------------------------|
+| note / captured thought | seed / talisman / carried charge | `CustomBar`, `seedMetabolization` |
+| active concern | object in the Hand | `HandSlot` |
+| action commitment | quest or move | `moveType`, `moveAspect`, `QuestMoveLog` |
+| emotional material | elemental/national terrain | `nation`, `emotionalAlchemyTag`, 3-2-1 flows |
+| campaign contribution | aid, milestone, need | `campaignRef`, `MilestoneNeed`, `MilestoneContribution`, `GameboardAidOffer` |
+| evidence of action | world-state update | `storyContent`, `completionEffects`, `createdBarId` |
+| invitation / social bridge | emissary object | invitation BARs, event invite BARs, shares |
+| oracle-attuned situation | hexagram-marked artifact | `hexagramId`, I Ching context |
+
+So the basic world rule can be:
+
+> A BAR is a piece of outer-world reality that has been made playable inside Calrunia.
+
+## Outer World To Inner World
+
+The player affects Calrunia by bringing real material into the game as BARs.
+
+```text
+Outer-world situation
+-> BAR capture
+-> BAR enters Hand / Vault / Garden
+-> Move, alchemy, superpower, Guide, or oracle reads it
+-> Calrunian world state changes
+```
+
+Examples:
+
+- A captured fear becomes an Argyran object in the Hand.
+- A direct-action commitment becomes Breakpoint pressure in a campaign.
+- An invitation BAR becomes a Diplomat emissary.
+- A milestone contribution becomes visible world repair.
+- A completed 3-2-1 becomes Shaman evidence that the Failed Mirror has cleared.
+- An I Ching-attuned BAR becomes Sage narrative data.
+
+## Inner World To Outer World
+
+Calrunia affects the outer world by transforming BARs into moves, quests, invitations, offers, and contribution artifacts.
+
+```text
+Calrunian reading / game mode
+-> move candidate
+-> quest / commitment / invitation / offer
+-> player acts outside the app
+-> player returns with evidence
+-> BAR matures and world state updates
+```
+
+The important loop is not "lore consumed." It is "behavior changed."
+
+## Design Principles
+
+### From Jane McGonigal
+
+Make the work feel playable by giving players clear goals, voluntary obstacles, feedback, social meaning, and urgent optimism.
+
+Application:
+
+- Each Guide needs a visible win condition.
+- The obstacle should be meaningful, not fake friction.
+- The player should see evidence that their move mattered.
+- Social play should make allyship feel collective rather than solitary.
+
+### From Yu-kai Chou
+
+Use motivational drivers carefully: meaning, accomplishment, ownership, social influence, scarcity, unpredictability, avoidance, and creativity.
+
+Application:
+
+- Unlocks should feel like earned mastery, not artificial scarcity.
+- BARs create ownership.
+- Guides create meaning.
+- Campaign milestones create accomplishment.
+- Invitations and aid offers create social influence.
+- I Ching creates mystery, but must return to action.
+
+### From C. Thi Nguyen
+
+Games are designed agencies. Players temporarily take on goals and constraints to experience and practice forms of agency.
+
+Application:
+
+- Each Guide should give the player a distinct agency.
+- Shaman agency is ritual transformation.
+- Challenger agency is decisive interruption.
+- Regent agency is stewardship.
+- Architect agency is system-building.
+- Diplomat agency is relational translation.
+- Sage agency is pattern-reading into action.
+
+## Multiple Design Options For BAR / World Intersection
+
+### Option A: BARs As Carried Relics
+
+**Pitch**: BARs are physicalized as objects in the player's Hand. The six-slot Hand is the immediate play inventory.
+
+**Existing pieces**:
+
+- `HandSlot`
+- `HandGlance`
+- `CustomBar.nation`
+- `seedMetabolization`
+- Move Generator
+
+**Mechanic**:
+
+- Player chooses which BARs to carry.
+- A carried BAR influences available Guide routes, move candidates, nation reveal, and oracle readings.
+- Hand size creates a meaningful constraint: what are you actually carrying now?
+
+**Strengths**:
+
+- Uses existing bounded inventory.
+- Makes outer-world concerns feel embodied.
+- Strong fit for Nguyen: players practice the agency of selective attention.
+
+**Risks**:
+
+- Could feel like inventory management unless the carried BARs visibly change play.
+
+**Best use**:
+
+- Default cross-world mechanic.
+
+### Option B: BARs As Seeds That Grow The World
+
+**Pitch**: BAR maturity determines how much a real-world concern has entered Calrunia.
+
+**Existing pieces**:
+
+- `seedMetabolization`
+- Vault / Garden maturity labels
+- `markMoveReady()`
+- BAR Garden
+
+**Mechanic**:
+
+```text
+Captured
+-> context_named
+-> elaborated
+-> shared_or_acted
+-> integrated
+```
+
+Each maturity stage changes the Calrunian expression:
+
+| Maturity | Calrunian Expression |
+|----------|----------------------|
+| captured | seed / spark |
+| context_named | named object / clue |
+| elaborated | quest seed / terrain marker |
+| shared_or_acted | world event / contribution |
+| integrated | lore, title, unlock, or permanent world change |
+
+**Strengths**:
+
+- Already in code.
+- Makes ordinary note-taking become world-building.
+- Gives feedback without needing a large new map.
+
+**Risks**:
+
+- Maturity must be legible to players.
+
+**Best use**:
+
+- The backbone of BAR-to-Calrunia progression.
+
+### Option C: BARs As Quest Fuel
+
+**Pitch**: A BAR can be converted into a quest, and completing the quest changes both player state and campaign state.
+
+**Existing pieces**:
+
+- `sourceBarId`
+- `questsFromBar`
+- `QuestMoveLog`
+- quest generation
+- `moveType`, `moveAspect`, `allyshipTarget`
+
+**Mechanic**:
+
+- Player selects a BAR.
+- Guide/move/oracle translates it into a quest.
+- Quest completion creates a new BAR or move log.
+- Returned evidence alters campaign progress or unlocks lore.
+
+**Strengths**:
+
+- Directly tied to changed behavior.
+- Lets each Guide become a campaign with quests.
+
+**Risks**:
+
+- Quest generation has sprawled; must constrain scope.
+
+**Best use**:
+
+- Guide campaign episodes.
+
+### Option D: BARs As Campaign Contributions
+
+**Pitch**: BARs become scoped contributions toward real campaign milestones.
+
+**Existing pieces**:
+
+- `campaignRef`
+- `MilestoneNeed`
+- `MilestoneContribution`
+- `GameboardAidOffer`
+- superpower translation
+
+**Mechanic**:
+
+- Campaign has milestone needs.
+- Player's BAR/superpower/orientation matches a need.
+- BAR becomes offer, action, or evidence.
+- Completion moves milestone progress.
+- Calrunia reflects the campaign's healing/rebuilding.
+
+**Strengths**:
+
+- Strongest outer-world impact loop.
+- Direct fit for Mastering Allyship.
+- McGonigal-style meaningful social goal.
+
+**Risks**:
+
+- Requires careful campaign stewardship.
+
+**Best use**:
+
+- First public campaign / launch campaign.
+
+### Option E: BARs As Oracle Cases
+
+**Pitch**: A BAR is submitted to the I Ching / Sage layer as a live case.
+
+**Existing pieces**:
+
+- `hexagramId`
+- I Ching cast context
+- trigram/sect docs
+- Move Generator candidate system
+
+**Mechanic**:
+
+- Player selects a BAR or outer-world tension.
+- Cast/read hexagram.
+- Upper/lower trigrams produce sect tension.
+- Oracle adds a move candidate.
+- Player acts and returns evidence.
+
+**Strengths**:
+
+- Clean bridge between outer artifact and inner-world lore.
+- Turns I Ching into decision aid, not flavor.
+
+**Risks**:
+
+- If output is not actionable, it becomes decorative.
+
+**Best use**:
+
+- Sage Guide and sect introduction.
+
+### Option F: BARs As World Wounds / Repairs
+
+**Pitch**: Campaign BARs map to wounds in the Calrunian world; completed outer-world actions repair those wounds.
+
+**Existing pieces**:
+
+- campaign instances
+- spatial maps / world rooms
+- campaign milestones
+- BARs collapsed from instances
+- story bridges
+
+**Mechanic**:
+
+- Campaign defines a Calrunian region or crisis.
+- BARs become wounds, resources, allies, or keys in that region.
+- Completing moves changes the room, unlocks lore, or repairs a faction relationship.
+
+**Strengths**:
+
+- Most RPG-like.
+- Makes collective progress visible.
+
+**Risks**:
+
+- Highest production cost.
+- Should not be first unless reused through existing world room infrastructure.
+
+**Best use**:
+
+- Later campaign visualization layer after Guide mechanics prove themselves.
+
+## Recommended Producer Strategy
+
+Do not pick one option. Layer them by production cost:
+
+```text
+Foundation: BARs as Carried Relics
+Progression: BARs as Seeds That Grow
+Action: BARs as Quest Fuel
+Impact: BARs as Campaign Contributions
+Mystery: BARs as Oracle Cases
+RPG World: BARs as World Wounds / Repairs
+```
+
+This lets us use what exists now while preserving the long-term Calrunian RPG fantasy.
+
+## Mechanics By Guide Campaign
+
+## Shaman Guide: Ritual Transformation Game
+
+### Existing Pieces To Reuse
+
+- BAR capture
+- Emotional First Aid / 3-2-1
+- `emotionalAlchemyTag`
+- `nation`
+- seed maturity
+
+### Player Loop
+
+```text
+Choose charged BAR
+-> name charge
+-> perform 3-2-1 / alchemy ritual
+-> create transformed meaning BAR
+-> reveal emotional terrain / nation
+```
+
+### Core Mechanics
+
+- **Charge Rating**: intensity gates ritual depth.
+- **Shadow Dialogue**: player writes It / You / I.
+- **Nation Reveal**: emotional channel maps to Calrunian terrain.
+- **Mirror Clearing**: successful ritual advances BAR maturity.
+
+### Outer-World Effect
+
+The player stops acting from projection and creates a cleaner next move.
+
+### Inner-World Effect
+
+The Failed Mirror clears around a specific BAR, region, or NPC.
+
+## Challenger Guide: Threshold Action Game
+
+### Existing Pieces To Reuse
+
+- Move Generator
+- `moveType`
+- `moveAspect`
+- evidence fields
+- QuestMoveLog
+- BAR maturity
+
+### Player Loop
+
+```text
+Choose avoided BAR
+-> identify cost of delay
+-> choose pressure move
+-> commit deadline
+-> complete action
+-> return proof
+```
+
+### Core Mechanics
+
+- **Threshold Clock**: player sets a real deadline.
+- **Proof Of Move**: completion requires evidence text or artifact.
+- **Dread Cut**: one decisive interruption can close a bad future but has cost.
+- **Crisis Discipline**: system distinguishes needed urgency from habitual emergency.
+
+### Outer-World Effect
+
+The player does the avoided action.
+
+### Inner-World Effect
+
+The Uncut Future is closed before it roots.
+
+## Regent Guide: Governance And Oath Game
+
+### Existing Pieces To Reuse
+
+- roles
+- invitation roles
+- campaign membership
+- commitment BARs
+- recurring quests
+- campaign milestones
+
+### Player Loop
+
+```text
+Accept role
+-> define responsibility
+-> create oath BAR
+-> steward recurring commitment
+-> review with evidence
+```
+
+### Core Mechanics
+
+- **Oath BAR**: a role commitment becomes a persistent object.
+- **Stewardship Track**: commitments are reviewed over time.
+- **Authority With Consent**: role scope must be explicit.
+- **Repair Action**: dropped commitments create repair quests, not shame loops.
+
+### Outer-World Effect
+
+The player holds a real responsibility more clearly.
+
+### Inner-World Effect
+
+The Burden Throne becomes a legitimate office instead of control or abdication.
+
+## Architect Guide: Builder / Strategy Game
+
+### Existing Pieces To Reuse
+
+- campaign milestones
+- milestone needs
+- superpower translation
+- campaign planning/admin tools
+- quest generation
+
+### Player Loop
+
+```text
+Choose messy goal
+-> map structure gap
+-> break into milestone needs
+-> assign superpower-fit actions
+-> test and revise
+```
+
+### Core Mechanics
+
+- **Milestone Decomposition**: big work becomes scoped needs.
+- **Dependency Map**: identify bottlenecks.
+- **Need Cards**: each need is playable by a superpower/orientation.
+- **Working Container Test**: a structure only succeeds if someone can use it.
+
+### Outer-World Effect
+
+The campaign gets a usable plan or coordination system.
+
+### Inner-World Effect
+
+The Endless Scaffold is converted into a living structure.
+
+## Diplomat Guide: Social Alliance Game
+
+### Existing Pieces To Reuse
+
+- invitation BARs
+- BAR sharing
+- GameboardAidOffer
+- campaign marketplace / aid offers
+- social links / responses
+
+### Player Loop
+
+```text
+Choose relational BAR
+-> map people and tension
+-> craft invitation / repair / bridge
+-> send or offer
+-> return relational signal
+```
+
+### Core Mechanics
+
+- **Ally Map**: who is involved and what each person needs to receive.
+- **Invitation Craft**: create an invitation BAR or share.
+- **Repair Move**: name harm and next right contact.
+- **Signal Return**: player records what happened relationally.
+
+### Outer-World Effect
+
+The player makes a move that lands better with people.
+
+### Inner-World Effect
+
+The Clouded Assembly becomes a table where truth and difference can be held.
+
+## Sage Guide: Oracle / Synthesis Game
+
+### Existing Pieces To Reuse
+
+- I Ching casting
+- `hexagramId`
+- trigram/sect data
+- Move Generator candidate list
+- completed move review
+
+### Player Loop
+
+```text
+Choose live BAR / tension
+-> cast or read I Ching
+-> identify upper/lower trigram
+-> receive sect-of-the-moment
+-> choose oracle move candidate
+-> act and extract lesson
+```
+
+### Core Mechanics
+
+- **Case Reading**: BAR becomes the oracle case.
+- **Upper/Lower Force**: visible force and hidden force.
+- **Sect Candidate**: oracle adds a move candidate to Move Generator.
+- **Doctrine Extraction**: completed action produces a lesson BAR.
+
+### Outer-World Effect
+
+The player acts from pattern recognition rather than confusion.
+
+### Inner-World Effect
+
+The Deferred Synthesis advances without pretending to be complete.
+
+## Three Viable Product Directions
+
+### Direction 1: The Pragmatic Guide Layer
+
+**Build only a Guide selection surface and use existing pages as unlock destinations.**
+
+Flow:
+
+```text
+Need prompt
+-> choose Guide
+-> complete small quest
+-> deep link to existing surface
+```
+
+Pros:
+
+- lowest cost
+- fast proof of orientation model
+- uses existing app
+
+Cons:
+
+- lightest Calrunia fantasy
+
+Best first if production risk is high.
+
+### Direction 2: The BAR-As-Relic RPG Layer
+
+**Make Hand/Vault/Garden the center of the first Calrunian RPG loop.**
+
+Flow:
+
+```text
+capture BAR
+-> carry in Hand
+-> Guide reads carried BAR
+-> move / alchemy / oracle transforms it
+-> maturity changes
+```
+
+Pros:
+
+- uses strongest existing cross-world object
+- gives players a character-like inventory
+- makes world logic visible
+
+Cons:
+
+- needs careful UX to avoid feeling abstract
+
+Best first if we want the app to feel game-like quickly.
+
+### Direction 3: The Campaign Impact RPG Layer
+
+**Tie BARs directly to milestones, needs, offers, and visible campaign progress.**
+
+Flow:
+
+```text
+campaign need
+-> player superpower / Guide
+-> BAR quest
+-> real-world contribution
+-> milestone progress
+-> Calrunia repair
+```
+
+Pros:
+
+- strongest allyship value
+- proves changed behavior and impact
+- good for first public campaign
+
+Cons:
+
+- needs steward-authored campaign content
+
+Best first if the goal is putting this in front of people soon.
+
+## Recommended First Slice
+
+Build a **BAR Portal Loop** that can support all six Guides without implementing them all.
+
+Minimal loop:
+
+```text
+Pick a BAR from Hand
+-> ask "What kind of help do you need?"
+-> recommend a Guide
+-> run one Guide-specific mechanic
+-> update BAR maturity / storyContent
+-> produce one outer-world move
+```
+
+This should be deterministic and mostly use existing pages:
+
+- Shaman routes to Emotional Alchemy / 3-2-1.
+- Challenger routes to Move Generator.
+- Architect routes to milestone/need planning.
+- Diplomat routes to invitation/aid offer.
+- Sage routes to I Ching / oracle candidate.
+- Regent routes to role/commitment BAR.
+
+## Design Guardrails
+
+- Every inner-world effect must be backed by a BAR mutation, quest log, contribution, or unlock.
+- Every Guide must return the player to a concrete outer-world action or artifact.
+- Do not add new currencies until vibeulons and BAR maturity are clearly used.
+- Do not add new world state if `CustomBar`, `Instance`, `Milestone`, or `QuestMoveLog` can hold the data.
+- Lore should explain an experienced mechanic, not replace the mechanic.
+- The player should always know: what am I carrying, what game am I playing, what changed because I acted?

--- a/.specify/specs/six-guide-calrunia-orientation/CALRUNIAN_OPPOSITION_MATRIX.md
+++ b/.specify/specs/six-guide-calrunia-orientation/CALRUNIAN_OPPOSITION_MATRIX.md
@@ -1,0 +1,298 @@
+# Calrunian Opposition Matrix
+
+> Companion artifacts:
+> - [GUIDE_CAMPAIGN_MATRIX.md](./GUIDE_CAMPAIGN_MATRIX.md) defines the six Guide campaigns as game types, player fantasies, core loops, and unlock paths.
+> - [BARS_CALRUNIA_WORLD_MECHANICS.md](./BARS_CALRUNIA_WORLD_MECHANICS.md) explains how BARs function as the membrane object between outer-world behavior and inner-world Calrunian play.
+> - [INNER_GARDEN_IMPLEMENTATION_RESEARCH.md](./INNER_GARDEN_IMPLEMENTATION_RESEARCH.md) maps the Guide campaigns onto the inner-garden room, Guide NPC, nursery, BAR planting, and campaign hub structures already in bars-engine.
+>
+> This document explains the Calrunian opposition that gives those campaigns heroic pressure.
+
+## Producer Frame
+
+If the six Guides are RPG campaigns, they need opposition. But in Calrunia, the opposition should not be arbitrary storybook villains.
+
+The world logic already gives us a stronger answer:
+
+> Antagonists in Calrunia are failed, partial, inherited, or overused cultivation patterns that have become socially, emotionally, or spiritually real.
+
+They are meaningful threats because cultivation changes the world. A practice that saves people in one crisis can become dangerous when inherited without the original necessity. A feeling that is not processed can accumulate in the collective body. A technique that interrupts catastrophe can narrow the world's possible futures if used too often.
+
+This is already present in the lore:
+
+- **The Long Undoing**: Argyra did not fall to an outside enemy; dissatisfaction accumulated across a generation until the people could no longer see each other clearly.
+- **velath-rem, the failed mirror**: the first signal of Argyran collapse; reflection became interference.
+- **velath-torr, Kerath's dread-cutting**: necessary emergency practice that closes bad futures before they root, but narrows possibility when overused.
+- **velath-sil, Caeleth's still-cut**: clarifying interruption that becomes cold severance when copied without true seeing.
+- **velath-dre**: practitioners who learned to cut but not when to stop; explicitly "not villains," but Caeleth's shadow made social.
+- **Verathane's velath sequence**: complete acknowledgment that opens experience rather than closing around it.
+- **Cindrel's Complete Kindling**: Pyrakanth anger held until the burn completes; a response to the Eastern Fire and the Kindling Wars.
+
+So the six Guide campaigns should fight **world-real distortions of practice**, not cartoon evil.
+
+## World Logic: Why Antagonists Are Allowed To Exist
+
+### 1. Emotional energy is not neutral once collectivized
+
+In Calrunia, feelings do not merely happen inside individuals. They become climates, practices, lineages, and eventually national history.
+
+The Long Undoing proves the rule: unprocessed dissatisfaction can gather enough force to become a civilizational event.
+
+### 2. Cultivation techniques have costs
+
+Kerath's dread-cutting saved people because catastrophe was actually arriving. But the lore is clear: closing bad futures by force does not process the energy. It holds it, and it narrows possibility.
+
+That means a heroic practice can become antagonistic when used routinely or without necessity.
+
+### 3. Lineages can inherit forms without wisdom
+
+Caeleth's lore already names the pattern. The velath-dre learned the form of the still-cut without the seeing that gives it purpose. They are not evil; they are a lineage failure made manifest.
+
+This is a strong model for Calrunian antagonists:
+
+```text
+founder practice
+-> useful under exact conditions
+-> copied without conditions
+-> social distortion
+-> campaign opposition
+```
+
+### 4. Crises leave residue
+
+Kerath gave survivors time, not healing. Verathane and Caeleth came later because the survivors needed what Kerath could not provide.
+
+Opposition persists because even a successful heroic intervention leaves unfinished emotional and social work.
+
+### 5. The antagonist is often a partial truth
+
+The best Calrunian antagonist is not wholly wrong.
+
+- The dread-cutter is right that catastrophe can arrive.
+- The still-cutter is right that patterns must sometimes stop.
+- The fire-keeper is right that heat can purify.
+- The mirror-practitioner is right that clarity matters.
+
+They become dangerous when their truth becomes total.
+
+## Campaign Opposition Overview
+
+| Guide | Campaign Opposition | Calrunian Root | Why It Is A Real Threat | Player's Heroic Work |
+|-------|---------------------|----------------|--------------------------|----------------------|
+| Shaman | The Failed Mirror | velath-rem / Long Undoing residue | Projection and distorted reflection make people unable to see each other or themselves | Restore relationship between feeling, image, and truth |
+| Challenger | The Uncut Future | Kerath / velath-torr shadow | Bad futures do sometimes arrive; hesitation lets them root | Make the necessary interruption without becoming addicted to crisis |
+| Regent | The Burden Throne | First Cultivator aftermath / stewardship residue | Emergency authority can harden into control or collapse into abdication | Hold responsibility with care, visibility, and consent |
+| Architect | The Endless Scaffold | failed civic/cultivation containers | Structures can preserve care or trap it in process | Build containers that let life and work move |
+| Diplomat | The Clouded Assembly | failed mirror + unprocessed survivor residue | People can gather while still mis-seeing each other | Restore truthful relation without forcing false harmony |
+| Sage | The Deferred Synthesis | unresolved velath stage model | The world lacks a complete integration of Kerath, Verathane, and Caeleth's practices | Read the pattern without pretending the synthesis is already complete |
+
+For each Guide's player-facing campaign loop, unlocks, and game feel, see [GUIDE_CAMPAIGN_MATRIX.md](./GUIDE_CAMPAIGN_MATRIX.md).
+
+## The Shaman's Guide Opposition: The Failed Mirror
+
+### Lore Root
+
+Argyra's Long Undoing began with **velath-rem**, the failed mirror. The people did not become blind. They could no longer reflect each other clearly. Looking produced interference.
+
+This is not just an image; it is a world condition. A society trained to look, calibrate, and reflect can collapse when its mirrors stop returning reality.
+
+### Campaign Antagonist
+
+**The Failed Mirror** is the Shaman campaign's core opposition.
+
+It appears as:
+
+- projection mistaken for perception
+- inherited grief without image
+- emotional charge that cannot find a true form
+- self-knowledge distorted by fear or dissatisfaction
+- people seeing their wound in everyone else's face
+
+### Why It Is Meaningful
+
+The Failed Mirror threatens the whole allyship loop. If the player cannot see what they are carrying, any outer-world move will carry the distortion forward.
+
+### Player's Heroic Work
+
+The player does not destroy the mirror. They restore its capacity to reflect.
+
+In practice:
+
+```text
+charge
+-> image
+-> dialogue
+-> acknowledgment
+-> meaning
+-> move
+```
+
+## The Challenger's Guide Opposition: The Uncut Future
+
+### Lore Root
+
+Kerath's lore establishes that bad futures can become real if not interrupted. Her velath-torr practice is dread-cutting: seeing the bad future fully enough to close it before it roots.
+
+But the lore also gives the danger: the practitioner who overuses this practice narrows the world's possibility.
+
+### Campaign Antagonist
+
+**The Uncut Future** is the Challenger campaign's core opposition.
+
+It appears as:
+
+- obvious harm that everyone keeps postponing
+- a bad pattern that has not yet become irreversible
+- a social field waiting for someone to name the failure
+- delayed action disguised as care or prudence
+
+### Why It Is Meaningful
+
+The threat is real because some futures are not symbolic. They will arrive unless someone acts.
+
+But the Challenger must not become a permanent emergency engine. The player learns the difference between:
+
+- the moment that must be cut
+- the anxiety that only wants to cut
+
+### Player's Heroic Work
+
+Make the necessary interruption and bear the cost without making crisis into identity.
+
+## The Regent's Guide Opposition: The Burden Throne
+
+### Lore Root
+
+The First Cultivator stories show that emergency action creates survivors, residues, duties, and institutions. Kerath saved enough people for continuation, but she did not heal them. Verathane and Caeleth were needed because survival created further responsibility.
+
+### Campaign Antagonist
+
+**The Burden Throne** is the Regent campaign's core opposition.
+
+It appears as:
+
+- authority claimed without accountability
+- responsibility carried alone until it becomes resentment
+- emergency power that refuses to end
+- obligation without repair
+- stewardship that becomes control
+
+### Why It Is Meaningful
+
+In Calrunia, power does not become legitimate merely because it was useful once. The practice that saved the world yesterday can govern badly tomorrow.
+
+### Player's Heroic Work
+
+Transform emergency authority into visible, shared, accountable stewardship.
+
+## The Architect's Guide Opposition: The Endless Scaffold
+
+### Lore Root
+
+Calrunia's practices are embodied in forms, sequences, channels, lineages, forges, settlements, and civic containers. Verathane's velath sequence mattered because form could carry experience. Cindrel's Line mattered because a boundary in the world changed what could be kindled safely.
+
+Structure is not neutral. It can carry transformation, or it can trap it.
+
+### Campaign Antagonist
+
+**The Endless Scaffold** is the Architect campaign's core opposition.
+
+It appears as:
+
+- plans that never become usable
+- rituals copied without purpose
+- systems that require maintenance but do not move care
+- process that hides responsibility
+- dependency chains nobody can see
+
+### Why It Is Meaningful
+
+A bad structure can exhaust every good intention placed inside it. The opposition is not chaos alone; it is structure without life.
+
+### Player's Heroic Work
+
+Build a container that lets care move through the world.
+
+## The Diplomat's Guide Opposition: The Clouded Assembly
+
+### Lore Root
+
+The Long Undoing made people unable to see each other clearly. Kerath's survivors carried residue: unprocessed dissatisfaction, persistent fear, anger at being saved, gratitude without healing.
+
+That is relationally volatile material. People can be in the same room and still not be in the same reality.
+
+### Campaign Antagonist
+
+**The Clouded Assembly** is the Diplomat campaign's core opposition.
+
+It appears as:
+
+- groups that gather but cannot trust what they see
+- indirect conflict
+- premature harmony
+- gratitude and resentment tangled together
+- people speaking from different residues of the same crisis
+
+### Why It Is Meaningful
+
+Allyship fails when moves cannot land in relationship. Even a correct action can become harmful if the relational field cannot receive it.
+
+### Player's Heroic Work
+
+Create conditions where difference, truth, and repair can share a table.
+
+## The Sage's Guide Opposition: The Deferred Synthesis
+
+### Lore Root
+
+Kerath's file states that the full integration of velath-torr, velath-sequ, and velath-sil into a unified stage model will be completed by a future Sage-level Argyran who has not yet arisen.
+
+This is crucial. Calrunia canon already contains an unsolved Sage problem.
+
+### Campaign Antagonist
+
+**The Deferred Synthesis** is the Sage campaign's core opposition.
+
+It appears as:
+
+- premature theories of everything
+- diviners who confuse partial maps for living reality
+- practitioners who flatten Kerath, Verathane, and Caeleth into one model before earning it
+- pattern reading that refuses the unfinishedness of the world
+
+### Why It Is Meaningful
+
+The Sage threat is not ignorance. It is false completion.
+
+The world is waiting for synthesis, but a forced synthesis would erase the distinct truth of each practice.
+
+### Player's Heroic Work
+
+Read the pattern, act from the best available map, and leave room for what has not yet been integrated.
+
+## Notes On Cindrel And Future Opposition
+
+Cindrel's Complete Kindling gives a second national crisis model beyond Argyra:
+
+- Pyrakanth faced visible fire rather than invisible distortion.
+- The Eastern Fire came from kindling too much, too fast.
+- Cindrel did not extinguish the fire; she contained it until it completed.
+- Cindrel's Line remains as a scar and boundary.
+
+This is especially useful for future Shaman, Challenger, Architect, and Regent content:
+
+- Shaman: anger that must be held until it reveals what remains
+- Challenger: action that must not become uncontrolled ignition
+- Architect: boundaries and civic design after catastrophe
+- Regent: agreements about how much heat a people may kindle at once
+
+## Design Rule For Future Villains
+
+When adding a Calrunian antagonist, answer these questions:
+
+1. Which practice or emotional force did this begin as?
+2. Under what conditions was it useful or necessary?
+3. What changed that made it dangerous?
+4. What cost does it impose on people, terrain, memory, or possibility?
+5. What does the player restore, integrate, interrupt, contain, or complete?
+
+If the antagonist cannot answer those questions, it is probably a storybook enemy rather than a Calrunian threat.

--- a/.specify/specs/six-guide-calrunia-orientation/GUIDE_CAMPAIGN_MATRIX.md
+++ b/.specify/specs/six-guide-calrunia-orientation/GUIDE_CAMPAIGN_MATRIX.md
@@ -1,0 +1,468 @@
+# Guide Campaign Matrix
+
+> Companion artifacts:
+> - [CALRUNIAN_OPPOSITION_MATRIX.md](./CALRUNIAN_OPPOSITION_MATRIX.md) grounds each Guide's heroic opposition in existing Calrunia lore and explains why the antagonists are world-real threats rather than storybook enemies.
+> - [BARS_CALRUNIA_WORLD_MECHANICS.md](./BARS_CALRUNIA_WORLD_MECHANICS.md) explains how BARs function as the membrane object between outer-world behavior and inner-world Calrunian play.
+> - [INNER_GARDEN_IMPLEMENTATION_RESEARCH.md](./INNER_GARDEN_IMPLEMENTATION_RESEARCH.md) maps these game types onto the inner-garden systems already present in bars-engine.
+
+## Pre-Production Frame
+
+**Mastering the Game of Allyship** is a series of six Guide campaigns. Each campaign teaches one level of allyship through a distinct type of game. The campaigns are not merely tutorials for app features; they are playable initiations into different modes of action, perception, relationship, and responsibility.
+
+The design goal:
+
+> Help players move from outer-world usefulness into Calrunian play without making lore feel like homework.
+
+Each Guide answers a different player need:
+
+```text
+What am I carrying?
+What kind of help do I need?
+What game am I being invited to play?
+What capability unlocks when I learn it?
+```
+
+## Campaign Overview
+
+| Guide Campaign | Allyship Level | Player Need | Type of Game | Calrunian Opposition | Primary Unlock |
+|----------------|----------------|-------------|--------------|----------------------|----------------|
+| The Shaman's Guide | Emotional / symbolic allyship | I need to understand what I am feeling | Ritual transformation game | The Failed Mirror | Emotional Alchemy |
+| The Challenger's Guide | Courage / action allyship | I need to stop avoiding action | Threshold action game | The Uncut Future | Pressure moves / direct action |
+| The Regent's Guide | Stewardship allyship | I need to hold responsibility well | Governance and oath game | The Burden Throne | Roles, commitments, stewardship surfaces |
+| The Architect's Guide | Systems allyship | I need to build a plan | Builder / strategy game | The Endless Scaffold | Milestones, needs, organizing tools |
+| The Diplomat's Guide | Relational allyship | I need to navigate people | Social alliance game | The Clouded Assembly | Invitations, ally maps, repair quests |
+| The Sage's Guide | Pattern allyship | I need to read the moment | Oracle / synthesis game | The Deferred Synthesis | I Ching, sect interpretation, review |
+
+## Opposition Logic
+
+The Guide campaigns are heroic because each one teaches the player to face a real distortion in Calrunian world logic.
+
+In Calrunia, antagonists are not arbitrary enemies. They are failed, partial, inherited, or overused cultivation patterns that have become socially, emotionally, or spiritually real.
+
+The lore already establishes this pattern:
+
+- The Long Undoing shows unprocessed dissatisfaction becoming civilizational crisis.
+- velath-rem, the failed mirror, shows reflection becoming interference.
+- Kerath's velath-torr shows necessary interruption becoming dangerous when overused.
+- Caeleth's velath-sil shows clarifying cuts becoming cold severance when copied without true seeing.
+- The velath-dre show lineage failure: practitioners inheriting a form without the wisdom that gave it purpose.
+- Cindrel's Complete Kindling shows that even fire must sometimes be contained until it completes.
+
+The full world-logic breakdown lives in [CALRUNIAN_OPPOSITION_MATRIX.md](./CALRUNIAN_OPPOSITION_MATRIX.md). This matrix keeps the campaign-facing summary close to the Guide design.
+
+## Level 1: The Shaman's Guide To Mastering Allyship
+
+### Game Type
+
+**Ritual transformation game.**
+
+The Shaman's Guide is the game of charged material. Players enter when a BAR, situation, or commitment has more emotional gravity than ordinary task management can hold. The game teaches the player to treat emotion as signal, shadow as recoverable energy, and inner resistance as playable material.
+
+### Heroic Opposition
+
+**The Failed Mirror** — rooted in velath-rem and the Long Undoing. The player is working against projection, distorted reflection, and the inability to see what is actually being carried.
+
+### Player Fantasy
+
+> I can descend into the feeling, retrieve what it is carrying, and return with meaning.
+
+### What The Player Does
+
+- Names what they are carrying.
+- Locates the emotional charge.
+- Performs a 3-2-1 or similar alchemical ritual.
+- Converts a stuck feeling into an insight, vow, or small move.
+- Learns that Calrunia has emotional terrain: nations begin to make sense here.
+
+### Core Loop
+
+```text
+Capture BAR
+-> identify charge
+-> enter ritual
+-> dialogue with the charged part
+-> name the transformed meaning
+-> return with a BAR/move
+```
+
+### Campaign Shape
+
+The Shaman campaign should feel like a descent-and-return arc. It can be intimate, strange, symbolic, and emotionally precise. The player is not being asked to be productive; they are learning to stop discarding the part of the problem that has the most energy.
+
+### Teaches
+
+- Emotional charge is not noise.
+- Shadow is not failure.
+- Feelings can become map data.
+- Inner stuckness can become outer movement.
+
+### Unlocks
+
+- Emotional Alchemy
+- 3-2-1 rituals
+- nation reveal
+- Shaman lore pages
+- deeper interpretation of BAR charge
+
+### Calrunian Emergence
+
+Nations first emerge here. When emotional charge stabilizes into terrain, the player can be told:
+
+> This feeling has a homeland.
+
+## Level 2: The Challenger's Guide To Mastering Allyship
+
+### Game Type
+
+**Threshold action game.**
+
+The Challenger's Guide is the game of avoidance, courage, and decisive movement. Players enter when they know enough to act but are still not acting. The game is not about more insight. It is about crossing the line between intention and observable behavior.
+
+### Heroic Opposition
+
+**The Uncut Future** — rooted in Kerath's dread-cutting and the danger of bad futures being allowed to root. The player is working against delay while learning not to become addicted to crisis.
+
+### Player Fantasy
+
+> I can face the thing I have been avoiding and make a real move.
+
+### What The Player Does
+
+- Names the avoidance.
+- Identifies the cost of delay.
+- Chooses a direct action.
+- Sets a timebox or deadline.
+- Completes an observable move.
+- Reports back with evidence.
+
+### Core Loop
+
+```text
+Name avoidance
+-> choose threshold
+-> commit publicly or concretely
+-> act under pressure
+-> return with proof
+```
+
+### Campaign Shape
+
+The Challenger campaign should feel like a series of gates, dares, trials, and moments of clean action. It should not shame the player. It should make courage concrete.
+
+### Teaches
+
+- Allyship requires action, not just alignment.
+- Courage can be right-sized.
+- Avoidance is a design signal.
+- A move must leave evidence.
+
+### Unlocks
+
+- pressure mode in Move Generator
+- deadline commitments
+- direct action quests
+- Breakpoint / Decisive Storm material when relevant
+- completion-proof patterns
+
+### Calrunian Emergence
+
+The Breakpoint Sect can first become legible here. When a player interrupts a harmful or stagnant pattern, the app can name it:
+
+> This is Breakpoint work.
+
+## Level 3: The Regent's Guide To Mastering Allyship
+
+### Game Type
+
+**Governance and oath game.**
+
+The Regent's Guide is the game of responsibility. Players enter when the problem is no longer just "what should I do?" but "what am I responsible for holding?" This campaign teaches the player to hold commitments, roles, resources, and agreements without collapsing into control or abdication.
+
+### Heroic Opposition
+
+**The Burden Throne** — rooted in the aftermath of emergency cultivation and the responsibilities left behind by survival. The player is working against authority without accountability and stewardship that hardens into control.
+
+### Player Fantasy
+
+> I can hold power, duty, and care without losing myself or dropping the work.
+
+### What The Player Does
+
+- Takes an oath or role.
+- Clarifies what they are stewarding.
+- Names the agreement.
+- Tracks commitments over time.
+- Repairs or renews obligations.
+- Practices authority as care.
+
+### Core Loop
+
+```text
+Accept role
+-> define responsibility
+-> make agreement visible
+-> steward over time
+-> review and renew
+```
+
+### Campaign Shape
+
+The Regent campaign should feel like council play, oathkeeping, stewardship, and long-form responsibility. It is less dramatic than Challenger play, but more durable. The player is learning what it means to be trusted.
+
+### Teaches
+
+- Responsibility needs containers.
+- Power can be held with care.
+- Commitments must be visible.
+- Governance is an allyship practice.
+
+### Unlocks
+
+- campaign roles
+- recurring commitment BARs
+- stewardship dashboards
+- oath/office lore
+- responsibility review surfaces
+
+### Calrunian Emergence
+
+Regent play makes Calrunia feel like a polity. The player begins to see the world not only as emotional terrain, but as a place with offices, councils, duties, and shared stakes.
+
+## Level 4: The Architect's Guide To Mastering Allyship
+
+### Game Type
+
+**Builder / strategy game.**
+
+The Architect's Guide is the game of systems. Players enter when good intentions are failing because there is no structure to carry them. This campaign turns overwhelm into plans, milestones, interfaces, and repeatable workflows.
+
+### Heroic Opposition
+
+**The Endless Scaffold** — rooted in forms, containers, rituals, and civic structures that preserve activity without moving care. The player is working against structure without life.
+
+### Player Fantasy
+
+> I can build the structure that lets the work continue.
+
+### What The Player Does
+
+- Maps a messy problem.
+- Breaks it into parts.
+- Finds bottlenecks and dependencies.
+- Creates milestones or needs.
+- Builds a system, ritual, or workflow.
+- Tests and iterates the structure.
+
+### Core Loop
+
+```text
+Map problem
+-> identify structure gap
+-> design container
+-> assign needs / parts
+-> test in the world
+-> refine
+```
+
+### Campaign Shape
+
+The Architect campaign should feel like building a playable machine for allyship. The player is not just making a plan; they are learning how systems either enable or suffocate care.
+
+### Teaches
+
+- Systems are moral artifacts.
+- Organization is an allyship move.
+- A campaign needs visible structure.
+- Good containers reduce heroic strain.
+
+### Unlocks
+
+- milestone planning
+- needs authoring / decomposition
+- system maps
+- skillful organizing quests
+- campaign infrastructure surfaces
+
+### Calrunian Emergence
+
+Architect play reveals Calrunia as engineered space: bridges, gates, halls, maps, foundries, gardens, and civic machines. The world becomes something players can build inside, not only visit.
+
+## Level 5: The Diplomat's Guide To Mastering Allyship
+
+### Game Type
+
+**Social alliance game.**
+
+The Diplomat's Guide is the game of relationship. Players enter when the move is technically clear but socially delicate. The campaign teaches invitation, repair, coalition-building, and translation across difference.
+
+### Heroic Opposition
+
+**The Clouded Assembly** — rooted in failed reflection and the survivor residue left by collective crisis. The player is working against groups that gather while still mis-seeing each other.
+
+### Player Fantasy
+
+> I can help the move land between people.
+
+### What The Player Does
+
+- Identifies who is involved.
+- Maps relationship dynamics.
+- Crafts invitations.
+- Repairs broken trust.
+- Translates between frames.
+- Builds coalitions and warm handoffs.
+
+### Core Loop
+
+```text
+Map people
+-> identify relational tension
+-> choose bridge move
+-> invite / repair / translate
+-> return with relational signal
+```
+
+### Campaign Shape
+
+The Diplomat campaign should feel like social choreography, council scenes, invitations, delicate negotiations, and relationship repair. Success is not merely "I acted"; success is "the move landed in relationship."
+
+### Teaches
+
+- Allyship happens between people.
+- Translation is a skill.
+- Repair is progress.
+- Invitations are designed, not blasted.
+
+### Unlocks
+
+- invitation tools
+- ally mapping
+- repair quests
+- coalition-building surfaces
+- relational lore / council scenes
+
+### Calrunian Emergence
+
+Diplomat play reveals Calrunia as a network of houses, bridges, alliances, rivalries, and ceremonies of relation. The player learns that every move has social weather.
+
+## Level 6: The Sage's Guide To Mastering Allyship
+
+### Game Type
+
+**Oracle / synthesis game.**
+
+The Sage's Guide is the game of pattern. Players enter when the problem is ambiguous, complex, or repetitive enough that immediate action alone is not sufficient. The campaign teaches the player to read the moment, synthesize what happened, and choose timing and discipline.
+
+### Heroic Opposition
+
+**The Deferred Synthesis** — rooted in the canonically unfinished integration of Kerath's velath-torr, Verathane's velath-sequ, and Caeleth's velath-sil. The player is working against false completion: pattern-reading that pretends the world is more integrated than it is.
+
+### Player Fantasy
+
+> I can see the pattern of the moment and choose the cleanest move.
+
+### What The Player Does
+
+- Brings a real-world tension.
+- Casts or receives an I Ching reading.
+- Reads upper and lower trigrams.
+- Identifies visible and hidden forces.
+- Receives a sect-of-the-moment.
+- Converts the pattern into a move.
+- Returns later with evidence and doctrine.
+
+### Core Loop
+
+```text
+Bring tension
+-> cast/read pattern
+-> name sect tension
+-> choose disciplined move
+-> act in the world
+-> extract lesson
+```
+
+### Campaign Shape
+
+The Sage campaign should feel like an oracle chamber, strategic review, mountain observatory, and teaching lineage. It is not passive contemplation. It is wisdom that returns to action.
+
+### Teaches
+
+- The moment has structure.
+- Divination is a decision aid, not decoration.
+- Sects are disciplines of action.
+- Reflection becomes doctrine when tested.
+
+### Unlocks
+
+- I Ching oracle
+- trigram / hexagram interpretation
+- sect-of-the-moment readings
+- strategic review
+- lesson/doctrine extraction
+
+### Calrunian Emergence
+
+Sage play is where the I Ching becomes the bridge artifact. The outer-world oracle enters Calrunia, becomes narrative data, and returns as an outer-world move.
+
+## Campaign Progression Model
+
+The six campaigns do not need to be strictly linear for every player, but they do create a progression of depth.
+
+```text
+Shaman: feel the charge
+Challenger: make the move
+Regent: hold the responsibility
+Architect: build the structure
+Diplomat: land it in relationship
+Sage: read the pattern
+```
+
+This progression teaches the essentials of allyship as escalating capacities:
+
+| Capacity | Guide | Failure Mode If Missing |
+|----------|-------|-------------------------|
+| Emotional honesty | Shaman | acting from unexamined charge |
+| Courage | Challenger | insight without movement |
+| Stewardship | Regent | action without responsibility |
+| Structure | Architect | care without continuity |
+| Relationship | Diplomat | technically correct moves that do not land |
+| Wisdom | Sage | action without pattern recognition |
+
+## Recommended First Campaign Shape
+
+For the first Mastering Allyship campaign, the player should not be asked to learn all six modes at once.
+
+Recommended onramp:
+
+1. Start with BAR capture as outer-world utility.
+2. Let the player choose what kind of help they need.
+3. Recommend one Guide.
+4. Let the Guide teach one bounded loop.
+5. Unlock one deeper app capability.
+6. Reveal one piece of Calrunian lore as a reward/explanation for what they just practiced.
+
+Example:
+
+```text
+Player captures a charged BAR.
+The app asks: "What kind of help do you need?"
+Player chooses: "I need to understand what I am feeling."
+Shaman Guide begins.
+Player completes a 3-2-1 ritual.
+Emotional Alchemy unlocks.
+Nation lore appears: "This feeling has a homeland."
+```
+
+## Producer Notes
+
+- The Guides should feel like six different games, not six text lessons.
+- Each Guide needs a playable loop with input, action, feedback, and unlock.
+- Lore should arrive as recognition: "Oh, this is what I was just doing."
+- App unlocks should feel like earned tools, not withheld features.
+- The player should always be returned to an outer-world move or artifact.
+- Each campaign's antagonist should be traceable to a Calrunian practice, crisis, lineage, or residue. If the threat cannot explain what useful truth became dangerous, it is probably not yet Calrunian enough.
+
+## One-Sentence Portal Rule
+
+Calrunia appears when a player's outer-world work needs inner-world meaning, discipline, or pattern recognition in order to become right action.

--- a/.specify/specs/six-guide-calrunia-orientation/INNER_GARDEN_IMPLEMENTATION_RESEARCH.md
+++ b/.specify/specs/six-guide-calrunia-orientation/INNER_GARDEN_IMPLEMENTATION_RESEARCH.md
@@ -1,0 +1,655 @@
+# Inner-Garden Implementation Research
+
+> Companion artifacts:
+> - [GUIDE_CAMPAIGN_MATRIX.md](./GUIDE_CAMPAIGN_MATRIX.md) defines the six Guide campaigns as game types, player fantasies, core loops, and unlock paths.
+> - [CALRUNIAN_OPPOSITION_MATRIX.md](./CALRUNIAN_OPPOSITION_MATRIX.md) grounds each Guide's heroic opposition in existing Calrunia lore and world logic.
+> - [BARS_CALRUNIA_WORLD_MECHANICS.md](./BARS_CALRUNIA_WORLD_MECHANICS.md) explains how BARs function as the membrane object between outer-world behavior and inner-world Calrunian play.
+> - [PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md](./PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md) frames the Pixi world as a draft/proving ground and defines the deprecation/bridge decision path.
+>
+> This document answers the implementation question: how can those six game types be created by integrating the current bars-engine Pixi world draft with the more robust Inner Garden prototype in the Library?
+
+## Source Correction
+
+The first pass of this document was based on the **current bars-engine Pixi world draft**, especially campaign hub rooms, spoke portals, face NPCs, nursery rooms, carried BARs, planted spoke beds, and the Collaboration Board.
+
+That was useful, but incomplete.
+
+There is a separate and more robust **Inner Garden source prototype** in the Library:
+
+```text
+The Library/04 Quests/Campaigns/inner-garden
+```
+
+That prototype is not yet fully incorporated into bars-engine. It contains the stronger game design layer:
+
+- farming loop
+- emotion-to-seed loop
+- harvest-to-card loop
+- cultivation progression
+- BAR deck mechanics
+- cultivation manuals
+- trigram advocate NPCs
+- Calrunia nation data
+- local save/state loop
+- manual bridge export back to bars-engine charge capture
+
+So the corrected integration frame is:
+
+> The bars-engine Pixi world is the current host surface. The Library Inner Garden prototype is the richer game design source that should upgrade it.
+
+## Producer Read
+
+The combined system already contains the bones of a playable RPG campaign loop.
+
+The current bars-engine Pixi world gives us a navigable campaign membrane:
+
+```text
+enter world
+-> choose a Guide face
+-> pick or generate a move
+-> carry a BAR
+-> enter a nursery
+-> complete a ritual or plant the BAR
+-> record spoke progress
+-> show campaign growth
+```
+
+That is close enough to the six Guide campaign idea that the next move should be composition, not invention.
+
+The Library Inner Garden prototype gives us a fuller cultivation game:
+
+```text
+real emotional input / BAR
+-> seed
+-> plant
+-> water / nurture / meditate
+-> harvest fruit
+-> mint or unlock card
+-> strengthen cultivation
+-> use card / manual / quest progress
+-> export bridge payload or return to outer-world action
+```
+
+> Recommendation: use bars-engine as the integrated product shell and persistence layer, while importing the Inner Garden prototype's farming, cultivation, deck/manual, BAR-to-card, and advocate ideas as the upgrade path for Calrunian play.
+
+## Library Inner Garden Prototype Findings
+
+### 1. The prototype already knows what the game is about
+
+`DESIGN.md` defines Inner Garden as a game about transforming real emotions into virtual power. Its four pillars match the Mastering Allyship move ladder:
+
+| Inner Garden Pillar | Prototype Meaning | Allyship Meaning |
+|---------------------|------------------|------------------|
+| Wake Up | discover skills, cards, lore, intentions | notice the real signal |
+| Clean Up | process emotional/material accumulation | metabolize charge and shadow |
+| Grow Up | permanent progression, cultivation levels, strategy | build capacity and structure |
+| Show Up | daily engagement, real-life consistency | take the outer-world move |
+
+### 2. The prototype has the BAR-to-card loop we need
+
+`DeckSystem.js` already treats BARs as a game input:
+
+```text
+BAR fields
+-> mint witness card
+-> spend card for cultivation reflection
+-> export bridge payload
+```
+
+This is the missing inner-world character object layer: a BAR can become a card, a card can become a cultivation technique, and a technique can become a repeatable play verb.
+
+### 3. Farming is the embodied metaphor missing from bars-engine
+
+`FarmingSystem.js` provides concrete verbs:
+
+- plant seed
+- water crop
+- nurture crop
+- advance growth stage
+- harvest fruit
+- upgrade garden
+
+Current bars-engine has BAR maturity, Garden panels, Hand/Vault, and spoke planting, but not a spatially embodied tending loop. The prototype's farming system is the strongest candidate for making allyship feel like practice rather than content consumption.
+
+### 4. Emotion is already playable material
+
+`EmotionSystem.js` turns real-life emotional entries into seeds, with intensity affecting quality and meditation improving the seed before planting.
+
+This maps cleanly to bars-engine:
+
+```text
+charge_capture / CustomBar
+-> emotion channel
+-> seed quality
+-> planting / nurturing
+-> harvest
+-> card / move / cultivation growth
+```
+
+### 5. Cultivation gives players inner-world identity
+
+`CultivationSystem.js` tracks virtue stats, cultivation experience, Qi, cultivation level, and breakthrough progress.
+
+This answers a gap from the broader design conversation:
+
+> Players need a character identity inside the inner world.
+
+In the prototype, the player is not just a user with tasks. They are a cultivator with stats, Qi, levels, cards, manuals, and a garden.
+
+### 6. Calrunia advocates are closer to sect gameplay than current Guide NPCs
+
+`CalruniaAdvocates.js` contains a 5 nation x 8 trigram advocate roster. That is more granular than the six Game Master faces and more aligned with the sect/archetype work.
+
+Important implication:
+
+> The six Game Master faces can introduce types of games, while the eight trigram advocate/sect lines can determine the player's deeper Calrunian discipline.
+
+The faces are game modes. The sects are lineages.
+
+### 7. The bridge already exists in miniature
+
+`BarChargeBridge.js` exports an `ig-bar-charge-bridge.v0` payload that maps Inner Garden BAR/card state back toward bars-engine `charge_capture`.
+
+That means the integration does not have to begin with a full rewrite. The prototype already assumes a bridge pattern:
+
+```text
+inner-garden object
+-> bridge JSON
+-> bars-engine charge/custom BAR
+```
+
+## Existing Bars-Engine Host Structure
+
+### 1. Campaign Hub
+
+The octagon campaign hub already gives campaigns a world map.
+
+Existing support:
+
+- `buildOctagonCampaignHubRooms` creates an eight-spoke hub.
+- Each spoke is entered through a `spoke_portal` anchor.
+- `campaignHubState` can store spoke-level hexagram, changing-line, face, and completion data.
+- The Card Club portal already connects world play back to an outer product surface.
+
+Design interpretation:
+
+> The hub is the campaign board. It is where outer-world problems become explorable Calrunian territory.
+
+### 2. Spoke Clearing
+
+Each spoke intro room already provides Guide selection.
+
+Existing support:
+
+- `buildSpokeIntroRoom` creates a clearing with six `face_npc` anchors.
+- The six faces are Shaman, Challenger, Regent, Architect, Diplomat, and Sage.
+- `FaceNpcModal` lets a player choose a Guide, pick a move, launch an authored trial, and carry a generated BAR.
+- Face selection persists through room navigation with `?face=`.
+
+Design interpretation:
+
+> The spoke clearing is the threshold where a player chooses what kind of game they are playing.
+
+### 3. Nurseries
+
+Each spoke has four activity rooms.
+
+Existing support:
+
+- `wake-up`
+- `clean-up`
+- `grow-up`
+- `show-up`
+
+Each nursery has a `nursery_activity` anchor that can launch a ritual or accept a carried BAR.
+
+Design interpretation:
+
+> The nursery is the mechanic room. It turns Guide intent into a BAR artifact that can be planted into campaign state.
+
+### 4. BAR Carrying And Planting
+
+The world already treats BARs as portable inner-world objects.
+
+Existing support:
+
+- `RoomCanvas` carries selected BAR state across world rooms through `?carrying=`.
+- `FaceNpcModal` can create or select a move BAR and place it into the player's carrying state.
+- `NurseryActivityModal` detects carried BARs and offers to plant them.
+- `plantBarOnSpoke` anchors the BAR into a `SpokeMoveBed`.
+- `plantKernelFromBar` lets later players add supporting kernels to the same bed.
+- `CollaborationBoard` visualizes planted beds across spokes.
+
+Design interpretation:
+
+> Planting is already the world-state write. It is the moment an outer-world allyship object becomes Calrunian campaign progress.
+
+## Revised Core Reuse Pattern
+
+The six Guide campaigns can be built by combining the two loops:
+
+```text
+outer-world problem
+-> captured BAR
+-> Guide face selection
+-> seed/card/manual/cultivation treatment
+-> nursery room, farm plot, ritual, or authored trial
+-> BAR/card transformation
+-> planted garden or spoke evidence
+-> visible campaign and character progress
+-> outer-world move
+```
+
+The game type changes by Guide. The product shell and persistence should stay stable.
+
+## Six Guide Games Inside The Existing Loop
+
+| Guide | Game Type | Prototype Mechanic To Import | bars-engine Host Piece | First Playable Slice |
+|-------|-----------|------------------------------|-----------------------|----------------------|
+| Shaman | Ritual transformation RPG | emotion seed, meditation boost, harvest-as-insight | Emotional Alchemy, `clean-up`, BAR maturity | Charged BAR becomes a planted seed, then a harvested insight card |
+| Challenger | Threshold action RPG | card/manual technique for decisive action | Move Generator, `show-up`, `QuestMoveLog` | A pressure BAR becomes a Challenger card that must be spent on an outer action |
+| Regent | Stewardship and oath RPG | cultivation level, Qi, responsibility stats | Roles, commitments, `HandSlot`, campaign membership | A player takes an oath card/manual and plants it as public stewardship |
+| Architect | Builder / strategy RPG | farm upgrade / plot expansion / growth planning | `CampaignMilestone`, `MilestoneNeed`, `SpokeMoveBed` | A campaign need becomes a growable build plot with contribution kernels |
+| Diplomat | Social alliance RPG | advocate NPCs, visas/citizenship, relationship manuals | invitations, shares, aid offers, membership | An invitation BAR becomes a bridge card that recruits or repairs a relationship |
+| Sage | Oracle / synthesis RPG | manual selection, trigram advocate reading, pattern diagnosis | I Ching, `hexagramId`, `campaignHubState` | A hexagram recommends a Guide face, sect/manual, and next cultivation move |
+
+## Three Production Options
+
+### Option A: Bridge The Prototype As A Separate Play Surface
+
+This is the fastest way to honor the robust prototype without forcing a rewrite.
+
+Keep the Inner Garden canvas game as its own playable artifact, but add a clean bars-engine bridge.
+
+Player experience:
+
+```text
+I capture or choose a BAR in bars-engine.
+I send it into Inner Garden.
+It becomes a seed/card/manual object.
+I play the garden loop.
+I export/return the result into bars-engine.
+```
+
+Pros:
+
+- Respects the prototype as a working game.
+- Lowest disruption to bars-engine.
+- Lets people feel the gardening/cultivation loop quickly.
+- Builds on the existing bridge export idea.
+
+Risks:
+
+- Split experience across surfaces.
+- Auth and persistence remain awkward until an API bridge exists.
+
+### Option B: Import Inner Garden Mechanics Into Pixi Rooms
+
+Use bars-engine Pixi rooms as the host, but implement Inner Garden mechanics as React/Pixi panels and actions.
+
+Examples:
+
+- farm plots become room anchors
+- seeds become `CustomBar` records or child records
+- cards become BAR/manual artifacts
+- cultivation level becomes player progress
+- advocates become world NPC anchors
+
+Pros:
+
+- Unified app experience.
+- Uses bars-engine auth, database, and campaign state.
+- Makes Guide campaigns feel native.
+
+Risks:
+
+- More engineering cost.
+- Requires schema decisions.
+- Could lose the prototype's simple game feel if over-productized.
+
+### Option C: Full Calrunian Cultivation RPG In Bars-Engine
+
+This is the long-term direction: planted BARs visibly repair rooms, alter NPC dialogue, unlock nation rooms, reveal sects, and change campaign weather.
+
+Pros:
+
+- Most magical.
+- Best match for the long-term Calrunian promise.
+
+Risks:
+
+- Highest cost.
+- Easy to overbuild before the core allyship loop is validated.
+
+## Recommended First Slice
+
+Build a thin version of Option A, then migrate toward Option B.
+
+The first slice should prove one sentence:
+
+> A real outer-world allyship problem can enter Inner Garden as a BAR, become a seed/card through play, and return to bars-engine as a usable allyship move or planted campaign artifact.
+
+Minimum viable path:
+
+1. Player selects a BAR in bars-engine.
+2. bars-engine creates an Inner Garden bridge payload.
+3. Inner Garden imports that BAR as a seed or witness card.
+4. Player plants, nurtures, meditates, or harvests it.
+5. Inner Garden exports a result payload.
+6. bars-engine imports that result as a `CustomBar`, `charge_capture`, planted spoke bed, or campaign contribution.
+7. The campaign hub or Garden surface shows visible progress.
+
+This respects the existing prototype and gives bars-engine a clear integration target.
+
+## Guide Mechanics From Existing Pieces
+
+### Shaman
+
+Best existing fit:
+
+- Inner Garden emotion seed and meditation loop
+- `clean-up` nursery
+- Emotional Alchemy
+- 3-2-1 ritual pattern
+- `NurseryRitualFlow`
+- BAR maturity from raw charge to named insight
+
+Mechanic:
+
+> Convert charge into meaning.
+
+The Shaman Guide should be introduced when the player has a BAR with emotional heat, ambiguity, projection, grief, fear, or shadow.
+
+### Challenger
+
+Best existing fit:
+
+- Inner Garden manual/card technique loop
+- `show-up` nursery
+- Move Generator
+- carried BAR
+- `QuestMoveLog`
+- planted action evidence
+
+Mechanic:
+
+> Convert avoidance into a decisive move.
+
+The Challenger Guide should be introduced when the player has named the problem but has not yet acted.
+
+### Regent
+
+Best existing fit:
+
+- cultivation stats, Qi, levels
+- roles and membership
+- commitment BARs
+- `HandSlot` as oath loadout
+- `SpokeMoveBed` as public responsibility
+
+Mechanic:
+
+> Convert willingness into held responsibility.
+
+The Regent Guide should be introduced when a player is ready to own a role, keep a promise, or steward a recurring obligation.
+
+### Architect
+
+Best existing fit:
+
+- farm plots, garden upgrades, growth planning
+- `grow-up` nursery
+- `CampaignMilestone`
+- `MilestoneNeed`
+- `MilestoneContribution`
+- Collaboration Board
+
+Mechanic:
+
+> Convert concern into structure.
+
+The Architect Guide should be introduced when a problem is too large for one move and needs a plan, sequence, or scaffold.
+
+### Diplomat
+
+Best existing fit:
+
+- Calrunia advocate NPC roster
+- wandering cultivators / visa / citizenship design
+- invitation BARs
+- Gameboard Aid Offers
+- shares
+- campaign membership and roles
+- spoke kernels from multiple players
+
+Mechanic:
+
+> Convert isolation into relationship.
+
+The current nursery set does not include an `open-up` room even though the broader WAVE move grammar includes Open Up. For the first slice, Diplomat can use `wake-up`, `grow-up`, and `show-up` as "read the room, build the bridge, send the invitation." A later slice should consider adding an Open Up room or equivalent relationship anchor.
+
+### Sage
+
+Best existing fit:
+
+- cultivation manuals
+- trigram advocate reading
+- I Ching
+- `hexagramId`
+- `campaignHubState.spokes`
+- `getFacesForHexagram`
+- orientation face filtering
+
+Mechanic:
+
+> Convert complexity into pattern.
+
+The Sage Guide should be introduced when the player does not know which Guide or move is appropriate. Sage reads the situation and recommends available faces, sects, or next moves.
+
+## Unlock Logic
+
+The current orientation code already thinks in six independently completable face packets.
+
+Existing support:
+
+- `compileOrientationMetaPacket`
+- `ORIENTATION_SUB_PACKET_FACES`
+- per-face sub-packet status
+- all-six completion state
+
+Production interpretation:
+
+> Orientation packets are the tutorial layer; inner-garden Guide campaigns are the embodied layer.
+
+Possible unlock ladder:
+
+| Completion | Unlock |
+|------------|--------|
+| Complete first Guide orientation | enter that Guide's spoke loop |
+| Plant first Guide BAR | unlock that Guide's basic app surface |
+| Plant all four nursery types for one Guide | unlock Guide campaign completion |
+| Complete multiple Guide campaigns | reveal nation and sect identity |
+| Complete Sage synthesis | unlock I Ching-driven Guide recommendations |
+
+## I Ching As Campaign Weather
+
+The engine already supports a useful bridge between divination and Guide selection:
+
+- `CustomBar.hexagramId` can attach oracle context to player material.
+- `campaignHubState.spokes[].hexagramId` can make a spoke feel divinatorily alive.
+- `getFacesForHexagram` maps hexagram trigrams to available Game Master faces.
+
+This lets the I Ching operationalize allyship without becoming a separate lore page:
+
+```text
+player brings problem
+-> oracle names the pattern
+-> trigrams recommend available Guide faces
+-> Guide turns pattern into a move
+-> BAR plants evidence into the campaign
+```
+
+This is the strongest current route from divinatory power to allyship practice.
+
+## Gaps To Resolve
+
+### 0. Integration Source Of Truth
+
+The current spec must treat `The Library/04 Quests/Campaigns/inner-garden` as a source artifact, not a side note.
+
+Immediate action:
+
+- define what should be ported
+- define what should remain linked/prototyped
+- define what bars-engine owns
+- define what the Library prototype owns
+
+### 1. Guide Campaign Registry
+
+There is no single authored registry that says:
+
+- which Guide owns which game type
+- which nursery types are preferred
+- which app surfaces unlock
+- which antagonist pressure is active
+- which completion condition counts
+
+This can be a lightweight content registry before it is a database model.
+
+### 2. Open Up Has No Nursery
+
+The broader move grammar has Wake, Open, Clean, Grow, Show, but the inner garden currently has only Wake, Clean, Grow, Show.
+
+Decision needed:
+
+- add an Open Up nursery later
+- treat Open Up as a Diplomat-specific modal
+- fold Open Up into Wake/Grow/Show for the first implementation slice
+
+### 3. Guide Completion Is Not Yet World Completion
+
+Orientation can track face packet completion, and planting can track spoke bed progress, but there is not yet a unified "Guide campaign status" that connects:
+
+```text
+orientation completion
+-> inner-garden action
+-> app unlock
+-> outer-world evidence
+```
+
+### 4. Lore Unlocks Need Action Gates
+
+Lore should appear when it solves the player's current problem.
+
+Good gates:
+
+- after a player chooses a Guide
+- after a player plants a BAR
+- after a player gets blocked
+- after a hexagram recommends a face
+- after a campaign spoke shows a specific antagonist pattern
+
+Weak gates:
+
+- showing Calrunia encyclopedia pages before the player has a task
+- explaining nations and sects before the player has felt why identity matters
+
+### 5. Campaign State Needs Better Feedback
+
+The Collaboration Board already shows planted beds, but the player-facing meaning is still early.
+
+Needed:
+
+- "what changed because I planted this?"
+- "what does this unlock?"
+- "who can build on this?"
+- "what outer-world move should happen next?"
+
+### 6. BAR-To-Seed/Card Schema
+
+The prototype has `ig-bar-charge-bridge.v0`, but bars-engine needs an inbound and outbound contract.
+
+Needed:
+
+- bars-engine BAR to Inner Garden seed
+- bars-engine BAR to Inner Garden witness card
+- Inner Garden harvest to bars-engine `CustomBar`
+- Inner Garden spent card to bars-engine move evidence
+- Inner Garden cultivation/manual progress to bars-engine unlock status
+
+### 7. Persistence Strategy
+
+Inner Garden currently uses local save state. bars-engine uses account-backed persistence.
+
+Possible sequence:
+
+1. manual import/export
+2. signed payload handoff
+3. API-backed read/write
+4. native bars-engine persistence
+
+## What To Build Next
+
+The deft next move is not only a Guide Campaign Registry. It is a **BAR-to-Inner-Garden bridge contract** plus one playable Guide slice.
+
+Recommended slice:
+
+> Shaman Guide using the Library Inner Garden prototype loop, bridged back into bars-engine.
+
+Why Shaman first:
+
+- The source prototype already turns emotional input into seeds.
+- Emotional Alchemy already has strong conceptual fit.
+- Clean Up nursery already exists.
+- Players can understand the before/after: charged material becomes usable insight.
+- It naturally introduces nations after the player has experienced emotional terrain.
+
+Alternative strong slice:
+
+> Sage Guide as the Guide selector.
+
+Why Sage first:
+
+- It operationalizes I Ching immediately.
+- It can recommend which of the six games the player should play.
+- It becomes the orientation engine for the whole stack.
+
+Producer choice:
+
+Start with Shaman if the goal is emotional proof.
+Start with Sage if the goal is system coherence.
+
+For putting this in front of people, Shaman is more legible. Sage is more architecturally elegant.
+
+## Evidence From The Codebase And Library
+
+bars-engine files reviewed:
+
+- `src/lib/spatial-world/octagon-campaign-hub.ts`
+- `src/lib/spatial-world/nursery-rooms.ts`
+- `src/app/world/[instanceSlug]/[roomSlug]/RoomCanvas.tsx`
+- `src/components/world/AnchorModal.tsx`
+- `src/components/world/FaceNpcModal.tsx`
+- `src/components/world/NurseryActivityModal.tsx`
+- `src/components/campaign-hub/CollaborationBoard.tsx`
+- `src/actions/nursery-ritual.ts`
+- `src/actions/plant-bar-on-spoke.ts`
+- `src/actions/spoke-move-seeds.ts`
+- `src/lib/quest-grammar/orientationMetaPacket.ts`
+- `src/lib/quest-grammar/iching-faces.ts`
+- `src/lib/quest-grammar/types.ts`
+
+Library Inner Garden files reviewed:
+
+- `The Library/04 Quests/Campaigns/inner-garden/DESIGN.md`
+- `The Library/04 Quests/Campaigns/inner-garden/BARS_ENGINE_INNER_GARDEN_GAP.md`
+- `The Library/04 Quests/Campaigns/inner-garden/GAP_ANALYSIS.md`
+- `The Library/04 Quests/Campaigns/inner-garden/SPEC_DECK_MECHANICS.md`
+- `The Library/04 Quests/Campaigns/inner-garden/js/core/Game.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/systems/FarmingSystem.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/systems/EmotionSystem.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/systems/CultivationSystem.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/systems/DeckSystem.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/systems/QuestSystem.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/data/CalruniaAdvocates.js`
+- `The Library/04 Quests/Campaigns/inner-garden/js/data/BarChargeBridge.js`

--- a/.specify/specs/six-guide-calrunia-orientation/PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md
+++ b/.specify/specs/six-guide-calrunia-orientation/PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md
@@ -1,0 +1,526 @@
+# Pixi World To Inner Garden Bridge Decision
+
+> Companion artifacts:
+> - [INNER_GARDEN_IMPLEMENTATION_RESEARCH.md](./INNER_GARDEN_IMPLEMENTATION_RESEARCH.md) identifies the Library Inner Garden prototype as the richer source design.
+> - [GUIDE_CAMPAIGN_MATRIX.md](./GUIDE_CAMPAIGN_MATRIX.md) defines the six Guide campaigns as game types.
+> - [BARS_CALRUNIA_WORLD_MECHANICS.md](./BARS_CALRUNIA_WORLD_MECHANICS.md) explains BARs as the membrane object between outer-world behavior and inner-world play.
+>
+> This document reframes the current bars-engine Pixi world as a draft/proving ground, not the canonical Calrunia game layer.
+
+## Decision Frame
+
+The Pixi world work should be treated as a **draft integration experiment**:
+
+> How might campaigns, BARs, Guide NPCs, and 2D movement become playable in a sprite world?
+
+The Library Inner Garden prototype should be treated as the **source game design**:
+
+> How does real emotional and allyship material become seeds, cards, cultivation, manuals, advocates, and Calrunian progression?
+
+The product move is therefore not "throw away Pixi" and not "paste Inner Garden into bars-engine."
+
+The move is:
+
+> Deprecate Pixi as the canonical world model, preserve the useful campaign integration lessons, and bridge/migrate toward Inner Garden as the canonical Calrunian play layer.
+
+## What The Pixi Draft Proved
+
+The Pixi work is still valuable because it proved several important integration ideas:
+
+| Pixi Draft Idea | Keep? | Why |
+|-----------------|-------|-----|
+| Campaign world entry route | Yes | Players need a threshold from app utility into play |
+| Campaign hub / spokes | Maybe | Useful metaphor for campaign structure, but may not be the final world map |
+| Guide NPC anchors | Yes | The six faces as game-mode hosts still matter |
+| Nursery rooms | Maybe | Wake/Clean/Grow/Show rooms map well to Inner Garden pillars, but may become farm/ritual areas |
+| Carrying a BAR | Yes | Strong membrane mechanic; should survive |
+| Planting a BAR on a spoke | Yes, revised | Planting should become seed/farm/campaign evidence, not only spoke bed state |
+| Collaboration Board | Yes, revised | Useful campaign feedback surface, but it should explain what grew and what changed |
+| Pixi room engine as canonical world | No / deprecate | Inner Garden has the richer game loop and should become the canonical play layer |
+
+## What Inner Garden Supersedes
+
+The Library Inner Garden prototype supersedes the Pixi draft in these domains:
+
+| Domain | Pixi Draft | Inner Garden Source |
+|--------|------------|--------------------|
+| Player identity | avatar in room | cultivator with stats, Qi, cards, manuals, garden |
+| BAR transformation | carry/plant BAR | BAR -> seed/card -> cultivation artifact |
+| Emotional play | modal ritual | seed quality, meditation, nurture, harvest |
+| Progression | planted spoke beds | cultivation levels, card unlocks, manuals, garden growth |
+| Sects/archetypes | Guide face NPCs | 5 nations x 8 trigram advocates / sect lineages |
+| Game feel | spatial navigation + modals | farming/cultivation/card loop |
+| Return to bars-engine | spoke bed receipt | bridge payload / charge capture / move evidence |
+
+## Deprecation Principle
+
+Do not remove Pixi code just because Inner Garden is stronger.
+
+Deprecate by role:
+
+1. **Freeze** Pixi as a prototype surface unless it is actively needed for a bridge.
+2. **Extract** the useful patterns: BAR carrying, Guide selection, campaign entry, planted evidence.
+3. **Rename** internal docs so Pixi is not described as "the inner garden."
+4. **Bridge** bars-engine to the Library Inner Garden loop.
+5. **Replace** Pixi world entry with Inner Garden entry once the bridge proves value.
+6. **Remove or archive** Pixi routes only after no Guide/campaign flow depends on them.
+
+## Six Game Master Analysis
+
+### Shaman
+
+The Shaman sees the core risk:
+
+> If we keep both systems alive without naming their roles, players and builders will split the soul of the game.
+
+Shaman recommendation:
+
+- Treat Pixi as an old ritual vessel.
+- Preserve what it taught: crossing threshold, carrying charge, planting evidence.
+- Move the emotional transformation center of gravity into Inner Garden's seed, meditation, nurture, and harvest loop.
+
+What to remove:
+
+- Any Pixi language that says "this is the inner garden" if it is only a spatial lobby.
+
+What to preserve:
+
+- The feeling of crossing into a charged inner place.
+
+### Challenger
+
+The Challenger sees the action problem:
+
+> This project needs a decisive cut. Pixi cannot remain half-canonical forever.
+
+Challenger recommendation:
+
+- Mark Pixi world as deprecated/prototype in docs.
+- Stop adding major new Guide campaign features directly to Pixi unless they are bridge work.
+- Build one concrete BAR -> Inner Garden -> bars-engine return loop.
+
+What to remove:
+
+- New feature investment in Pixi-only campaign rooms.
+
+What to preserve:
+
+- The working mechanics that prove BAR carrying and planting can create game-state changes.
+
+### Regent
+
+The Regent sees governance and migration risk:
+
+> Deprecation without stewardship creates orphaned routes, broken expectations, and unclear ownership.
+
+Regent recommendation:
+
+- Define ownership boundaries:
+  - bars-engine owns auth, BARs, campaigns, persistence, unlocks.
+  - Inner Garden owns play loop, cultivation, seeds, cards, manuals.
+  - bridge owns translation contracts.
+- Create a retirement checklist before deleting routes.
+
+What to remove:
+
+- Ambiguous ownership of player progress between localStorage and database.
+
+What to preserve:
+
+- Campaign membership, roles, and contribution accountability in bars-engine.
+
+### Architect
+
+The Architect sees the systems shape:
+
+> Pixi and Inner Garden are not competing engines. They are currently two layers without an interface.
+
+Architect recommendation:
+
+- Build the bridge as a contract first:
+
+```text
+bars-engine CustomBar
+-> Inner Garden seed/card import
+-> Inner Garden play result
+-> bars-engine CustomBar / move evidence / campaign contribution
+```
+
+- Do not start with visual migration. Start with data translation and one playable path.
+
+What to remove:
+
+- Duplicate concepts with no contract: garden, seed, card, planting, progress.
+
+What to preserve:
+
+- Any Pixi schema or code that already models spatial anchors, planted state, or campaign receipts.
+
+### Diplomat
+
+The Diplomat sees the stakeholder and player communication issue:
+
+> If we call this a deprecation, people may hear "lost work." We need to frame it as succession.
+
+Diplomat recommendation:
+
+- Name Pixi as the draft that taught us how campaign play could become spatial.
+- Name Inner Garden as the richer game that now inherits the mission.
+- Communicate the bridge as "bringing the campaign work into the better play loop."
+
+What to remove:
+
+- Competing player-facing entry points that make users wonder which world is real.
+
+What to preserve:
+
+- Any Pixi-facing demos/screenshots that help explain the campaign vision, clearly labeled as prototype.
+
+### Sage
+
+The Sage sees the pattern:
+
+> The Pixi draft solved the portal problem. Inner Garden solves the game problem. The bridge must solve the return problem.
+
+Sage recommendation:
+
+- Use the I Ching/oracle layer to decide when a BAR should become a seed, card, manual lesson, Guide prompt, or campaign contribution.
+- Treat Inner Garden as the inner-world processor.
+- Treat bars-engine as the outer-world accountability and meaning system.
+
+What to remove:
+
+- Lore-only or map-only features that do not transform player behavior.
+
+What to preserve:
+
+- The core triadic movement:
+
+```text
+outer-world material
+-> inner-world cultivation
+-> outer-world move/evidence
+```
+
+## Bridge Model
+
+The bridge should be explicit and boring before it becomes magical.
+
+### Import
+
+```text
+bars-engine CustomBar / charge_capture
+-> bridge payload
+-> Inner Garden seed or witness card
+```
+
+Minimum fields:
+
+- source BAR id
+- player id or anonymous session id
+- title / summary
+- behavior
+- activation
+- result
+- emotion channel
+- intensity
+- campaignRef
+- Guide face, if selected
+- hexagram/trigram context, if present
+
+### Inner Garden Play
+
+```text
+seed/card
+-> plant / nurture / meditate / harvest / spend
+-> cultivation result
+```
+
+Possible outputs:
+
+- harvested insight
+- witness card
+- spent card
+- cultivation XP
+- manual progress
+- Guide completion evidence
+- campaign contribution candidate
+
+### Return
+
+```text
+Inner Garden result
+-> bars-engine import
+-> CustomBar / move evidence / campaign progress / unlock
+```
+
+The return is essential. Without it, Inner Garden becomes a side game. With it, Inner Garden becomes the inner-world processor for allyship practice.
+
+## Interview: What We Need To Decide
+
+### 1. Canonical Experience
+
+When you imagine a player "entering Calrunia" six months from now, what do they see first?
+
+- Inner Garden farm/cultivation screen
+- campaign hub/spoke map
+- Guide selection surface
+- I Ching/oracle prompt
+- something else
+
+### 2. Pixi Fate
+
+Which of these is closest to your intent?
+
+- Pixi is fully retired once Inner Garden is integrated.
+- Pixi remains as a map shell around Inner Garden mechanics.
+- Pixi remains only for campaign hub/prototype demos.
+- Pixi code is archived but its concepts are ported.
+
+### 3. First Bridge Slice
+
+Which first loop would be most valuable to put in front of people?
+
+- Shaman: charged BAR -> seed -> meditation/nurture -> harvested insight
+- Challenger: pressure BAR -> decisive action card -> outer-world evidence
+- Sage: BAR + I Ching -> recommended Guide/sect/manual
+- Architect: campaign need -> growable build plot -> contribution evidence
+
+### 4. Player Identity
+
+Inside Calrunia, is the player primarily:
+
+- a cultivator
+- a campaign ally
+- a Guide apprentice
+- a nation citizen
+- a sect initiate
+- all of these, in a progression order
+
+### 5. Campaign Relationship
+
+Are campaigns supposed to be:
+
+- the reason the player enters Inner Garden
+- one content type inside Inner Garden
+- outer-world containers that Inner Garden helps metabolize
+- the main multiplayer/social layer around individual cultivation
+
+### 6. Deletion Boundaries
+
+What can we safely remove or freeze now?
+
+- Pixi route development
+- nursery room expansion
+- spoke bed UI work
+- face NPC trial work
+- campaign hub world map work
+- none yet, only relabel
+
+### 7. Demo Goal
+
+For the people you want to put this in front of, what problem should the demo solve?
+
+- "I have emotional charge and need to transform it."
+- "I am stuck and need a concrete allyship move."
+- "I need to understand my role in a campaign."
+- "I need a playful way to keep practicing."
+- "I need to see that this is more than lore."
+
+## Proposed Near-Term Decision
+
+Interview update:
+
+1. There are **two games** in the product hierarchy:
+   - a card-based campaign management game that deposits players into a village/lobby of available campaigns
+   - Inner Garden as the immersive story/cultivation game that teaches Mastering Allyship mechanics
+2. Campaigns appear in Inner Garden later. Players first learn cultivation, emotional practice, cards, and allyship mechanics.
+3. Pixi should be fully retired after its useful concepts are ported.
+4. The first bridge loop should be Shaman, because Inner Garden already has an MVP version of this loop.
+5. The Shaman loop must speak to the player's bars-engine Hand and Vault.
+6. Campaigns are one reason to enter Inner Garden, not the only reason.
+7. The routes may remain, but the Pixi runtime does not need to remain.
+8. The artifact must solve a practical user problem: provide a quick, fun, immersive way to teach increasingly complex Mastering Allyship concepts and practices.
+
+Updated decision:
+
+1. Mark Pixi world as **prototype / draft spatial campaign layer**.
+2. Stop expanding Pixi runtime.
+3. Keep routes where they still function as product thresholds, but replace their runtime target over time.
+4. Preserve BAR carrying, Guide selection, planting, campaign lobby, campaign-state receipt, and village/lobby concepts.
+5. Define a bridge contract from bars-engine Hand/Vault BARs to Inner Garden seeds/cards.
+6. Build the Shaman bridge slice first: Hand/Vault BAR -> Inner Garden seed/card -> Shaman cultivation loop -> returned insight/evidence BAR.
+
+## Two-Game Hierarchy
+
+The emerging product hierarchy is:
+
+```text
+bars-engine outer utility
+-> card-based campaign management game
+-> village / campaign lobby
+-> Inner Garden immersive cultivation game
+-> later campaign re-entry as advanced play
+```
+
+### Game 1: Card-Based Campaign Management
+
+This game is closer to a campaign operations layer.
+
+Its job:
+
+- show available campaigns
+- organize players, offers, needs, roles, and moves
+- manage cards/BARs as campaign objects
+- provide the village/lobby threshold
+- connect outer-world action to game-state accountability
+
+This is where campaigns are legible early.
+
+### Game 2: Inner Garden
+
+This game is the immersive curriculum layer.
+
+Its job:
+
+- teach Mastering Allyship through play
+- turn BARs into seeds/cards/cultivation artifacts
+- make emotional alchemy embodied and fun
+- introduce nations, sects, advocates, manuals, and practices over time
+- make increasingly complex concepts learnable without lore homework
+
+This is where campaigns emerge later, after the player has learned the inner cultivation game.
+
+### Hierarchy Rule
+
+Campaign management can send material into Inner Garden, but Inner Garden should not assume the player already understands campaigns.
+
+```text
+campaign mode may be an entry point
+but cultivation is the onboarding spine
+```
+
+## Routes Without Pixi Runtime
+
+The current route work may still be valuable even if the Pixi runtime is retired.
+
+Keep:
+
+- route names that define player thresholds
+- campaign/world entry URLs if they already have product meaning
+- server-side campaign context loading
+- auth, membership, and campaignRef resolution
+- return paths from game mode back to bars-engine
+
+Retire:
+
+- Pixi room rendering as the canonical experience
+- Pixi-specific room expansion
+- new Pixi-only nursery features
+- Pixi-only campaign hub map work
+
+Port concepts:
+
+- Guide selection
+- carrying from Hand/Vault
+- planting as campaign/cultivation evidence
+- village/lobby as campaign threshold
+- spoke/hub as possible campaign organization metaphor
+
+## Six Faces On The Updated Hierarchy
+
+### Shaman
+
+Shaman says:
+
+> Inner Garden should be the first true descent. The player should feel a BAR become living material.
+
+Implication:
+
+- The first playable bridge should use existing Shaman/Inner Garden MVP mechanics.
+- Hand/Vault must feed the ritual.
+- Returned output should be a transformed BAR, not merely a local game reward.
+
+### Challenger
+
+Challenger says:
+
+> Retire the runtime. Do not keep feeding a draft.
+
+Implication:
+
+- Freeze Pixi runtime development now.
+- Make a clear cut: routes can stay, Pixi rendering should not receive new campaign feature investment.
+- The next visible proof should be playable Inner Garden, not another map room.
+
+### Regent
+
+Regent says:
+
+> Keep the routes until their responsibilities have heirs.
+
+Implication:
+
+- Routes should be evaluated by role, not deleted wholesale.
+- If a route owns auth, campaign context, or return flow, keep it and change its target.
+- If a route only exists to render Pixi rooms, mark it for retirement.
+
+### Architect
+
+Architect says:
+
+> Define the interface before moving the building.
+
+Implication:
+
+- Build the bridge contract first:
+
+```text
+Hand/Vault BAR
+-> Inner Garden import
+-> Shaman seed/card loop
+-> Inner Garden result
+-> bars-engine BAR/move evidence
+```
+
+- After that, decide whether Inner Garden is embedded, linked, or ported module by module.
+
+### Diplomat
+
+Diplomat says:
+
+> The player must not see two Calrunias.
+
+Implication:
+
+- The campaign game and Inner Garden need clear names and roles.
+- "Village" can be the social/campaign threshold.
+- "Inner Garden" can be the personal cultivation story.
+- Campaigns entering Inner Garden later should feel like maturation, not mode confusion.
+
+### Sage
+
+Sage says:
+
+> Campaigns are not the root. Practice is the root. Campaigns are one application of cultivated capacity.
+
+Implication:
+
+- Inner Garden should be able to stand alone as a fun game.
+- Its hidden curriculum is Mastering Allyship.
+- Campaign management should become more powerful after cultivation, not be required as the player's first context.
+
+## Updated Removal Map
+
+| Surface / Concept | Recommendation | Reason |
+|-------------------|----------------|--------|
+| Pixi runtime | Retire after concept porting | Superseded by Inner Garden as canonical play layer |
+| Pixi routes | Keep temporarily | They may still own useful thresholds, campaign context, and return paths |
+| `/world/...` route semantics | Reassess | May become village/campaign lobby or redirect to Inner Garden entry |
+| Nursery expansion in Pixi | Freeze | Inner Garden already has stronger cultivation mechanics |
+| Spoke beds | Preserve concept, revise implementation | Planting evidence still matters, but should connect to seeds/cards/cultivation |
+| Face NPCs | Preserve concept | Six faces are still game-mode/curriculum guides |
+| Campaign hub map | Port concept selectively | Campaign lobby/village may not need spatial Pixi |
+| Hand/Vault | Preserve and prioritize | First Shaman loop depends on it |
+| Inner Garden local-only save | Bridge then migrate | Useful prototype, but bars-engine needs player-linked continuity |
+

--- a/.specify/specs/six-guide-calrunia-orientation/plan.md
+++ b/.specify/specs/six-guide-calrunia-orientation/plan.md
@@ -1,0 +1,200 @@
+# Plan: Six Guide Campaigns — Calrunia Orientation and Unlock Ladder
+
+## Objective
+
+Create the canonical product architecture for orienting Mastering Allyship players into Calrunia through six Game Master Guide campaigns and progressive app unlocks.
+
+This plan is intentionally documentation-first. The next implementation should follow after the orientation model, guide outlines, and unlock taxonomy are stable.
+
+## Phase 1 — Orientation Authority
+
+Define the orientation ladder and the reason Calrunia appears.
+
+Artifacts:
+
+- `spec.md`
+- `GUIDE_CAMPAIGN_MATRIX.md`
+- `PORTAL_EVENTS_AND_UNLOCKS.md`
+
+Key decisions:
+
+- BARs remain outer-world utility.
+- Superpowers are first identity layer.
+- Game Master faces are game modes.
+- Emotional Alchemy opens the nation layer.
+- Sects follow nations as disciplines.
+- I Ching bridges outer-world artifact, inner-world narrative data, and outer-world move.
+
+## Phase 2 — Six Guide Campaign Outlines
+
+Create one outline per Guide:
+
+- Shaman
+- Challenger
+- Regent
+- Architect
+- Diplomat
+- Sage
+
+Each outline should include:
+
+- campaign promise
+- player need prompt
+- lessons
+- core loop
+- unlocks
+- first 3-5 quests
+- lore pages introduced
+- success / completion state
+
+Candidate files:
+
+```text
+.specify/specs/six-guide-calrunia-orientation/guides/shaman.md
+.specify/specs/six-guide-calrunia-orientation/guides/challenger.md
+.specify/specs/six-guide-calrunia-orientation/guides/regent.md
+.specify/specs/six-guide-calrunia-orientation/guides/architect.md
+.specify/specs/six-guide-calrunia-orientation/guides/diplomat.md
+.specify/specs/six-guide-calrunia-orientation/guides/sage.md
+```
+
+## Phase 3 — Unlock Taxonomy
+
+Define unlock types and initial candidates.
+
+Unlock classes:
+
+- app surface
+- lore page
+- move-generator mode
+- campaign route
+- oracle/interpreter
+- identity/title
+- role/campaign responsibility
+
+Needed decisions:
+
+- Which capabilities are hidden by default?
+- Which capabilities are visible but locked?
+- Which capabilities are simply "introduced" through Guide completion?
+- Which unlocks require persistence?
+
+## Phase 4 — Runtime Model Draft
+
+Before implementation, design minimal types:
+
+```ts
+type GuideFace = 'shaman' | 'challenger' | 'regent' | 'architect' | 'diplomat' | 'sage'
+type GuideStatus = 'locked' | 'available' | 'active' | 'completed'
+type UnlockKind = 'app_surface' | 'lore_page' | 'campaign_route' | 'oracle' | 'identity' | 'role'
+type PortalEventKind =
+  | 'first_bar'
+  | 'first_move_generated'
+  | 'move_resistance_named'
+  | 'superpower_revealed'
+  | 'emotional_alchemy_completed'
+  | 'nation_revealed'
+  | 'sect_pattern_detected'
+  | 'iching_cast_completed'
+  | 'campaign_impact_returned'
+```
+
+Implementation should prefer authored data first, then persistence.
+
+## Phase 5 — First Slice Recommendation
+
+The first implementation slice should not build all six campaigns.
+
+Recommended first slice:
+
+1. Add a Guide selection/orientation document or simple UI surface.
+2. Define the six Guide cards with player need prompts.
+3. Add one unlock path for the Shaman or Sage Guide.
+4. Connect completion to one meaningful existing surface:
+   - Shaman -> Emotional Alchemy / 3-2-1
+   - Sage -> I Ching / oracle candidate
+
+Why:
+
+- Shaman validates the charge-to-nation path.
+- Sage validates the I Ching-to-sect path.
+- Both directly support the current design pain point.
+
+## File Impacts
+
+Documentation:
+
+- `.specify/specs/six-guide-calrunia-orientation/spec.md`
+- `.specify/specs/six-guide-calrunia-orientation/plan.md`
+- `.specify/specs/six-guide-calrunia-orientation/tasks.md`
+- future guide outline docs under `guides/`
+- possible architecture docs under `docs/architecture/`
+
+Potential runtime later:
+
+- `src/lib/guides/`
+- `src/lib/guides/types.ts`
+- `src/lib/guides/registry.ts`
+- `src/app/mastering-allyship/guides/page.tsx`
+- `src/app/mastering-allyship/guides/[face]/page.tsx`
+- player/profile persistence for guide completion
+
+## Risks
+
+- Too much lore too early.
+- Unlocks feeling like artificial restriction instead of curriculum.
+- Confusing superpower, nation, sect, and face as competing identities.
+- Treating I Ching as flavor instead of recommendation logic.
+- Building a new Calrunia surface before the existing Move Generator and campaign flows are used as orientation portals.
+
+## Verification
+
+Early verification is design review, not tests:
+
+- Can a new player explain what a BAR is before hearing about Calrunia?
+- Can a player choose a Guide based on need?
+- Can each Guide unlock be justified as "you learned the practice needed for this"?
+- Can the I Ching path produce a concrete outer-world move?
+- Can the team say which layer a feature belongs to?
+
+## Phase 6 — Inner Garden Shaman Bridge Implementation
+
+This phase makes the first executable bridge from bars-engine into Inner Garden while retiring Pixi as the canonical Calrunian runtime.
+
+Implementation decisions:
+
+- Use this spec kit as the authority for v1.
+- V1 is Shaman only.
+- V1 accepts only raw personal capture material:
+  - `CustomBar.type` is `bar` or `charge_capture`
+  - current player is the creator
+  - `status` is `active`
+  - `archivedAt` is null
+  - `isSystem` is false
+  - `inviteId` and `mergedIntoId` are null
+  - effective maturity is `captured`
+- V1 stores completion as a new `CustomBar`; no new tables.
+- Inner Garden result BARs set:
+  - `sourceBarId` to the source BAR
+  - `gameMasterFace` to `shaman`
+  - `questSource` to `inner_garden_shaman`
+  - Shaman run details in `agentMetadata`
+  - post-Shaman maturity in `seedMetabolization`
+- Pixi `/world/:instanceSlug/:roomSlug` route remains but redirects to `/inner-garden` unless `ENABLE_PIXI_WORLD_PROTOTYPE` is enabled.
+
+Runtime files:
+
+```text
+src/lib/inner-garden/bridge.ts
+src/actions/inner-garden.ts
+src/app/inner-garden/page.tsx
+src/app/inner-garden/shaman/page.tsx
+src/app/world/[instanceSlug]/[roomSlug]/page.tsx
+```
+
+Acceptance criteria:
+
+- A player can choose a raw Hand/Vault capture BAR from `/inner-garden`.
+- `/inner-garden/shaman?barId=...` rejects ineligible BARs.
+- Completing the Shaman form creates a new Vault BAR linked to the source.
+- Normal Pixi world traffic redirects to Inner Garden unless the prototype flag is enabled.

--- a/.specify/specs/six-guide-calrunia-orientation/spec.md
+++ b/.specify/specs/six-guide-calrunia-orientation/spec.md
@@ -1,0 +1,416 @@
+# Spec: Six Guide Campaigns — Calrunia Orientation and Unlock Ladder
+
+## Purpose
+
+Define how Mastering the Game of Allyship players are oriented from outer-world utility into Calrunia, and how the six Game Master faces become playable guide campaigns that teach the essentials of allyship at different modes of play.
+
+This spec captures a long-running design pain point:
+
+> bars-engine has BARs, moves, superpowers, emotional alchemy, nations, sects, I Ching/trigrams, and Calrunian lore, but it does not yet have a canonical orientation path that tells a player when they are crossing from real-world work into the shared imagined world, who they are inside that world, and what new app capabilities unlock as they learn.
+
+The answer proposed here:
+
+> Players do not get oriented by reading lore. They get oriented by completing one or more Game Master Guide campaigns.
+
+Each Guide is simultaneously:
+
+- an onboarding campaign
+- a mode of play
+- a lore doorway
+- a curriculum for an allyship skill level
+- an unlock path for app capabilities that would otherwise be hidden
+
+## Core Problem
+
+The app currently has multiple partial portals into deeper play:
+
+- BAR capture: outer-world notebook / productivity / meaning capture
+- Move Generator: turning carried material into action
+- Superpowers: identity and contribution lens
+- Emotional Alchemy: charge, shadow, and transformation
+- Nations: emotional terrain as world geography
+- Sects: disciplined action lineages
+- I Ching: outer-world artifact with inner-world oracle power
+- Calrunia: shared mythic world where external problems become narrative data
+
+The missing design object is the **orientation threshold**:
+
+```text
+When does the player cross from "I am using a helpful app"
+into "I am playing a game in Calrunia"?
+```
+
+Without a clear threshold, lore arrives either too early as homework or too late as disconnected flavor.
+
+## Product Thesis
+
+Calrunia should appear when ordinary productivity stops being enough.
+
+The player starts in outer-world utility. As their BARs become charged, blocked, relational, strategic, symbolic, or campaign-shaped, the app introduces deeper layers of the world.
+
+```text
+BARs
+-> Moves
+-> Superpowers
+-> Emotional Alchemy
+-> Nations
+-> Sects
+-> I Ching / Oracle
+-> Calrunia as campaign world
+```
+
+The Game Master faces are the mode-of-play layer:
+
+```text
+What kind of game am I playing inside Calrunia right now?
+```
+
+## Design Decisions
+
+| Topic | Decision |
+|-------|----------|
+| Faces are game modes | The six Game Master faces are not only voices or NPC styles. They are the types of games a player can play in Calrunia. |
+| Guide campaigns are the main orientation unit | Each face gets a Guide campaign: "The Shaman's Guide to Mastering Allyship", "The Challenger's Guide...", etc. |
+| Unlocks are curriculum gates | Hidden app features unlock when the player has learned the practice needed to use them. Complexity is earned through play. |
+| Calrunia is revealed progressively | Do not open with full world lore. Reveal Calrunia when a player's outer-world problem needs inner-world meaning to become right action. |
+| Lore pages are support artifacts | Lore pages are appropriate once attached to a Guide, unlock, quest, or role. They should answer "what did I just encounter and how do I practice it?" |
+| Sects follow nations | Nations emerge when emotional charge needs terrain. Sects emerge when recurring or oracle-shaped situations need disciplined action. |
+| I Ching is a bridge artifact | The I Ching belongs to both worlds: an outer-world artifact with inner-world oracle applications and outer-world action consequences. |
+
+## Orientation Stack
+
+| Layer | Player Question | System Meaning | Lore Depth |
+|-------|-----------------|----------------|------------|
+| BARs | What am I carrying? | Capture, notebook, productivity, meaning object | No lore required |
+| Moves | What should I do with this? | Turn material into action | Light practice language |
+| Superpowers | How do I tend to help? | Contribution identity / translation lens | Outer-world legible identity |
+| Game Master Face | What kind of game am I playing? | Mode of play / guide / curriculum | First Calrunian guide presence |
+| Emotional Alchemy | Why is this charged or blocked? | Charge becomes game material | Magical threshold |
+| Nations | What terrain am I in? | Emotion becomes landscape/culture | World geography appears |
+| Sects | What discipline does the situation ask for? | Trigram/archetype lineage of action | Practice lineage appears |
+| I Ching / Oracle | What is the pattern of the moment? | Divination routes ambiguity into disciplined moves | Mythic/systemic bridge |
+| Calrunia Campaign | How does this real work become playable? | External problems become narrative data | Full shared world |
+
+## The Six Guide Campaigns
+
+### The Shaman's Guide to Mastering Allyship
+
+**Mode of play**: ritual, shadow, symbolic transformation.
+
+**Teaches**:
+
+- emotional alchemy
+- 3-2-1 shadow work
+- listening to charge as signal
+- moving from feeling to meaning
+
+**Player learns**:
+
+> My feelings are not obstacles. They are game material.
+
+**Unlocks**:
+
+- Emotional Alchemy
+- 3-2-1 rituals
+- deeper charge interpretation
+- first nation reveal when emotional terrain stabilizes
+- Shaman-flavored Calrunian lore pages
+
+### The Challenger's Guide to Mastering Allyship
+
+**Mode of play**: courage, confrontation, decisive action.
+
+**Teaches**:
+
+- direct action
+- courage under friction
+- breaking avoidance
+- turning insight into observable moves
+
+**Player learns**:
+
+> Allyship requires moves, not just insight.
+
+**Unlocks**:
+
+- pressure/deadline modes in Move Generator
+- direct action quests
+- decisive commitment BARs
+- Breakpoint / Decisive Storm content when appropriate
+
+### The Regent's Guide to Mastering Allyship
+
+**Mode of play**: stewardship, duty, authority, governance.
+
+**Teaches**:
+
+- holding commitments
+- stewarding shared resources
+- honoring agreements
+- role clarity
+
+**Player learns**:
+
+> Power is held through care, duty, and follow-through.
+
+**Unlocks**:
+
+- campaign roles
+- oath/commitment BARs
+- stewardship dashboards
+- recurring responsibilities
+- governance/council lore
+
+### The Architect's Guide to Mastering Allyship
+
+**Mode of play**: systems, plans, structures, organizing.
+
+**Teaches**:
+
+- skillful organizing
+- system design
+- milestone decomposition
+- turning overwhelm into structure
+
+**Player learns**:
+
+> Good intentions need structures that can carry them.
+
+**Unlocks**:
+
+- campaign planning tools
+- milestone needs
+- system maps / blueprints
+- skillful organizing quests
+- Architect-flavored build lore
+
+### The Diplomat's Guide to Mastering Allyship
+
+**Mode of play**: relationship, invitation, coalition, repair.
+
+**Teaches**:
+
+- invitations
+- conflict translation
+- repair
+- coalition-building
+- helping a move land in relationship
+
+**Player learns**:
+
+> The move has to land in relationship.
+
+**Unlocks**:
+
+- invitation tools
+- ally maps
+- repair quests
+- coalition surfaces
+- bridge/council lore
+
+### The Sage's Guide to Mastering Allyship
+
+**Mode of play**: pattern recognition, synthesis, timing, wisdom.
+
+**Teaches**:
+
+- reading the moment
+- strategic reflection
+- extracting doctrine from experience
+- I Ching / trigram pattern interpretation
+
+**Player learns**:
+
+> The moment has a pattern; right action follows from reading it clearly.
+
+**Unlocks**:
+
+- I Ching oracle
+- sect interpretation
+- strategic review
+- doctrine / lesson extraction from completed moves
+- Sage-flavored oracle lore
+
+## Guide Selection
+
+The first Guide should be selected through player need, not taxonomy.
+
+Example prompt:
+
+> What kind of help do you need right now?
+
+| Player Need | Guide |
+|-------------|-------|
+| I need to understand what I am feeling | Shaman |
+| I need to stop avoiding action | Challenger |
+| I need to hold responsibility well | Regent |
+| I need to build a plan | Architect |
+| I need to navigate people | Diplomat |
+| I need to read the pattern | Sage |
+
+## Portal Events
+
+A **Portal Event** is any moment where the app has enough signal to invite the player deeper.
+
+Candidate Portal Events:
+
+- first BAR captured
+- first move generated
+- first move resisted or left incomplete
+- first emotional alchemy result
+- repeated move patterns
+- campaign contribution need selected
+- outer-world problem submitted for interpretation
+- I Ching cast completed
+
+The app should not treat all Portal Events equally. Each event can unlock a different depth.
+
+| Portal Event | Likely Unlock |
+|--------------|---------------|
+| First BAR | BARs as notebook / meaning capture |
+| First move generated | Guide campaign invitation |
+| Move resistance named | Shaman / Challenger route |
+| Superpower revealed | superpower identity and contribution lens |
+| Emotional charge metabolized | nation reveal |
+| Repeated move discipline | sect invitation |
+| I Ching cast completed | oracle interpretation / sect-of-the-moment |
+| Campaign impact returned | Calrunia campaign identity |
+
+## Character Identity Model
+
+The app eventually needs a player-facing identity container that can answer:
+
+> Who am I between worlds?
+
+Candidate identity fields:
+
+- outer-world name / player profile
+- active campaign or cause
+- BARs carried
+- superpower
+- active Guide campaign
+- completed Guide campaigns
+- current GM face affinity
+- nation affiliation
+- sect apprenticeship or situational sect
+- current I Ching reading
+- completed moves / returned impact
+
+This does not require a full character sheet in the first slice, but the orientation system should be designed so these fields have a future home.
+
+## User Stories
+
+### P1: I know why lore is appearing
+
+**As a player**, I want Calrunian lore to appear only when it helps me understand or act on something I am carrying, so it feels useful rather than like homework.
+
+**Acceptance**: Guide/lore surfaces are introduced through a Portal Event or unlock, not as an unrelated reading assignment.
+
+### P2: I can choose the kind of game I need
+
+**As a player**, I want to choose a Guide based on the help I need, so I can enter the right mode of allyship practice.
+
+**Acceptance**: Guide selection uses player-facing need statements, not only face names.
+
+### P3: Completing a Guide unlocks meaningful capability
+
+**As a player**, I want Guide completion to unlock app capabilities that match what I learned, so complexity feels earned.
+
+**Acceptance**: Each Guide maps to at least one hidden/locked app capability and one lore doorway.
+
+### P4: The I Ching makes the world actionable
+
+**As a player**, I want an I Ching reading to help translate my real-world problem into a disciplined move, so divination leads to changed action.
+
+**Acceptance**: I Ching output can identify visible/hidden forces, relevant sect discipline, and one outer-world move.
+
+## Functional Requirements
+
+### FR1: Define the orientation ladder
+
+Create canonical docs/data describing the layered progression:
+
+```text
+BARs -> Moves -> Superpowers -> GM Guides -> Emotional Alchemy -> Nations -> Sects -> I Ching -> Calrunia
+```
+
+### FR2: Define the six Guide campaigns
+
+Each Guide must define:
+
+- face
+- mode of play
+- player need prompt
+- core lessons
+- starter campaign outline
+- unlocks
+- lore doorway
+- success criteria
+
+### FR3: Define unlock taxonomy
+
+Create an authored unlock taxonomy with at least:
+
+- app surface unlock
+- lore page unlock
+- campaign route unlock
+- oracle/interpretation unlock
+- role/identity unlock
+
+### FR4: Define Portal Events
+
+Create a deterministic set of Portal Event types and rules for which event can invite which Guide or layer.
+
+### FR5: Connect I Ching to orientation
+
+Document how I Ching cast/trigram data can:
+
+- identify sect-of-the-moment
+- recommend a guide mode
+- shape Move Generator candidates
+- open Sage and sect lore progressively
+
+### FR6: Preserve outer-world utility
+
+BAR capture and basic productivity must remain usable without Calrunian lore.
+
+### FR7: Support progressive disclosure
+
+No first-run experience should require players to understand nations, sects, hexagrams, or full Calrunian history before creating value.
+
+## Non-Goals
+
+- Implement the Guide campaign UI in this spec.
+- Build full character sheet persistence immediately.
+- Make all Calrunian lore public at first launch.
+- Force every player into a sect on day one.
+- Replace existing BAR/productivity value with lore.
+
+## Success Criteria
+
+- The team can explain when Calrunia appears in one sentence.
+- Each Game Master face has a clear campaign/game-mode purpose.
+- Each Guide has a matching unlock path.
+- Lore depth is tied to player action and app capability.
+- Sects become legible as disciplines after nations/emotional terrain are established.
+- The I Ching has a clear role as a bridge artifact between outer-world problem, inner-world narrative data, and outer-world move.
+
+## Open Questions
+
+1. Should a player choose their first Guide, or should the app recommend one based on their first BAR / superpower / move resistance?
+2. Are Guides linear campaigns, repeatable trainings, or both?
+3. Does completing one Guide unlock Calrunia globally, or only unlock that face's doorway?
+4. Should nation reveal require Shaman/emotional alchemy completion, or can other Guides reveal nations through their own route?
+5. Is sect identity always situational at first, or can certain Guide completions grant early apprenticeship?
+6. Where does the future "between worlds" character identity live in the app: profile, vault, campaign hub, or a new passport/sigil surface?
+
+## References
+
+- `.specify/specs/inner-outer-allyship-moves/spec.md`
+- `.specify/specs/mobility-quest-superpower-campaign/spec.md`
+- `.specify/specs/trigram-archetype-gap-resolution/`
+- `docs/architecture/ALLYSHIP_MOVE_TRANSLATOR_ICHING_GAP_ANALYSIS.md`
+- `docs/architecture/CALRUNIA_SECTS_AND_LINEAGES.md`
+- `src/components/bars/MoveGenerator.tsx`
+- `src/lib/superpowers/translate.ts`
+- `src/lib/superpowers/matrix.ts`

--- a/.specify/specs/six-guide-calrunia-orientation/tasks.md
+++ b/.specify/specs/six-guide-calrunia-orientation/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Six Guide Campaigns — Calrunia Orientation and Unlock Ladder
+
+## Spec Kit
+
+- [x] T1: Create `spec.md` capturing the orientation problem, six Guide campaigns, unlock ladder, and Calrunia portal logic.
+- [x] T2: Create `plan.md` with phased documentation-first implementation strategy.
+- [x] T3: Create `tasks.md` as the working checklist.
+
+## Design Authority Artifacts
+
+- [x] T4: Create `GUIDE_CAMPAIGN_MATRIX.md` summarizing all six Guides in one table.
+- [ ] T5: Create `PORTAL_EVENTS_AND_UNLOCKS.md` defining Portal Events, unlock types, and initial unlock rules.
+- [ ] T6: Create `CHARACTER_IDENTITY_BETWEEN_WORLDS.md` sketching the future player identity/passport model.
+- [x] T6A: Create `CALRUNIAN_OPPOSITION_MATRIX.md` grounding Guide campaign antagonists in existing Calrunia lore and world logic.
+- [x] T6B: Create `BARS_CALRUNIA_WORLD_MECHANICS.md` exploring how BARs move between outer-world behavior and inner-world Calrunian play, with mechanics options rooted in existing bars-engine systems.
+- [x] T6C: Create `INNER_GARDEN_IMPLEMENTATION_RESEARCH.md` mapping the six Guide game types onto the inner-garden room, Guide NPC, nursery, BAR planting, and campaign hub structures already in bars-engine.
+- [x] T6D: Update `INNER_GARDEN_IMPLEMENTATION_RESEARCH.md` to incorporate the separate Library inner-garden prototype as the richer source design for farming, cultivation, deck/manual, BAR-to-card, and advocate systems not yet fully integrated into bars-engine.
+- [x] T6E: Create `PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md` with six Game Master analysis, deprecation/integration framing, bridge model, and user interview questions.
+- [x] T6F: Update `PIXI_TO_INNER_GARDEN_BRIDGE_DECISION.md` with interview findings: two-game hierarchy, full Pixi runtime retirement after concept porting, Shaman/Hand/Vault first loop, and routes-without-Pixi guidance.
+
+## Six Guide Outlines
+
+- [ ] T7: Create `guides/shaman.md` with promise, lessons, quests, unlocks, and lore doorway.
+- [ ] T8: Create `guides/challenger.md` with promise, lessons, quests, unlocks, and lore doorway.
+- [ ] T9: Create `guides/regent.md` with promise, lessons, quests, unlocks, and lore doorway.
+- [ ] T10: Create `guides/architect.md` with promise, lessons, quests, unlocks, and lore doorway.
+- [ ] T11: Create `guides/diplomat.md` with promise, lessons, quests, unlocks, and lore doorway.
+- [ ] T12: Create `guides/sage.md` with promise, lessons, quests, unlocks, and lore doorway.
+
+## Product Integration Review
+
+- [ ] T13: Audit existing app surfaces and map each to an orientation layer: BARs, Move Generator, Superpower, Emotional Alchemy, Nations, Sects, I Ching, Calrunia.
+- [ ] T14: Identify which existing surfaces should be hidden, visible-but-locked, or always available.
+- [ ] T15: Decide first implementation slice: Shaman Guide, Sage Guide, or six-card Guide selection only.
+
+## Runtime Design Prep
+
+- [ ] T16: Draft `GuideFace`, `GuideStatus`, `UnlockKind`, and `PortalEventKind` type contracts.
+- [ ] T17: Draft an authored Guide registry shape.
+- [ ] T18: Draft a migration/persistence strategy for Guide progress only if needed by the first implementation slice.
+
+## Inner Garden Shaman Bridge Implementation
+
+- [x] T23: Add implementation phase to `plan.md` for the Inner Garden Shaman bridge.
+- [x] T24: Add pure bridge schema and eligibility helpers for `bars-inner-garden.v1` and `inner-garden-bars.v1`.
+- [x] T25: Add server actions to list eligible raw Hand/Vault capture BARs, build import payloads, and complete Shaman runs.
+- [x] T26: Add authenticated `/inner-garden` entry route listing eligible raw BARs.
+- [x] T27: Add `/inner-garden/shaman?barId=...` route for the first Shaman cultivation loop.
+- [x] T28: Deprecate normal Pixi `/world/:instanceSlug/:roomSlug` runtime via redirect unless the prototype flag is enabled.
+- [x] T29: Add and run eligibility/bridge tests.
+
+## Acceptance Review
+
+- [ ] T19: Confirm the team can state the Calrunia portal rule in one sentence.
+- [ ] T20: Confirm each Guide has a player need prompt, not only a face name.
+- [ ] T21: Confirm each Guide unlock maps to a practice the player has learned.
+- [ ] T22: Confirm lore pages are attached to actions, unlocks, or Guide progress.

--- a/src/actions/inner-garden.ts
+++ b/src/actions/inner-garden.ts
@@ -1,0 +1,201 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { getCurrentPlayer } from '@/lib/auth'
+import { dbBase } from '@/lib/db'
+import { readHandDb } from '@/lib/hand-service'
+import {
+  INNER_GARDEN_SHAMAN_SOURCE,
+  buildBarsInnerGardenImportPayload,
+  buildShamanResultSeedMetabolization,
+  getInnerGardenEligibilityReason,
+  normalizeSeedQuality,
+  toInnerGardenEligibleBar,
+  type BarsInnerGardenImportPayload,
+  type InnerGardenBarCandidate,
+  type InnerGardenEligibleBar,
+} from '@/lib/inner-garden/bridge'
+
+type ErrorResult = { error: string }
+
+const BAR_SELECT = {
+  id: true,
+  title: true,
+  description: true,
+  type: true,
+  creatorId: true,
+  status: true,
+  archivedAt: true,
+  seedMetabolization: true,
+  nation: true,
+  intensity: true,
+  campaignRef: true,
+  gameMasterFace: true,
+  hexagramId: true,
+  isSystem: true,
+  inviteId: true,
+  mergedIntoId: true,
+} as const
+
+function asCandidate(bar: Awaited<ReturnType<typeof findCandidateBar>>): InnerGardenBarCandidate | null {
+  if (!bar) return null
+  return bar
+}
+
+async function findCandidateBar(barId: string) {
+  return dbBase.customBar.findUnique({
+    where: { id: barId },
+    select: BAR_SELECT,
+  })
+}
+
+export async function listInnerGardenEligibleBars(): Promise<
+  | { hand: InnerGardenEligibleBar[]; vault: InnerGardenEligibleBar[] }
+  | ErrorResult
+> {
+  const player = await getCurrentPlayer()
+  if (!player) return { error: 'Not authenticated' }
+
+  const [hand, bars] = await Promise.all([
+    readHandDb(player.id),
+    dbBase.customBar.findMany({
+      where: {
+        creatorId: player.id,
+        type: { in: ['bar', 'charge_capture'] },
+        status: 'active',
+        archivedAt: null,
+        isSystem: false,
+        inviteId: null,
+        mergedIntoId: null,
+      },
+      orderBy: { createdAt: 'desc' },
+      select: BAR_SELECT,
+    }),
+  ])
+
+  const byId = new Map(bars.map((bar) => [bar.id, bar]))
+  const used = new Set<string>()
+  const handBars: InnerGardenEligibleBar[] = []
+
+  for (const slot of hand.slots) {
+    if (!slot.barId) continue
+    const bar = byId.get(slot.barId)
+    if (!bar) continue
+    if (getInnerGardenEligibilityReason(bar, player.id)) continue
+    used.add(bar.id)
+    handBars.push(
+      toInnerGardenEligibleBar(bar, {
+        kind: 'hand',
+        slotIndex: slot.slotIndex,
+        isCarrying: slot.isCarrying,
+      })
+    )
+  }
+
+  const vaultBars = bars
+    .filter((bar) => !used.has(bar.id))
+    .filter((bar) => !getInnerGardenEligibilityReason(bar, player.id))
+    .map((bar) => toInnerGardenEligibleBar(bar, { kind: 'vault' }))
+
+  return { hand: handBars, vault: vaultBars }
+}
+
+export async function buildInnerGardenImportPayload(
+  barId: string
+): Promise<{ payload: BarsInnerGardenImportPayload } | ErrorResult> {
+  const player = await getCurrentPlayer()
+  if (!player) return { error: 'Not authenticated' }
+
+  const [barRaw, hand] = await Promise.all([findCandidateBar(barId), readHandDb(player.id)])
+  const bar = asCandidate(barRaw)
+  if (!bar) return { error: 'BAR not found' }
+
+  const reason = getInnerGardenEligibilityReason(bar, player.id)
+  if (reason) return { error: `BAR is not eligible for Inner Garden (${reason})` }
+
+  const handSlot = hand.slots.find((slot) => slot.barId === bar.id)
+  const eligible = toInnerGardenEligibleBar(
+    bar,
+    handSlot
+      ? { kind: 'hand', slotIndex: handSlot.slotIndex, isCarrying: handSlot.isCarrying }
+      : { kind: 'vault' }
+  )
+
+  return { payload: buildBarsInnerGardenImportPayload(eligible) }
+}
+
+export async function completeInnerGardenShamanRun(formData: FormData): Promise<void> {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const sourceBarId = String(formData.get('sourceBarId') ?? '').trim()
+  const emotionId = String(formData.get('emotionId') ?? '').trim().slice(0, 60)
+  const cultivationAction = String(formData.get('cultivationAction') ?? '').trim().slice(0, 120)
+  const harvestedInsight = String(formData.get('harvestedInsight') ?? '').trim().slice(0, 2000)
+  const seedQuality = normalizeSeedQuality(formData.get('seedQuality'))
+
+  if (!sourceBarId || !emotionId || !cultivationAction || harvestedInsight.length < 3) {
+    redirect(`/inner-garden/shaman?barId=${encodeURIComponent(sourceBarId)}&error=missing`)
+  }
+
+  const source = await findCandidateBar(sourceBarId)
+  if (!source) redirect('/inner-garden?error=not-found')
+
+  const reason = getInnerGardenEligibilityReason(source, player.id)
+  if (reason) redirect(`/inner-garden?error=${encodeURIComponent(reason)}`)
+
+  const resultTitle = `Harvested insight: ${source.title}`.slice(0, 80)
+  const resultDescription = harvestedInsight
+
+  const result = await dbBase.customBar.create({
+    data: {
+      creatorId: player.id,
+      title: resultTitle,
+      description: resultDescription,
+      type: 'bar',
+      reward: 0,
+      visibility: 'private',
+      status: 'active',
+      inputs: '[]',
+      rootId: 'temp',
+      sourceBarId: source.id,
+      gameMasterFace: 'shaman',
+      questSource: INNER_GARDEN_SHAMAN_SOURCE,
+      campaignRef: source.campaignRef,
+      nation: source.nation,
+      intensity: source.intensity,
+      seedMetabolization: buildShamanResultSeedMetabolization(
+        source.seedMetabolization,
+        harvestedInsight
+      ),
+      agentMetadata: JSON.stringify({
+        schemaVersion: 'inner-garden-bars.v1',
+        source: INNER_GARDEN_SHAMAN_SOURCE,
+        sourceBarId: source.id,
+        sourceBarType: source.type,
+        guideFace: 'shaman',
+        emotionId,
+        seedQuality,
+        cultivationAction,
+        harvestedInsight,
+        completedAt: new Date().toISOString(),
+      }),
+    },
+    select: { id: true },
+  })
+
+  await dbBase.customBar.update({
+    where: { id: result.id },
+    data: { rootId: result.id },
+  })
+
+  revalidatePath('/inner-garden')
+  revalidatePath('/bars/garden')
+  revalidatePath('/vault')
+  revalidatePath(`/bars/${source.id}`)
+  revalidatePath(`/bars/${result.id}`)
+
+  redirect(`/bars/${result.id}?innerGarden=shaman`)
+}
+

--- a/src/app/inner-garden/page.tsx
+++ b/src/app/inner-garden/page.tsx
@@ -1,0 +1,149 @@
+/**
+ * @page /inner-garden
+ * @entity BAR
+ * @description Inner Garden entry for the Shaman bridge; lists raw Hand/Vault capture BARs eligible for cultivation
+ * @permissions authenticated
+ * @searchParams error:string (optional bridge error reason)
+ * @relationships PLAYER (auth), BAR (Hand/Vault captures)
+ * @dimensions WHO:player, WHAT:inner_garden_entry, WHERE:inner_garden, ENERGY:raw_capture
+ * @example /inner-garden
+ * @agentDiscoverable false
+ */
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getCurrentPlayer } from '@/lib/auth'
+import { listInnerGardenEligibleBars } from '@/actions/inner-garden'
+import type { InnerGardenEligibleBar } from '@/lib/inner-garden/bridge'
+
+function LocationPill({ bar }: { bar: InnerGardenEligibleBar }) {
+  if (bar.location.kind === 'hand') {
+    return (
+      <span className="rounded border border-emerald-800/60 bg-emerald-950/30 px-2 py-0.5 text-[10px] uppercase tracking-wider text-emerald-300">
+        Hand slot {bar.location.slotIndex + 1}{bar.location.isCarrying ? ' · carrying' : ''}
+      </span>
+    )
+  }
+  return (
+    <span className="rounded border border-zinc-800 bg-zinc-950 px-2 py-0.5 text-[10px] uppercase tracking-wider text-zinc-500">
+      Vault
+    </span>
+  )
+}
+
+function BarRow({ bar }: { bar: InnerGardenEligibleBar }) {
+  return (
+    <Link
+      href={`/inner-garden/shaman?barId=${encodeURIComponent(bar.id)}`}
+      className="block rounded-lg border border-zinc-800 bg-zinc-950/70 p-4 transition hover:border-emerald-700/70 hover:bg-zinc-900"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <LocationPill bar={bar} />
+            <span className="text-[10px] uppercase tracking-wider text-zinc-600">
+              raw {bar.type === 'charge_capture' ? 'charge' : 'BAR'}
+            </span>
+          </div>
+          <h2 className="truncate text-sm font-semibold text-zinc-100">{bar.title}</h2>
+          <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-zinc-500">{bar.description}</p>
+        </div>
+        <span className="shrink-0 text-xs text-emerald-400">Enter</span>
+      </div>
+    </Link>
+  )
+}
+
+export default async function InnerGardenPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>
+}) {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const [{ error }, result] = await Promise.all([searchParams, listInnerGardenEligibleBars()])
+  if ('error' in result) redirect('/login')
+
+  const hasAny = result.hand.length > 0 || result.vault.length > 0
+
+  return (
+    <main className="min-h-screen bg-black px-4 py-8 text-zinc-200 sm:px-8">
+      <div className="mx-auto max-w-4xl space-y-8">
+        <header className="space-y-3">
+          <Link href="/vault" className="text-sm text-zinc-500 transition hover:text-zinc-300">
+            ← Vault
+          </Link>
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-400">Inner Garden</p>
+            <h1 className="mt-2 text-3xl font-bold text-white">Choose raw material for the Shaman loop</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-400">
+              Only raw personal captures can enter this first Inner Garden slice. Quests, campaign kernels,
+              invitations, and already-matured BARs stay in their current systems.
+            </p>
+          </div>
+        </header>
+
+        {error && (
+          <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 p-3 text-sm text-amber-300">
+            That BAR could not enter Inner Garden: {error}.
+          </div>
+        )}
+
+        {!hasAny ? (
+          <section className="rounded-xl border border-dashed border-zinc-800 p-10 text-center">
+            <h2 className="text-lg font-semibold text-zinc-200">No raw captures are ready</h2>
+            <p className="mx-auto mt-2 max-w-md text-sm text-zinc-500">
+              Capture a new BAR or charge, then return here before it has been transformed into a quest,
+              campaign object, or later maturity phase.
+            </p>
+            <div className="mt-5 flex flex-wrap justify-center gap-3">
+              <Link
+                href="/bars/capture"
+                className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-600"
+              >
+                Capture BAR
+              </Link>
+              <Link
+                href="/vault/charges"
+                className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 transition hover:border-zinc-500"
+              >
+                Open charges
+              </Link>
+            </div>
+          </section>
+        ) : (
+          <div className="grid gap-8 lg:grid-cols-2">
+            <section className="space-y-3">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-300">Hand</h2>
+                <p className="text-xs text-zinc-600">Prioritized because these are already being carried.</p>
+              </div>
+              {result.hand.length > 0 ? (
+                <div className="space-y-3">{result.hand.map((bar) => <BarRow key={bar.id} bar={bar} />)}</div>
+              ) : (
+                <div className="rounded-lg border border-zinc-900 p-4 text-sm text-zinc-600">
+                  No raw captures in Hand.
+                </div>
+              )}
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-300">Vault</h2>
+                <p className="text-xs text-zinc-600">Eligible raw captures not currently in Hand.</p>
+              </div>
+              {result.vault.length > 0 ? (
+                <div className="space-y-3">{result.vault.map((bar) => <BarRow key={bar.id} bar={bar} />)}</div>
+              ) : (
+                <div className="rounded-lg border border-zinc-900 p-4 text-sm text-zinc-600">
+                  No raw captures in Vault.
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}
+

--- a/src/app/inner-garden/shaman/page.tsx
+++ b/src/app/inner-garden/shaman/page.tsx
@@ -1,0 +1,179 @@
+/**
+ * @page /inner-garden/shaman
+ * @entity BAR
+ * @description Shaman bridge loop: turns one eligible raw BAR into an Inner Garden harvested insight BAR
+ * @permissions authenticated
+ * @searchParams barId:string (required source BAR), error:string (optional)
+ * @relationships PLAYER (auth), BAR (source and returned insight)
+ * @dimensions WHO:player, WHAT:shaman_cultivation, WHERE:inner_garden, ENERGY:emotional_charge
+ * @example /inner-garden/shaman?barId=bar_123
+ * @agentDiscoverable false
+ */
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getCurrentPlayer } from '@/lib/auth'
+import { buildInnerGardenImportPayload, completeInnerGardenShamanRun } from '@/actions/inner-garden'
+
+const EMOTIONS = [
+  ['fear', 'Fear'],
+  ['anger', 'Anger'],
+  ['sadness', 'Sadness'],
+  ['joy', 'Joy'],
+  ['neutrality', 'Neutrality'],
+] as const
+
+const ACTIONS = [
+  ['name_the_charge', 'Name the charge'],
+  ['sit_with_seed', 'Sit with the seed'],
+  ['compost_projection', 'Compost projection'],
+  ['harvest_witness', 'Harvest witness'],
+] as const
+
+export default async function InnerGardenShamanPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ barId?: string; error?: string }>
+}) {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const { barId, error } = await searchParams
+  if (!barId) redirect('/inner-garden?error=missing-bar')
+
+  const result = await buildInnerGardenImportPayload(barId)
+  if ('error' in result) {
+    return (
+      <main className="min-h-screen bg-black px-4 py-8 text-zinc-200 sm:px-8">
+        <div className="mx-auto max-w-2xl space-y-5">
+          <Link href="/inner-garden" className="text-sm text-zinc-500 transition hover:text-zinc-300">
+            ← Inner Garden
+          </Link>
+          <div className="rounded-xl border border-amber-900/60 bg-amber-950/20 p-6">
+            <h1 className="text-xl font-bold text-amber-200">This BAR cannot enter the Shaman loop</h1>
+            <p className="mt-2 text-sm text-amber-300/80">{result.error}</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  const payload = result.payload
+  const defaultEmotion = payload.bar.emotionHint ?? 'neutrality'
+
+  return (
+    <main className="min-h-screen bg-black px-4 py-8 text-zinc-200 sm:px-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <header className="space-y-3">
+          <Link href="/inner-garden" className="text-sm text-zinc-500 transition hover:text-zinc-300">
+            ← Inner Garden
+          </Link>
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-400">Shaman Guide</p>
+            <h1 className="mt-2 text-3xl font-bold text-white">Tend the seed</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-400">
+              This MVP slice uses the Inner Garden cultivation shape: the BAR enters as raw material,
+              receives attention, and returns as a harvested insight in your Vault.
+            </p>
+          </div>
+        </header>
+
+        {error === 'missing' && (
+          <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 p-3 text-sm text-amber-300">
+            Complete each field before harvesting the insight.
+          </div>
+        )}
+
+        <section className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5">
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-zinc-600">
+            <span>{payload.location.kind === 'hand' ? `Hand slot ${payload.location.slotIndex + 1}` : 'Vault'}</span>
+            <span>·</span>
+            <span>{payload.bar.type === 'charge_capture' ? 'Charge capture' : 'BAR'}</span>
+            {payload.bar.elementHint ? (
+              <>
+                <span>·</span>
+                <span>{payload.bar.elementHint}</span>
+              </>
+            ) : null}
+          </div>
+          <h2 className="text-lg font-semibold text-zinc-100">{payload.bar.title}</h2>
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-zinc-400">
+            {payload.bar.description}
+          </p>
+        </section>
+
+        <form action={completeInnerGardenShamanRun} className="space-y-5 rounded-xl border border-zinc-800 bg-zinc-950/70 p-5">
+          <input type="hidden" name="sourceBarId" value={payload.bar.id} />
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Seed emotion</span>
+              <select
+                name="emotionId"
+                defaultValue={defaultEmotion}
+                className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+              >
+                {EMOTIONS.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Cultivation action</span>
+              <select
+                name="cultivationAction"
+                defaultValue="name_the_charge"
+                className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+              >
+                {ACTIONS.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="space-y-2 text-sm">
+            <span className="block text-zinc-300">Seed quality</span>
+            <input
+              name="seedQuality"
+              type="range"
+              min="1"
+              max="100"
+              defaultValue="55"
+              className="w-full accent-emerald-500"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm">
+            <span className="block text-zinc-300">Harvested insight</span>
+            <textarea
+              name="harvestedInsight"
+              required
+              minLength={3}
+              rows={6}
+              placeholder="What can this charge become when it is tended instead of carried alone?"
+              className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="max-w-md text-xs leading-relaxed text-zinc-600">
+              The result will be saved as a new Shaman BAR in your Vault and linked back to the original.
+            </p>
+            <button
+              type="submit"
+              className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-600"
+            >
+              Harvest insight
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  )
+}
+

--- a/src/app/world/[instanceSlug]/[roomSlug]/page.tsx
+++ b/src/app/world/[instanceSlug]/[roomSlug]/page.tsx
@@ -49,6 +49,18 @@ export default async function WorldRoomPage({
   if (!player) redirect('/conclave/guided')
   if (!isGameAccountReady(player)) redirect('/conclave/guided')
 
+  const pixiPrototypeEnabled =
+    process.env.ENABLE_PIXI_WORLD_PROTOTYPE === '1' ||
+    process.env.ENABLE_PIXI_WORLD_PROTOTYPE === 'true'
+  if (!pixiPrototypeEnabled) {
+    const qs = new URLSearchParams({
+      instanceSlug,
+      roomSlug,
+      retiredRuntime: 'pixi',
+    })
+    redirect(`/inner-garden?${qs.toString()}`)
+  }
+
   const instance = await dbBase.instance.findUnique({
     where: { slug: instanceSlug },
     include: {

--- a/src/lib/inner-garden/__tests__/bridge.test.ts
+++ b/src/lib/inner-garden/__tests__/bridge.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import {
+  BARS_TO_INNER_GARDEN_SCHEMA_VERSION,
+  buildBarsInnerGardenImportPayload,
+  buildShamanResultSeedMetabolization,
+  getInnerGardenEligibilityReason,
+  isRawInnerGardenMaturity,
+  toInnerGardenEligibleBar,
+  type InnerGardenBarCandidate,
+} from '@/lib/inner-garden/bridge'
+import { effectiveMaturity, parseSeedMetabolization } from '@/lib/bar-seed-metabolization'
+
+const PLAYER_ID = 'player_1'
+
+function candidate(patch: Partial<InnerGardenBarCandidate> = {}): InnerGardenBarCandidate {
+  return {
+    id: 'bar_1',
+    title: 'A raw charge',
+    description: 'I felt the charge in the room.',
+    type: 'bar',
+    creatorId: PLAYER_ID,
+    status: 'active',
+    archivedAt: null,
+    seedMetabolization: null,
+    nation: 'metal',
+    intensity: '4',
+    campaignRef: null,
+    gameMasterFace: null,
+    hexagramId: null,
+    isSystem: false,
+    inviteId: null,
+    mergedIntoId: null,
+    ...patch,
+  }
+}
+
+function testEligibility() {
+  assert.equal(getInnerGardenEligibilityReason(candidate(), PLAYER_ID), null)
+  assert.equal(getInnerGardenEligibilityReason(candidate({ type: 'charge_capture' }), PLAYER_ID), null)
+  assert.equal(getInnerGardenEligibilityReason(candidate({ type: 'quest' }), PLAYER_ID), 'unsupported-type')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ type: 'campaign_kernel' }), PLAYER_ID), 'unsupported-type')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ creatorId: 'other' }), PLAYER_ID), 'not-owned')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ status: 'done' }), PLAYER_ID), 'inactive')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ archivedAt: new Date() }), PLAYER_ID), 'archived')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ isSystem: true }), PLAYER_ID), 'system-bar')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ inviteId: 'invite_1' }), PLAYER_ID), 'invitation-bar')
+  assert.equal(getInnerGardenEligibilityReason(candidate({ mergedIntoId: 'bar_2' }), PLAYER_ID), 'merged')
+  assert.equal(
+    getInnerGardenEligibilityReason(candidate({ seedMetabolization: '{"maturity":"context_named"}' }), PLAYER_ID),
+    'not-raw'
+  )
+}
+
+function testRawMaturity() {
+  assert.equal(isRawInnerGardenMaturity(null), true)
+  assert.equal(isRawInnerGardenMaturity(''), true)
+  assert.equal(isRawInnerGardenMaturity('{"maturity":"captured"}'), true)
+  assert.equal(isRawInnerGardenMaturity('{"maturity":"elaborated"}'), false)
+}
+
+function testPayload() {
+  const eligible = toInnerGardenEligibleBar(candidate(), {
+    kind: 'hand',
+    slotIndex: 0,
+    isCarrying: true,
+  })
+  const payload = buildBarsInnerGardenImportPayload(eligible)
+
+  assert.equal(payload.schemaVersion, BARS_TO_INNER_GARDEN_SCHEMA_VERSION)
+  assert.equal(payload.source, 'bars-engine')
+  assert.equal(payload.bar.id, 'bar_1')
+  assert.equal(payload.bar.type, 'bar')
+  assert.equal(payload.bar.elementHint, 'metal')
+  assert.equal(payload.bar.emotionHint, 'fear')
+  assert.deepEqual(payload.location, { kind: 'hand', slotIndex: 0, isCarrying: true })
+  assert.equal(Object.prototype.hasOwnProperty.call(payload.bar, 'creatorId'), false)
+}
+
+function testResultMaturity() {
+  const raw = buildShamanResultSeedMetabolization(null, 'The charge wants a boundary.')
+  const parsed = parseSeedMetabolization(raw)
+  assert.equal(effectiveMaturity(parsed), 'context_named')
+  assert.equal(parsed.soilKind, 'holding_pen')
+  assert.equal(parsed.contextNote, 'The charge wants a boundary.')
+}
+
+testEligibility()
+testRawMaturity()
+testPayload()
+testResultMaturity()
+
+console.log('inner-garden bridge: eligibility and payload OK')
+

--- a/src/lib/inner-garden/bridge.ts
+++ b/src/lib/inner-garden/bridge.ts
@@ -1,0 +1,171 @@
+import {
+  effectiveMaturity,
+  mergeSeedMetabolization,
+  parseSeedMetabolization,
+  type MaturityPhase,
+} from '@/lib/bar-seed-metabolization'
+
+export const BARS_TO_INNER_GARDEN_SCHEMA_VERSION = 'bars-inner-garden.v1'
+export const INNER_GARDEN_TO_BARS_SCHEMA_VERSION = 'inner-garden-bars.v1'
+export const INNER_GARDEN_SHAMAN_SOURCE = 'inner_garden_shaman'
+
+export const INNER_GARDEN_CAPTURE_TYPES = ['bar', 'charge_capture'] as const
+export type InnerGardenCaptureType = (typeof INNER_GARDEN_CAPTURE_TYPES)[number]
+
+export type InnerGardenLocation =
+  | { kind: 'hand'; slotIndex: number; isCarrying: boolean }
+  | { kind: 'vault' }
+
+export type InnerGardenEligibleBar = {
+  id: string
+  title: string
+  description: string
+  type: InnerGardenCaptureType
+  nation: string | null
+  intensity: string | null
+  campaignRef: string | null
+  gameMasterFace: string | null
+  hexagramId: number | null
+  maturity: MaturityPhase
+  location: InnerGardenLocation
+}
+
+export type BarsInnerGardenImportPayload = {
+  schemaVersion: typeof BARS_TO_INNER_GARDEN_SCHEMA_VERSION
+  source: 'bars-engine'
+  mode: 'embedded'
+  bar: {
+    id: string
+    title: string
+    description: string
+    type: InnerGardenCaptureType
+    emotionHint: string | null
+    elementHint: string | null
+    intensity: string | null
+    campaignRef: string | null
+    gameMasterFace: string | null
+    hexagramId: number | null
+  }
+  location: InnerGardenLocation
+}
+
+export type InnerGardenCompletionPayload = {
+  schemaVersion: typeof INNER_GARDEN_TO_BARS_SCHEMA_VERSION
+  guideFace: 'shaman'
+  sourceBarId: string
+  emotionId: string
+  seedQuality: number
+  cultivationAction: string
+  harvestedInsight: string
+}
+
+export type InnerGardenBarCandidate = {
+  id: string
+  title: string
+  description: string
+  type: string
+  creatorId: string
+  status: string
+  archivedAt: Date | null
+  seedMetabolization: string | null
+  nation: string | null
+  intensity: string | null
+  campaignRef: string | null
+  gameMasterFace: string | null
+  hexagramId: number | null
+  isSystem: boolean
+  inviteId: string | null
+  mergedIntoId: string | null
+}
+
+const ELEMENT_TO_EMOTION: Record<string, string> = {
+  fire: 'anger',
+  water: 'sadness',
+  wood: 'joy',
+  metal: 'fear',
+  earth: 'neutrality',
+}
+
+export function isInnerGardenCaptureType(type: string): type is InnerGardenCaptureType {
+  return (INNER_GARDEN_CAPTURE_TYPES as readonly string[]).includes(type)
+}
+
+export function isRawInnerGardenMaturity(seedMetabolization: string | null | undefined): boolean {
+  return effectiveMaturity(parseSeedMetabolization(seedMetabolization)) === 'captured'
+}
+
+export function getInnerGardenEligibilityReason(
+  bar: InnerGardenBarCandidate,
+  playerId: string
+): string | null {
+  if (bar.creatorId !== playerId) return 'not-owned'
+  if (!isInnerGardenCaptureType(bar.type)) return 'unsupported-type'
+  if (bar.status !== 'active') return 'inactive'
+  if (bar.archivedAt) return 'archived'
+  if (bar.isSystem) return 'system-bar'
+  if (bar.inviteId) return 'invitation-bar'
+  if (bar.mergedIntoId) return 'merged'
+  if (!isRawInnerGardenMaturity(bar.seedMetabolization)) return 'not-raw'
+  return null
+}
+
+export function toInnerGardenEligibleBar(
+  bar: InnerGardenBarCandidate,
+  location: InnerGardenLocation
+): InnerGardenEligibleBar {
+  return {
+    id: bar.id,
+    title: bar.title,
+    description: bar.description,
+    type: bar.type as InnerGardenCaptureType,
+    nation: bar.nation,
+    intensity: bar.intensity,
+    campaignRef: bar.campaignRef,
+    gameMasterFace: bar.gameMasterFace,
+    hexagramId: bar.hexagramId,
+    maturity: effectiveMaturity(parseSeedMetabolization(bar.seedMetabolization)),
+    location,
+  }
+}
+
+export function buildBarsInnerGardenImportPayload(
+  bar: InnerGardenEligibleBar
+): BarsInnerGardenImportPayload {
+  const elementHint = bar.nation?.trim().toLowerCase() || null
+  return {
+    schemaVersion: BARS_TO_INNER_GARDEN_SCHEMA_VERSION,
+    source: 'bars-engine',
+    mode: 'embedded',
+    bar: {
+      id: bar.id,
+      title: bar.title,
+      description: bar.description,
+      type: bar.type,
+      elementHint,
+      emotionHint: elementHint ? ELEMENT_TO_EMOTION[elementHint] ?? null : null,
+      intensity: bar.intensity,
+      campaignRef: bar.campaignRef,
+      gameMasterFace: bar.gameMasterFace,
+      hexagramId: bar.hexagramId,
+    },
+    location: bar.location,
+  }
+}
+
+export function normalizeSeedQuality(raw: FormDataEntryValue | null): number {
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return 50
+  return Math.max(1, Math.min(100, Math.round(n)))
+}
+
+export function buildShamanResultSeedMetabolization(
+  sourceSeedMetabolization: string | null | undefined,
+  harvestedInsight: string
+): string | null {
+  return mergeSeedMetabolization(sourceSeedMetabolization, {
+    maturity: 'context_named',
+    soilKind: 'holding_pen',
+    contextNote: harvestedInsight,
+  })
+}
+


### PR DESCRIPTION
## Summary
- Adds the six-guide Calrunia orientation spec kit, including the Inner Garden Shaman Bridge implementation phase and Pixi deprecation decision record.
- Adds v1 BAR eligibility and bridge payload helpers for raw `bar` / `charge_capture` intake into Inner Garden.
- Adds authenticated `/inner-garden` and `/inner-garden/shaman` routes plus Shaman completion storage back into Vault as a linked result BAR.
- Redirects normal `/world/...` traffic toward Inner Garden unless `ENABLE_PIXI_WORLD_PROTOTYPE` is enabled.

## Verification
- `/Users/wendellbritt/The Library /node_modules/.bin/tsx src/lib/inner-garden/__tests__/bridge.test.ts`
- Previously verified in the source workspace: targeted ESLint, targeted type-check, route validation. Full `tsc --noEmit` is still blocked by pre-existing nested Library syntax errors outside this slice.

## Notes
- Built from `origin/main` in a clean worktree so this PR contains only the Inner Garden Shaman Bridge commit.