### PR TITLE
[codex] Add The Crossing CYOA landing design spec

### DIFF
--- a/.specify/specs/pick-your-move-invitation-surface/plan.md
+++ b/.specify/specs/pick-your-move-invitation-surface/plan.md
@@ -1,0 +1,192 @@
+# Plan: Pick Your Move Invitation Surface
+
+## Implementation Strategy
+
+Phase 0 is complete when the concept exists as a spec in both the Library and bars-engine Spec Kit.
+
+Implementation should proceed in small slices:
+
+1. Author static content and role definitions.
+2. Add the support intake to The Crossing campaign landing page.
+3. Wire role submissions to create campaign-tagged `CustomBar` records.
+4. Add a steward/manual entry path for existing offers.
+5. Later, convert selected support BARs into contribution records, quests, or milestone progress.
+
+## Campaign Placement
+
+The Crossing support intake belongs on the campaign landing page itself, not on a detached demo page.
+
+The campaign relationship should be:
+
+```text
+Mastering the Game of Allyship Launch + Barn Raising (`mtgoa-barn-raising`)
+-> The Crossing car fundraiser
+```
+
+Implementation should use `Campaign.parentCampaignId` when the canonical parent is represented as a `Campaign`. If the active launch surface is still represented as an `Instance` or static `/launch` page, use the best available parent ref/link for the EOD slice and leave a follow-up to normalize it into the campaign hierarchy.
+
+Parent rule:
+
+- Use `mtgoa-barn-raising` as the parent ref for The Crossing.
+- Treat `mtgoa-barn-raising` as the community/homies route for people already in Wendell's field.
+- Do not use `allyship-book` as this parent. `allyship-book` is the newcomer/book route for people entering the work fresh.
+
+The Crossing page should include a clear upward link:
+
+```text
+Part of the Mastering the Game of Allyship Launch + Barn Raising
+```
+
+Every support BAR should preserve that lineage in metadata.
+
+## Ontology Note
+
+This implementation should treat support submissions as **campaign-captured BARs**.
+
+They are not required to appear in a supporter/player hand or vault.
+
+Current schema still requires `CustomBar.creatorId`, so the MVP should use a campaign steward/player id as administrative owner while setting `campaignRef: "the-crossing"` to mark where the BAR belongs.
+
+Do not add player-vault assignment as an EOD requirement.
+
+## bars-engine Legality
+
+Allowed today:
+
+- `CustomBar.creatorId` references the steward/player account.
+- `CustomBar.campaignRef` marks the campaign field.
+- `claimedById` remains null.
+- No `PlayerQuest` is created.
+- No `HandSlot` is created.
+
+Definition expansion:
+
+- Current database uses player `creatorId` as administrative ownership.
+- Product semantics should distinguish administrative steward from campaign belonging.
+- Campaign-captured BARs are valid BARs even if they are not in a public supporter's hand or vault.
+
+Known caveat:
+
+- A steward-owned private active BAR can appear in the steward's vault as a draft under current vault queries.
+- EOD can accept this as an inbox behavior.
+- Follow-up should split campaign inbox BARs from personal vault BARs.
+
+Access rule:
+
+- BARs in a campaign you steward should be accessible from vault/stewardship surfaces.
+- This is stewardship access, not necessarily personal ownership.
+- Initial implementation may expose them in the same surface; later UI should split "my BARs" from "campaign BARs I steward."
+
+## File Impact Candidates
+
+Likely landing surfaces:
+
+- campaign landing/hub surfaces under `src/app/campaign/*`
+- likely `src/app/campaign/[ref]/page.tsx`
+- likely `src/app/campaign/[ref]/CampaignLanding.tsx`
+- possible parent launch surface: `src/app/launch/page.tsx`
+- possible event parent surface: `src/app/event/page.tsx`
+
+Potential library/content files:
+
+- `src/lib/campaign-share-url.ts`
+- static role definition file such as `src/lib/the-crossing-support-moves.ts`
+- server action: `src/actions/the-crossing-support.ts`
+
+Spec/library anchors:
+
+- `The Library/06 Specs/Pick Your Move Invitation Surface Spec v0.1.md`
+- `The Library/04 Quests/Personal/The Crossing - Fundraiser Momentum Move Packet.md`
+- `.specify/specs/pick-your-move-invitation-surface/spec.md`
+
+## Phase 1: Static Role Picker
+
+Goal: Put the lightweight role picker in front of people and persist submissions as campaign BARs.
+
+Work:
+
+- Resolve the parent link/ref for `mtgoa-barn-raising`.
+- Render the support section on The Crossing campaign landing page.
+- Include a visible parent campaign link above or near the campaign story.
+- Define six support roles as static data, including primary domain, secondary domains, and starter allyship card ids.
+- Add a "Want to help but not sure what your move is?" section.
+- Make each role show description, tiny move, and CTA.
+- Make each role show its impact lane in plain language.
+- Optionally show one starter card title/prompt pulled from its role domain.
+- Add a public form that creates a `CustomBar` with `campaignRef: "the-crossing"`.
+- Use campaign steward as `creatorId` for unauthenticated submissions.
+- Store contributor name/contact, role metadata, and parent campaign lineage in BAR metadata fields.
+
+Validation:
+
+- Page is readable on mobile.
+- Page reads as The Crossing's campaign landing page, not a separate support utility.
+- Page links back to the Mastering the Game of Allyship Launch + Barn Raising parent.
+- Non-donation roles feel first-class.
+- CTA copy is clear.
+- Connector is not confused with Car Scout or Signal Booster.
+- Donor includes time and money, not only cash.
+- Submitting the form creates a `CustomBar`.
+- Created BAR has `campaignRef: "the-crossing"`.
+- Created BAR has parent campaign lineage metadata.
+- Created BAR has correct `allyshipDomain` and starter card id metadata.
+- Created BAR does not need to appear in any public player's hand or vault.
+- No `PlayerQuest` or `HandSlot` row is required for support intake BARs.
+- Steward can access created support BARs through the campaign/stewardship workflow.
+
+## Phase 2: Raised-Hand Capture
+
+Goal: Let helpers self-identify without making them sign up while preserving the BAR primitive.
+
+Work:
+
+- Add "I can help with this" capture path per role.
+- Write public submissions to `CustomBar`.
+- Add steward/manual-entry route or script for existing support already received.
+
+Validation:
+
+- Wendell can see who raised a hand and for which role.
+- Helpers understand what will happen next.
+- Existing car offers and car scout offers can be entered as BARs.
+
+## Phase 3: BAR Bridge
+
+Goal: Convert support action BARs into campaign progress, gratitude, and next moves.
+
+Work:
+
+- After action, ask: "What happened?"
+- Update or create follow-up BARs using Before / Action / Result.
+- Include selected role and selected allyship card id in the BAR metadata.
+- Later: convert accepted/completed support BARs into `ContributionRecord` or milestone progress.
+
+Validation:
+
+- At least one support action can become a BAR.
+- The system can thank people and show momentum honestly.
+
+## Design Notes
+
+The page should feel like being welcomed into useful participation, not being sorted by a personality quiz.
+
+Role cards should be compact and action-oriented.
+
+The app bridge belongs after the role picker, not before it.
+
+## Risks
+
+- Too much ontology too early.
+- Role picker feels like a menu, not an invitation.
+- CTAs create follow-up burden without capture discipline.
+- Donation and non-donation paths compete rather than reinforce.
+
+## Verification
+
+Before implementation is considered done:
+
+- View page at mobile and desktop widths.
+- Confirm text does not overflow role cards.
+- Confirm all role CTAs work.
+- Confirm donation CTA remains available.
+- Ask one tester: "Which role would you pick?" and "What would you do next?"

--- a/.specify/specs/pick-your-move-invitation-surface/spec.md
+++ b/.specify/specs/pick-your-move-invitation-surface/spec.md
@@ -1,0 +1,510 @@
+# Spec: Pick Your Move Invitation Surface
+
+**Status:** Draft spec kit. Preserve the concept before implementation.  
+**Library source:** `The Library/06 Specs/Pick Your Move Invitation Surface Spec v0.1.md`  
+**Related specs:** `campaign-hub-spoke-landing-architecture`, `mtgoa-launch-barn-raising-party`, `barn-raising-live-data`, `mobility-quest-superpower-campaign`, `campaign-scoped-donation-cta`.
+
+## Purpose
+
+Create a lightweight public-facing invitation surface for The Crossing car fundraiser that lets supporters choose a useful role and take one concrete action before the full BARS Engine product is ready.
+
+This surface belongs on The Crossing campaign landing page itself. The Crossing is a subcampaign of `mtgoa-barn-raising`, the Mastering the Game of Allyship Launch + Barn Raising campaign for Wendell's existing community, so the landing page must link back up to that parent campaign.
+
+The surface should bring people closer to the app by letting them experience the core loop:
+
+```text
+Care -> Role -> Move -> Artifact -> Impact -> BAR
+```
+
+without requiring them to understand BARS Engine terminology.
+
+All submitted information must be captured as a `CustomBar` tagged to the campaign via `campaignRef`. This is not a parallel lead tracker.
+
+## Problem
+
+People are unlikely to start by thinking, "I am not showing up and I feel bad about it." That is too internal and shame-adjacent for a public landing page.
+
+People are more likely to start from:
+
+- I care about this.
+- I want to help.
+- I know someone.
+- I already donated and want another way to participate.
+- I cannot donate, but maybe I can still be useful.
+- I do not know what my useful move is.
+
+The landing page needs an inciting event and a tiny action path, not an ontology lesson.
+
+## Product Hypothesis
+
+The first public "BARS Engine" experience can be a role picker attached to a real campaign.
+
+For The Crossing car fundraiser, the current bottleneck is finding the actual car. The page can convert supporter energy into specific help:
+
+- car leads
+- listing evaluation
+- introductions
+- shares
+- encouragement
+- donations
+
+This creates an early field test of move generation, ally discovery, and BAR capture.
+
+## Campaign Placement and Lineage
+
+The role picker is not a separate microsite or detached intake form.
+
+It should be embedded into the canonical public landing page for The Crossing campaign:
+
+```text
+Mastering the Game of Allyship Launch + Barn Raising (`mtgoa-barn-raising`)
+-> The Crossing car fundraiser
+-> Pick Your Move / support intake
+```
+
+Implementation should use the existing campaign hierarchy where possible:
+
+- The Crossing should be represented as a child/subcampaign.
+- The parent should be `mtgoa-barn-raising`.
+- The page should include a visible parent link such as: "Part of the Mastering the Game of Allyship Launch + Barn Raising."
+- The parent link should route to the parent campaign/launch page, not to a generic homepage.
+
+Route distinction:
+
+- `mtgoa-barn-raising` is the community/homies route: the field for people already in Wendell's community who are helping raise the barn.
+- `allyship-book` is the newcomer route: the field for people who are new to the work and entering through the book itself.
+
+Do not silently attach The Crossing to Bruised Banana just because older fundraiser specs mention it. The Crossing is part of the current Mastering the Game of Allyship launch field.
+
+## Core Data Decision
+
+Every submission creates a campaign BAR.
+
+```text
+Role signup
+-> Support details
+-> CustomBar
+-> campaignRef: "the-crossing"
+-> parent campaign lineage metadata: "mtgoa-barn-raising"
+-> allyshipDomain from role
+-> starter card id in metadata
+```
+
+Do not create a separate support-log primitive for the first version.
+
+BARs created from this surface represent "evidence of support entering the field." They may later be upgraded, linked, converted into quests, attached to milestones, or counted in campaign contribution summaries.
+
+## Ontology Upgrade: Campaign-Captured BARs
+
+This spec introduces a distinction the product has not needed clearly before:
+
+```text
+Personal BAR
+Campaign-captured BAR
+```
+
+A BAR does not have to begin in a player's hand or vault.
+
+Some BARs originate in a campaign field:
+
+- a car lead
+- a warm introduction
+- a time offer
+- a money/resource offer
+- an encouragement/check-in
+- a listing review
+- an offline contribution reported by a steward
+
+These are still BARs because they are bounded artifacts of reality with enough shape to carry meaning and future action.
+
+They are not necessarily player inventory.
+
+### Working Model
+
+BARs now have several separable axes:
+
+| Axis | Meaning |
+|---|---|
+| Creator / Steward | Who can administer or edit the BAR record. Current schema requires `creatorId`. |
+| Campaign | Which field the BAR belongs to, via `campaignRef`. |
+| Player Hand / Vault | Whether the BAR is held as a player-owned playable object. Optional. |
+| Maturity | Whether the BAR is raw evidence, active support, completed impact, quest seed, or archived provenance. |
+
+For EOD implementation, unauthenticated support submissions can be steward-owned `CustomBar` records with `campaignRef: "the-crossing"`.
+
+Later implementation may make campaign ownership first-class, but this spec should not block on that schema upgrade.
+
+### Product Implication
+
+Players and campaigns can both capture and mature BARs.
+
+```text
+Player captures BAR
+-> BAR may enter a campaign
+
+Campaign captures BAR
+-> BAR may later enter a player's hand, become a quest, or mature into campaign provenance
+```
+
+The Crossing support surface is the first practical test of campaign-captured BARs.
+
+### Current bars-engine Constraint Check
+
+As of this spec, bars-engine allows a BAR to be campaign-scoped without being in a player's hand, assigned quest list, or explicit vault slot.
+
+The current schema does require:
+
+- `CustomBar.creatorId` must reference a `Player`.
+
+The current schema does **not** require:
+
+- `claimedById`
+- `PlayerQuest` assignment
+- `HandSlot`
+- `HandSlot.isCarrying`
+- a player-facing vault placement record
+
+Therefore, campaign-captured BARs are allowed today if they are represented as steward-owned `CustomBar` rows with `campaignRef` set.
+
+This is a product-definition expansion, not an immediate schema blocker.
+
+### Definition Expansion Required
+
+The product definition of BAR must expand from:
+
+```text
+A player-owned artifact in a vault or hand.
+```
+
+to:
+
+```text
+A bounded artifact of reality that may be stewarded by a player, carried by a player, or captured by a campaign field.
+```
+
+Current schema still uses `creatorId` as administrative ownership. The semantic owner can be the campaign when `campaignRef` is set and metadata marks the BAR as campaign-captured.
+
+### EOD Placement Rule
+
+For the EOD slice:
+
+- create `CustomBar` records
+- set `creatorId` to the campaign steward/player id
+- set `campaignRef` to The Crossing campaign ref
+- include parent campaign lineage metadata for `mtgoa-barn-raising`
+- set `claimedById` to `null`
+- do not create `PlayerQuest`
+- do not create `HandSlot`
+- do not require the BAR to appear in a supporter's vault
+
+### Vault Query Caveat
+
+Because current vault queries treat some private active creator-owned BARs as drafts, steward-owned campaign-captured BARs may appear in the steward's vault unless excluded.
+
+For EOD, this is acceptable as a steward inbox.
+
+### Steward Access Rule
+
+If a BAR exists in a campaign you steward, it should be accessible to you from the vault/stewardship surface even if you did not personally "carry" it.
+
+This access does not mean:
+
+```text
+This BAR is mine as a personal artifact.
+```
+
+It means:
+
+```text
+This BAR is in a field I steward.
+```
+
+Working access rule:
+
+```text
+Personal vault access
+= BARs I created / carry / claim
+
+Campaign stewardship access
+= BARs attached to campaigns I steward
+```
+
+For the first implementation, these may appear together. The UI should eventually distinguish:
+
+- My BARs
+- Campaign BARs I steward
+- BARs I carry in hand
+- BARs awaiting follow-up
+- BARs matured into contributions or quests
+
+For the next pass, add a filter or view distinction so `evidenceKind: "support_intake"` / `agentMetadata.sourceType: "campaign_support_intake"` can be shown as campaign inbox rather than personal draft clutter.
+
+## User Stories
+
+### P1 — Choose my useful role
+
+As a supporter, I want to quickly see the different ways I can help, so I can choose a move that fits my actual capacity.
+
+Acceptance:
+
+- Page includes a "Want to help but not sure what your move is?" section.
+- Role choices are visible without sign-in.
+- Each role has one plain-language description and one tiny move.
+
+### P2 — Help without donating
+
+As a supporter who cannot donate, I want a meaningful non-money way to participate, so I do not feel useless or excluded.
+
+Acceptance:
+
+- Non-donation roles are presented as first-class help, not fallback help.
+- Car Scout, Car Person, Connector, Signal Booster, and Encourager all have concrete actions.
+
+### P3 — Continue helping after donating
+
+As someone who already donated, I want another useful move, so my support can continue as momentum.
+
+Acceptance:
+
+- Copy explicitly says that people who already donated can still help by sending leads, making introductions, or sharing.
+
+### P4 — Bring people toward the app
+
+As the campaign creator, I want supporters to experience the BARS Engine promise before the product is ready, so the landing page becomes a bridge into future app use.
+
+Acceptance:
+
+- Page includes a soft explanation: "This is an early version of BARS Engine: a way to turn care into concrete action."
+- App bridge copy does not interrupt the primary help flow.
+
+### P4b — Preserve campaign lineage
+
+As a supporter, I want to understand that The Crossing is part of the larger Mastering the Game of Allyship Launch + Barn Raising, so the car fundraiser feels connected to the actual community field instead of like an isolated emergency.
+
+Acceptance:
+
+- The Crossing landing page includes a visible link back to `mtgoa-barn-raising`.
+- Copy frames the car fundraiser as a concrete dependency inside the launch campaign.
+- Support BARs include parent campaign lineage in metadata.
+- The page does not make the parent campaign more important than the immediate car support action.
+
+### P5 — Capture visible impact
+
+As the campaign creator, I want each support submission to become a campaign-tagged BAR, so actions can be followed up, thanked, sorted by role, and later converted into contribution records.
+
+Acceptance:
+
+- Submission creates a `CustomBar`.
+- The BAR has `campaignRef` set to the Crossing campaign ref.
+- The BAR includes selected role, domain, starter card id, contributor name/contact, and details in structured metadata.
+- Every role has an obvious "tell me what you are offering" path.
+
+### P6 — Track existing support
+
+As Wendell, I want to enter existing offers manually, so homies who already offered cars, scouting, money, or support are represented in the campaign record.
+
+Acceptance:
+
+- Admin/steward can create the same kind of campaign BAR manually.
+- Existing car offers and car scout offers can be captured without pretending they came through the public page.
+- Manual entries use the same role/domain/card model as public submissions.
+
+## Role Model
+
+Roles are campaign-specific expressions of allyship domains. They are not personality labels; they are impact lanes.
+
+Each role answers:
+
+```text
+What kind of impact are you trying to create?
+```
+
+| Role | Primary Domain | Secondary Domain | Description | Tiny Move | Primary Artifact | Starter Card Pulls |
+|---|---|---|---|---|---|---|
+| Car Scout | `GATHERING_RESOURCES` | `SKILLFUL_ORGANIZING` | Finds viable cars, listings, and vehicle paths. | Send one promising listing. | Listing lead | `OPEN-GR-ARCHITECT`, `WAKE-SO-ARCHITECT` |
+| Car Person | `SKILLFUL_ORGANIZING` | `DIRECT_ACTION` | Evaluates listings, risk, repairs, title issues, and buying strategy. | Sanity-check one listing. | Listing review | `SHOW-SO-ARCHITECT`, `WAKE-DA-CHALLENGER` |
+| Connector | `GATHERING_RESOURCES` | `SKILLFUL_ORGANIZING` | Makes warm human introductions to someone who can help. | Make one warm introduction. | Intro | `WAKE-GR-DIPLOMAT`, `SHOW-GR-DIPLOMAT` |
+| Signal Booster | `RAISE_AWARENESS` | null | Shares the ask strategically with context. | Share post/thread with one sentence. | Share | `SHOW-RA-DIPLOMAT`, `SHOW-RA-SAGE` |
+| Encourager | `DIRECT_ACTION` | `GATHERING_RESOURCES` | Reaches out to Wendell, reflects momentum, and encourages aligned action. | Send one check-in. | Encouragement | `SHOW-DA-REGENT`, `OPEN-GR-DIPLOMAT` |
+| Donor | `GATHERING_RESOURCES` | null | Contributes material support: money, time, expertise, space, or concrete resources. | Donate, offer time, or share the donation link. | Contribution | `WAKE-GR-DIPLOMAT`, `SHOW-GR-ARCHITECT` |
+
+### Role Boundary Rules
+
+Connector must stay narrow.
+
+- Car Scout means: "I found a car or vehicle lead."
+- Connector means: "I know a person who should talk to Wendell."
+- Signal Booster means: "I shared the ask with an audience."
+- Donor means: "I contributed material resources, including time or money."
+- Encourager means: "I helped keep the person and campaign in motion."
+
+If a role overlaps too much in the interface, prefer the more specific role.
+
+### Allyship Deck Card Pulls
+
+When a supporter chooses a role, the app should eventually pull cards from that role's domain affinity.
+
+MVP behavior:
+
+- show one suggested allyship card per role
+- use `campaignQuestion` as the reflection prompt
+- translate the card into one car-campaign tiny move
+
+Later behavior:
+
+- role-filtered draw from the full Allyship Deck
+- include `domain`, `move`, `operation`, and card id in provenance
+- capture completed action as a BAR
+
+Example:
+
+```text
+Role: Connector
+Domain: GATHERING_RESOURCES
+Card: WAKE-GR-DIPLOMAT / Who Holds the Purse
+Campaign Question: Who are the givers, gatekeepers, and stakeholders in this ask?
+Move: Name one person who could unlock a car lead, then make a warm introduction.
+Artifact: Introduction message
+```
+
+## UX Contract
+
+Recommended section order:
+
+1. Parent campaign link: "Part of the Mastering the Game of Allyship Launch + Barn Raising."
+2. Story: what happened and why the car matters.
+3. Momentum: fundraising is moving.
+4. Need: now we need to find the actual car.
+5. Pick Your Move: role picker.
+6. Take One Action: role-specific CTA.
+7. Optional Capture: "Tell me what you did."
+8. Soft App Bridge: early BARS Engine explanation.
+
+Primary headline:
+
+```text
+Want to help but not sure what your move is?
+```
+
+Secondary copy:
+
+```text
+Pick the kind of help that feels natural.
+```
+
+Avoid:
+
+- diagnosing people as not showing up
+- making helpers learn the ontology first
+- implying money is the only meaningful help
+- overexplaining BARS Engine before they act
+
+## Data Contract
+
+For MVP, role definitions can be authored static content. Submissions should persist as `CustomBar` records.
+
+Future structured model:
+
+```ts
+type SupportRole =
+  | 'car_scout'
+  | 'car_person'
+  | 'connector'
+  | 'signal_booster'
+  | 'encourager'
+  | 'donor'
+
+type SupportMove = {
+  role: SupportRole
+  primaryDomain: 'GATHERING_RESOURCES' | 'RAISE_AWARENESS' | 'DIRECT_ACTION' | 'SKILLFUL_ORGANIZING'
+  secondaryDomains?: Array<'GATHERING_RESOURCES' | 'RAISE_AWARENESS' | 'DIRECT_ACTION' | 'SKILLFUL_ORGANIZING'>
+  label: string
+  description: string
+  tinyMove: string
+  artifact: string
+  ctaLabel: string
+  ctaHref: string
+  starterCardIds: string[]
+}
+```
+
+### BAR Write Contract
+
+MVP submission creates:
+
+```ts
+type SupportBarInput = {
+  campaignRef: 'the-crossing'
+  parentCampaignRef: 'mtgoa-barn-raising'
+  role: SupportRole
+  name: string
+  contact: string
+  offerSummary: string
+  details: string
+  url?: string
+  starterCardId: string
+}
+```
+
+Maps to `CustomBar`:
+
+```ts
+{
+  creatorId: stewardPlayerId,
+  title: `[${roleLabel}] ${offerSummary}`,
+  description: details,
+  type: 'vibe',
+  visibility: 'private' | 'public',
+  status: 'active',
+  campaignRef: 'the-crossing',
+  allyshipDomain: primaryDomain,
+  moveType: 'show_up',
+  evidenceKind: 'support_intake',
+  contextLines: JSON.stringify({
+    contributorName: name,
+    contributorContact: contact,
+    role,
+    starterCardId,
+    url
+  }),
+  docQuestMetadata: JSON.stringify({
+    source: 'pick_your_move_support_page',
+    parentCampaignRef,
+    campaignLineage: [parentCampaignRef, 'the-crossing'],
+    artifact: roleArtifact,
+    secondaryDomains
+  })
+}
+```
+
+Note: public unauthenticated submissions still require a `creatorId` because `CustomBar.creatorId` is required. For the EOD version, use the campaign steward/player id as the creator and store the actual contributor in `contextLines`. Later, authenticated users can create their own BARs directly.
+
+## Non-Goals
+
+- Full BARS Engine onboarding.
+- User account requirement.
+- AI-generated move generation.
+- Complete donation infrastructure rewrite.
+- Replacing existing donation wizard or campaign hub.
+- Final public copy.
+- A separate non-BAR lead database.
+
+## Acceptance Criteria
+
+- Supporter can choose a role within 10 seconds.
+- Supporter can take one useful action without knowing what a BAR is.
+- Page presents non-money help as meaningful.
+- Page makes the app connection without making the app the main ask.
+- Page links The Crossing back to the Mastering the Game of Allyship Launch + Barn Raising campaign.
+- Every submitted role produces a campaign-tagged BAR.
+- Every submitted role preserves campaign lineage back to the parent launch campaign.
+- Existing offers can be manually entered as campaign-tagged BARs.
+- At least one role produces trackable evidence: listing, intro, share, message, contribution, or check-in.
+
+## Open Questions
+
+- What visual treatment makes role picking feel alive rather than like a utility menu?
+- Should role CTAs route to DMs, forms, email, or in-app capture for the first live version?
+- Should "Tell me what you did" be optional after each role or a single footer CTA?
+- Should the page ask for name/contact on raised hands, or keep the first iteration frictionless?
+- Which roles should be visible on mobile without scrolling?

--- a/.specify/specs/pick-your-move-invitation-surface/tasks.md
+++ b/.specify/specs/pick-your-move-invitation-surface/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Pick Your Move Invitation Surface
+
+## Phase 0: Spec Capture
+
+- [x] Create Library spec.
+- [x] Create Spec Kit `spec.md`.
+- [x] Create Spec Kit `plan.md`.
+- [x] Create Spec Kit `tasks.md`.
+
+## Phase 1: Static Surface
+
+- [ ] Identify/create the canonical public landing page for The Crossing car fundraiser.
+- [ ] Place the support intake on The Crossing campaign landing page, not a detached demo page.
+- [ ] Use `mtgoa-barn-raising` as The Crossing parent campaign/ref.
+- [ ] Represent The Crossing as a child/subcampaign of that parent where the current data model allows.
+- [ ] Add a visible parent link: "Part of the Mastering the Game of Allyship Launch + Barn Raising."
+- [ ] Do not attach The Crossing to `allyship-book`; that route is for people new to the work.
+- [ ] Create static support role data.
+- [ ] Add primary domain to each role.
+- [ ] Add secondary domains where needed.
+- [ ] Add starter Allyship Deck card ids to each role.
+- [ ] Add role boundary copy so Connector does not overlap with Car Scout or Signal Booster.
+- [ ] Add "Want to help but not sure what your move is?" section.
+- [ ] Add six role cards: Car Scout, Car Person, Connector, Signal Booster, Encourager, Donor.
+- [ ] Add one tiny move and one CTA per role.
+- [ ] Add one impact statement per role.
+- [ ] Define Donor as time, money, expertise, space, or concrete resources.
+- [ ] Keep non-donation roles visually equal to donor role.
+- [ ] Create server action or route that creates `CustomBar` from support submission.
+- [ ] Set `campaignRef` on every support BAR.
+- [ ] Store parent campaign lineage on every support BAR.
+- [ ] Store role/domain/card/contributor metadata on the BAR.
+- [ ] Do not assign support BARs to a public player hand/vault in the EOD slice.
+- [ ] Document steward-owned / campaign-captured BAR behavior in code comments near the create action.
+
+## Phase 2: Lightweight Capture
+
+- [ ] Use form as first capture channel.
+- [ ] Add "Tell me what you are offering" CTA.
+- [ ] Include role context in the capture path.
+- [ ] Ensure no sign-in is required for first contact.
+- [ ] Use steward/player id as `creatorId` for unauthenticated submissions.
+- [ ] Add manual-entry path for already-received car offers and car scout offers.
+- [ ] Verify created support BAR has no `PlayerQuest` assignment.
+- [ ] Verify created support BAR has no `HandSlot`.
+- [x] Decide whether steward vault as support inbox is acceptable for EOD.
+- [ ] Verify campaign steward can access support BARs attached to campaigns they steward.
+- [ ] Add follow-up task to separate campaign inbox BARs from personal vault drafts if needed.
+
+## Phase 3: App Bridge
+
+- [ ] Add soft BARS Engine bridge copy below role picker.
+- [ ] Avoid making ontology explanation primary.
+- [ ] Add optional early-circle CTA for people interested in the app.
+
+## Phase 4: Validation
+
+- [ ] Test mobile layout.
+- [ ] Test desktop layout.
+- [ ] Verify all links/CTAs.
+- [ ] Ask at least one person which role they would choose.
+- [ ] Record feedback in the Library.

--- a/.specify/specs/the-crossing-campaign-landing-page/DESIGN_HANDOFF.md
+++ b/.specify/specs/the-crossing-campaign-landing-page/DESIGN_HANDOFF.md
@@ -1,0 +1,468 @@
+# Design Handoff: The Crossing CYOA Campaign Landing Page
+
+## Audience
+
+This document is intended for Claude Design or another visual/product designer.
+
+## Design Goal
+
+Transform the current MVP support page into a **choose-your-own-adventure campaign experience**.
+
+The current page has the right information in rough MVP form, but the vibe is wrong:
+
+```text
+Current vibe: Fill out a support form.
+Desired vibe: Choose your role in the campaign and enter that path.
+```
+
+The page should feel like a public-facing mini BARS Engine experience:
+
+```text
+Story -> How To Play -> Choose A Path -> Role Page -> Move -> Contribution Saved As BAR
+```
+
+## Experience Principles
+
+- The user should feel invited into play, not assigned homework.
+- The page should not lead with ontology.
+- The page should not feel like a form menu.
+- The first click should feel like choosing a character role or campaign path.
+- Each option should use the same visual/card logic as BARs and the Allyship Deck.
+- The landing page should bring people closer to BARS Engine without making them learn BARS Engine first.
+
+## Campaign Context
+
+The Crossing is the community/homies route into the current ask.
+
+Parent campaign:
+
+```text
+mtgoa-barn-raising
+```
+
+Important internal note:
+
+```text
+The Crossing is the community route into this ask: people already in Wendell's field helping raise the barn together.
+```
+
+This is **not user-facing copy**. It is internal positioning only.
+
+User-facing framing should be simpler:
+
+```text
+Help Wendell get back on the road.
+Choose the way you can help.
+Every kind of support moves the campaign.
+```
+
+## Page Structure
+
+### 1. Hero
+
+Purpose:
+
+Help people understand the immediate ask quickly.
+
+Needed content:
+
+- Campaign name: The Crossing
+- Short plain-language statement: Wendell needs a reliable car.
+- Parent link: Part of Mastering the Game of Allyship Launch + Barn Raising.
+- Primary CTA: Choose Your Move.
+- Secondary CTA: Read the full story.
+
+Design note:
+
+This should not look like a generic fundraising page. It should feel like the opening scene of a campaign.
+
+### 2. Story Preview
+
+The current story is too thin.
+
+Landing page should include:
+
+- Short story preview.
+- Link to a separate full story page.
+
+Proposed link:
+
+```text
+/campaign/the-crossing/story
+```
+
+CTA copy options:
+
+- Read the whole story
+- Why this matters
+- What happened
+
+The full story page should include:
+
+- What happened with the car.
+- Why the car matters practically.
+- Why this moment connects to the larger launch + barn raising.
+- What kind of help is most useful now.
+- How people can participate without donating.
+
+### 3. How To Play
+
+Rename the current "How to Contribute" section to:
+
+```text
+How To Play
+```
+
+This section should explain the participation loop without saying too much BARS jargon.
+
+Suggested copy direction:
+
+```text
+Pick the path that fits your real capacity.
+Each path gives you a small move.
+Your move creates evidence the campaign can follow up on.
+```
+
+Include inline links to each option/path.
+
+Important:
+
+The "How To Play" section should not be a dense paragraph. It should be a compact game instruction strip.
+
+### 4. Choose A Path
+
+The central interaction should be path selection.
+
+The current role cards should become clickable cards that open a full path, not forms.
+
+Desired interaction:
+
+```text
+User sees role/path cards
+-> clicks a card
+-> card opens with a short preview OR routes to role detail page
+-> user enters full role page
+```
+
+MVP design can use accordion expansion on the landing page, but the desired product direction is dedicated role pages.
+
+Proposed route pattern:
+
+```text
+/campaign/the-crossing/role/car-scout
+/campaign/the-crossing/role/car-expert
+/campaign/the-crossing/role/connector
+/campaign/the-crossing/role/signal-booster
+/campaign/the-crossing/role/encourager
+/campaign/the-crossing/role/donor
+```
+
+## Path / Role Model
+
+### Role Naming
+
+Rename:
+
+```text
+Car Person
+```
+
+to one of:
+
+- Car Expert
+- Car Consultant
+- Car Advisor
+
+Current recommendation:
+
+```text
+Car Expert
+```
+
+Reason:
+
+It is clearer and more immediately legible than "Car Person." It signals practical expertise without sounding too formal.
+
+### Roles
+
+The current six role paths remain:
+
+- Car Scout
+- Car Expert
+- Connector
+- Signal Booster
+- Encourager
+- Donor
+
+Open design question:
+
+The user said "all 4 options need to be listed." This likely refers to the four allyship domains:
+
+- Gather Resources
+- Raise Awareness
+- Direct Action
+- Skillful Organizing
+
+Design recommendation:
+
+Use four domain gates as the first organizing layer, then show the campaign-specific role paths within them.
+
+Example:
+
+```text
+Gather Resources
+-> Car Scout
+-> Connector
+-> Donor
+
+Skillful Organizing
+-> Car Expert
+
+Raise Awareness
+-> Signal Booster
+
+Direct Action
+-> Encourager
+```
+
+This lets the experience honor the four-domain BARS structure while still giving people plain-language campaign roles.
+
+## Card Logic
+
+All path cards should use the same design logic as:
+
+- BAR cards
+- Allyship Deck cards
+
+Each card should include:
+
+- Role name
+- Allyship domain
+- Tiny move
+- Artifact created
+- One sentence of impact
+- Starter Allyship Deck card or cards
+
+Each card should feel playable.
+
+Avoid:
+
+- form-first layouts
+- generic web cards
+- long descriptions
+- "submit" as the first action
+
+## Role Detail Pages
+
+Each role page should answer:
+
+```text
+What is this role?
+Why does it matter?
+What moves can I make?
+What should I do now?
+How do I save this contribution?
+```
+
+Each role page should include:
+
+- Role overview
+- Related Allyship Deck moves/cards
+- Concrete examples
+- One primary next action
+- Optional "save this as a BAR" / sign up for BARS Engine CTA
+- Link to Superpower Quiz if the person does not know their role yet
+
+### Allyship Deck Integration
+
+Each role page should display relevant moves from the Allyship Deck.
+
+Examples from the current role model:
+
+Car Scout:
+
+- `OPEN-GR-ARCHITECT`
+- `WAKE-SO-ARCHITECT`
+
+Car Expert:
+
+- `SHOW-SO-ARCHITECT`
+- `WAKE-DA-CHALLENGER`
+
+Connector:
+
+- `WAKE-GR-DIPLOMAT`
+- `SHOW-GR-DIPLOMAT`
+
+Signal Booster:
+
+- `SHOW-RA-DIPLOMAT`
+- `SHOW-RA-SAGE`
+
+Encourager:
+
+- `SHOW-DA-REGENT`
+- `OPEN-GR-DIPLOMAT`
+
+Donor:
+
+- `WAKE-GR-DIPLOMAT`
+- `SHOW-GR-ARCHITECT`
+
+### Superpower Quiz Link
+
+Each role page should include a soft fallback:
+
+```text
+Not sure this is your role?
+Take the Superpower Quiz.
+```
+
+Purpose:
+
+Help uncertain visitors self-identify without making the page feel like a personality quiz.
+
+Design note:
+
+This should be secondary to choosing a role, not the primary CTA.
+
+### BARS Engine Signup
+
+Role pages should invite people to sign up for BARS Engine so their contributions can be saved.
+
+Suggested CTA language:
+
+```text
+Save this contribution
+```
+
+or:
+
+```text
+Create your BARS Engine account to track your support
+```
+
+Avoid:
+
+```text
+Fill out this form
+```
+
+### Donor Path
+
+The Donor role needs a quick donation route.
+
+Required:
+
+- Fast Venmo CTA.
+- Optional note that donations of time, expertise, temporary transportation, tools, or space also count.
+
+Suggested CTA:
+
+```text
+Send Venmo
+```
+
+Secondary CTA:
+
+```text
+Offer another resource
+```
+
+The donor page should not make people navigate through an account flow before giving money.
+
+## Navigation Model
+
+Recommended page flow:
+
+```text
+/campaign/the-crossing
+-> /campaign/the-crossing/story
+-> /campaign/the-crossing/role/[role]
+-> Superpower Quiz
+-> BARS Engine signup
+```
+
+The landing page should remain easy to share on Facebook/Instagram.
+
+## Copy Changes From Current MVP
+
+Remove from user-facing page:
+
+```text
+The Crossing is the community route into this ask: people already in Wendell’s field helping raise the barn together.
+```
+
+Replace with:
+
+```text
+Every kind of help moves this forward.
+Choose the path that fits what you can actually offer.
+```
+
+Rename:
+
+```text
+How to Contribute
+```
+
+to:
+
+```text
+How To Play
+```
+
+Replace form-first CTAs with path CTAs:
+
+- Explore Car Scout
+- Explore Car Expert
+- Explore Connector
+- Explore Signal Booster
+- Explore Encourager
+- Give or Offer Resources
+
+## Visual Direction
+
+The design should feel like:
+
+- campaign map
+- role selection screen
+- deck draw
+- small adventure portal
+
+Not like:
+
+- intake form
+- generic donation page
+- CRM lead capture
+- marketing landing page
+
+Possible visual metaphors:
+
+- six cards on a campaign board
+- four domain gates with role cards beneath
+- choose-your-path adventure spread
+- "draw your move" interaction
+
+## Mobile Requirements
+
+Mobile is likely the primary share surface from Facebook/Instagram.
+
+Requirements:
+
+- Hero CTA visible without needing to understand the whole page.
+- Role/path cards readable as tappable choices.
+- No text overflow.
+- No horizontal scrolling.
+- Role pages should be short and scannable.
+- Venmo path should be one tap from Donor page.
+
+## Open Questions For Wendell
+
+1. When you said "all 4 options," do you mean the four allyship domains, four main help paths, or something else?
+2. Should Car Person become Car Expert, Car Consultant, or Car Advisor?
+3. What is the exact Venmo link/handle to use for the Donor path?
+4. Where should the Superpower Quiz live today?
+5. Should role detail pages collect contact info immediately, or first invite people to take a move and then save it?
+6. What should be included in the full story page before this goes public?
+

--- a/.specify/specs/the-crossing-campaign-landing-page/plan.md
+++ b/.specify/specs/the-crossing-campaign-landing-page/plan.md
@@ -1,0 +1,73 @@
+# Plan: The Crossing Campaign Landing Page
+
+## Phase 1: Spec Kit
+
+Create focused implementation spec, plan, and tasks.
+
+## Phase 2: Static Role Model
+
+Add role definitions for:
+
+- Car Scout
+- Car Person
+- Connector
+- Signal Booster
+- Encourager
+- Donor
+
+Include domains, tiny moves, artifacts, CTA labels, starter cards, and boundary copy.
+
+## Phase 3: Public Page Surface
+
+Integrate the support section into `/campaign/[ref]` when `ref` is `the-crossing`.
+
+Render a static fallback page for `the-crossing` if no approved/live campaign record exists yet.
+
+## Phase 4: BAR Capture
+
+Add a public server action that:
+
+- validates role and basic form fields
+- resolves a steward player id
+- creates a `CustomBar`
+- stores contributor metadata and campaign lineage
+- redirects back to `/campaign/the-crossing?thanks=1`
+
+## Phase 5: Verification
+
+Run type/lint or targeted checks available locally.
+
+If a database is available, submit one test support BAR and verify the stored fields.
+
+## Phase 6: Design Handoff
+
+Capture the next design direction for Claude Design:
+
+- Turn the landing page into a choose-your-own-adventure role selection experience.
+- Move full story content to a separate story page.
+- Rename "How to Contribute" to "How To Play."
+- Replace form-first role cards with clickable role/path cards.
+- Add dedicated role detail pages with Allyship Deck moves.
+- Add Superpower Quiz and BARS Engine signup pathways.
+- Make Donor path support a fast Venmo action.
+
+## File Impacts
+
+- `src/lib/the-crossing-support-moves.ts`
+- `src/actions/the-crossing-support.ts`
+- `src/app/campaign/[ref]/page.tsx`
+- `src/app/campaign/[ref]/CampaignLanding.tsx`
+- `src/app/campaign/[ref]/TheCrossingSupportSection.tsx`
+- `.specify/specs/the-crossing-campaign-landing-page/DESIGN_HANDOFF.md`
+
+## Risks
+
+- No steward player exists in the connected DB.
+- Existing campaign route only exposes approved/live campaigns.
+- Support form creates follow-up burden before a steward inbox UI exists.
+
+## Mitigations
+
+- Use static fallback for `/campaign/the-crossing`.
+- Resolve steward id with explicit env override first.
+- Store support BARs as private campaign inbox records for EOD.

--- a/.specify/specs/the-crossing-campaign-landing-page/spec.md
+++ b/.specify/specs/the-crossing-campaign-landing-page/spec.md
@@ -1,0 +1,136 @@
+# Spec: The Crossing Campaign Landing Page
+
+## Status
+
+Implementation spec for the first public shareable slice.
+
+Current MVP status:
+
+```text
+Functionally useful, not experientially correct.
+```
+
+The next design pass should follow `DESIGN_HANDOFF.md` and shift the experience from form-first support intake to choose-your-own-adventure role selection.
+
+## Purpose
+
+Ship `/campaign/the-crossing` as the public campaign landing page for The Crossing car fundraiser.
+
+The page should let Wendell's existing community understand the ask, pick a useful support role, and submit help as a campaign-captured BAR.
+
+## Relationship to Existing Specs
+
+This implements the EOD slice of:
+
+- `.specify/specs/pick-your-move-invitation-surface/spec.md`
+- `The Library/06 Specs/Pick Your Move Invitation Surface Spec v0.1.md`
+
+## Campaign Lineage
+
+The Crossing is a subcampaign of:
+
+```text
+mtgoa-barn-raising
+```
+
+Meaning:
+
+- `mtgoa-barn-raising` is the community/homies route for people already in Wendell's field.
+- `allyship-book` is the newcomer/book route and is not the parent for this page.
+
+Every support BAR created from this page must include:
+
+```text
+campaignRef: the-crossing
+parentCampaignRef: mtgoa-barn-raising
+campaignLineage: [mtgoa-barn-raising, the-crossing]
+```
+
+## User Stories
+
+### P1: Understand The Ask
+
+As a visitor, I want to quickly understand that Wendell needs a reliable car and that this sits inside the larger launch + barn-raising field.
+
+Acceptance:
+
+- Page renders at `/campaign/the-crossing`.
+- Page includes a visible link back to `mtgoa-barn-raising`.
+- Page explains that help can be money, car leads, expertise, introductions, sharing, or encouragement.
+
+### P2: Pick A Useful Role
+
+As a supporter, I want to choose the role that fits my real capacity.
+
+Acceptance:
+
+- Page shows six role cards: Car Scout, Car Person, Connector, Signal Booster, Encourager, Donor.
+- Each role has a domain, tiny move, impact statement, and action prompt.
+- Non-money roles are visually first-class.
+
+### P3: Submit Help As A BAR
+
+As Wendell, I want every role submission to become campaign evidence instead of disappearing into DMs.
+
+Acceptance:
+
+- Submitting the form creates a `CustomBar`.
+- `CustomBar.campaignRef` is `the-crossing`.
+- `CustomBar.evidenceKind` is `support_intake`.
+- Metadata includes role, contributor details, starter card id, and parent lineage.
+- Submission does not require sign-in.
+
+## Data Contract
+
+Support submissions map to `CustomBar`:
+
+```ts
+{
+  creatorId: stewardPlayerId,
+  title: `[${roleLabel}] ${offerSummary}`,
+  description: details,
+  type: 'vibe',
+  reward: 0,
+  visibility: 'private',
+  status: 'active',
+  campaignRef: 'the-crossing',
+  allyshipDomain: role.primaryDomain,
+  moveType: 'show_up',
+  evidenceKind: 'support_intake',
+  contextLines: JSON.stringify({ contributorName, contributorContact, role, offerSummary, url }),
+  docQuestMetadata: JSON.stringify({ source, parentCampaignRef, campaignLineage, starterCardId, artifact }),
+  agentMetadata: JSON.stringify({ sourceType: 'campaign_support_intake' })
+}
+```
+
+## Steward Resolution
+
+Because `CustomBar.creatorId` is required, unauthenticated public submissions must be administratively owned by a steward.
+
+Resolution order:
+
+1. `THE_CROSSING_STEWARD_PLAYER_ID` env var, if valid.
+2. The Crossing campaign `createdById`, if a campaign exists.
+3. The `mtgoa-barn-raising` campaign `createdById`, if a campaign exists.
+4. Owner/steward membership on the `mtgoa-barn-raising` instance.
+5. First available player as a local/EOD fallback.
+
+The actual contributor remains stored in metadata.
+
+## Non-Goals
+
+- Full BARS Engine onboarding.
+- Account creation before submitting help.
+- New database tables.
+- Donation processor rewrite.
+- Final visual design. See `DESIGN_HANDOFF.md` for the intended design direction.
+- Public dashboard of support BARs.
+
+## Acceptance Criteria
+
+- `/campaign/the-crossing` renders even if the campaign record has not been created yet.
+- The page links to `/campaign/mtgoa-barn-raising`.
+- Role cards are usable on mobile.
+- Support form creates a real campaign-tagged `CustomBar`.
+- Created BAR carries `the-crossing` and `mtgoa-barn-raising` lineage.
+- Existing campaign pages continue to render normally.

--- a/.specify/specs/the-crossing-campaign-landing-page/tasks.md
+++ b/.specify/specs/the-crossing-campaign-landing-page/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: The Crossing Campaign Landing Page
+
+## Phase 1: Spec Kit
+
+- [x] Create `spec.md`.
+- [x] Create `plan.md`.
+- [x] Create `tasks.md`.
+
+## Phase 2: Role Definitions
+
+- [x] Create `src/lib/the-crossing-support-moves.ts`.
+- [x] Define campaign constants for `the-crossing` and `mtgoa-barn-raising`.
+- [x] Define six support roles.
+- [x] Export helper to validate role ids.
+
+## Phase 3: Landing Page
+
+- [x] Add The Crossing static fallback campaign data.
+- [x] Ensure `/campaign/the-crossing` renders without an approved DB campaign record.
+- [x] Add parent link to `/campaign/mtgoa-barn-raising`.
+- [x] Add support role section only for The Crossing.
+- [x] Preserve existing behavior for all other campaign pages.
+
+## Phase 4: BAR Capture
+
+- [x] Add `src/actions/the-crossing-support.ts`.
+- [x] Resolve steward player id.
+- [x] Validate submitted role.
+- [x] Create `CustomBar` with `campaignRef: "the-crossing"`.
+- [x] Store `parentCampaignRef: "mtgoa-barn-raising"` and `campaignLineage`.
+- [x] Redirect to success state.
+
+## Phase 5: Verification
+
+- [x] Run targeted static checks.
+- [x] Run Library index after spec changes.
+- [x] Confirm changed files.
+- [x] Verify `/campaign/the-crossing` renders in the browser.
+- [x] Verify mobile layout has no horizontal overflow at 390px.
+
+## Phase 6: Design Handoff
+
+- [x] Capture choose-your-own-adventure design direction.
+- [x] Capture story page requirement.
+- [x] Capture "How To Play" replacement for "How to Contribute."
+- [x] Capture role/path-card interaction model.
+- [x] Capture dedicated role detail page requirements.
+- [x] Capture Allyship Deck move integration.
+- [x] Capture Superpower Quiz and BARS Engine signup pathways.
+- [x] Capture Donor/Venmo requirement.
+- [x] Capture open questions for Wendell.

--- a/src/actions/the-crossing-support.ts
+++ b/src/actions/the-crossing-support.ts
@@ -1,0 +1,132 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { db } from '@/lib/db'
+import {
+  getTheCrossingSupportRole,
+  THE_CROSSING_CAMPAIGN_REF,
+  THE_CROSSING_PARENT_CAMPAIGN_REF,
+} from '@/lib/the-crossing-support-moves'
+
+const SOURCE = 'the_crossing_campaign_landing_page'
+
+function clean(value: FormDataEntryValue | null, max = 1000): string {
+  return String(value ?? '').trim().slice(0, max)
+}
+
+async function findStewardPlayerId(): Promise<string | null> {
+  const envPlayerId = process.env.THE_CROSSING_STEWARD_PLAYER_ID?.trim()
+  if (envPlayerId) {
+    const player = await db.player.findUnique({ where: { id: envPlayerId }, select: { id: true } })
+    if (player) return player.id
+  }
+
+  const crossingCampaign = await db.campaign.findFirst({
+    where: { slug: THE_CROSSING_CAMPAIGN_REF },
+    select: { createdById: true },
+  })
+  if (crossingCampaign?.createdById) return crossingCampaign.createdById
+
+  const parentCampaign = await db.campaign.findFirst({
+    where: { OR: [{ slug: THE_CROSSING_PARENT_CAMPAIGN_REF }, { instance: { campaignRef: THE_CROSSING_PARENT_CAMPAIGN_REF } }] },
+    select: { createdById: true },
+  })
+  if (parentCampaign?.createdById) return parentCampaign.createdById
+
+  const parentInstance = await db.instance.findFirst({
+    where: { OR: [{ slug: THE_CROSSING_PARENT_CAMPAIGN_REF }, { campaignRef: THE_CROSSING_PARENT_CAMPAIGN_REF }] },
+    select: { id: true },
+  })
+  if (parentInstance) {
+    const membership = await db.instanceMembership.findFirst({
+      where: {
+        instanceId: parentInstance.id,
+        roleKey: { in: ['owner', 'steward'] },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: { playerId: true },
+    })
+    if (membership?.playerId) return membership.playerId
+  }
+
+  const firstPlayer = await db.player.findFirst({
+    orderBy: { createdAt: 'asc' },
+    select: { id: true },
+  })
+  return firstPlayer?.id ?? null
+}
+
+export async function submitTheCrossingSupport(formData: FormData) {
+  const roleId = clean(formData.get('role'), 80)
+  const role = getTheCrossingSupportRole(roleId)
+  if (!role) redirect('/campaign/the-crossing?error=role')
+
+  const contributorName = clean(formData.get('name'), 120)
+  const contributorContact = clean(formData.get('contact'), 180)
+  const offerSummary = clean(formData.get('offerSummary'), 180)
+  const details = clean(formData.get('details'), 2400)
+  const url = clean(formData.get('url'), 500)
+
+  if (!contributorName || !contributorContact || !offerSummary) {
+    redirect(`/campaign/the-crossing?role=${encodeURIComponent(role.id)}&error=missing`)
+  }
+
+  const stewardPlayerId = await findStewardPlayerId()
+  if (!stewardPlayerId) {
+    redirect(`/campaign/the-crossing?role=${encodeURIComponent(role.id)}&error=steward`)
+  }
+
+  const starterCardId = role.starterCardIds[0] ?? null
+  const title = `[${role.label}] ${offerSummary}`
+
+  // Campaign-captured BAR: administratively steward-owned, semantically belonging
+  // to The Crossing campaign field via campaignRef + lineage metadata.
+  const bar = await db.customBar.create({
+    data: {
+      creatorId: stewardPlayerId,
+      title,
+      description: details || offerSummary,
+      type: 'vibe',
+      reward: 0,
+      visibility: 'private',
+      status: 'active',
+      inputs: '[]',
+      rootId: 'temp',
+      campaignRef: THE_CROSSING_CAMPAIGN_REF,
+      allyshipDomain: role.primaryDomain,
+      moveType: 'show_up',
+      evidenceKind: 'support_intake',
+      contextLines: JSON.stringify({
+        contributorName,
+        contributorContact,
+        role: role.id,
+        roleLabel: role.label,
+        offerSummary,
+        url: url || null,
+      }),
+      docQuestMetadata: JSON.stringify({
+        source: SOURCE,
+        parentCampaignRef: THE_CROSSING_PARENT_CAMPAIGN_REF,
+        campaignLineage: [THE_CROSSING_PARENT_CAMPAIGN_REF, THE_CROSSING_CAMPAIGN_REF],
+        artifact: role.artifact,
+        tinyMove: role.tinyMove,
+        starterCardId,
+        starterCardIds: role.starterCardIds,
+        secondaryDomains: role.secondaryDomains,
+      }),
+      agentMetadata: JSON.stringify({
+        sourceType: 'campaign_support_intake',
+        campaignRef: THE_CROSSING_CAMPAIGN_REF,
+        parentCampaignRef: THE_CROSSING_PARENT_CAMPAIGN_REF,
+      }),
+    },
+    select: { id: true },
+  })
+
+  await db.customBar.update({ where: { id: bar.id }, data: { rootId: bar.id } })
+
+  revalidatePath('/campaign/the-crossing')
+  redirect(`/campaign/the-crossing?thanks=1&role=${encodeURIComponent(role.id)}`)
+}
+

--- a/src/app/campaign/[ref]/CampaignLanding.tsx
+++ b/src/app/campaign/[ref]/CampaignLanding.tsx
@@ -3,8 +3,10 @@
 import Link from 'next/link'
 import type { CampaignPageData, VisitorStatus } from './page'
 import type { CampaignSkin } from '@/lib/ui/campaign-skin'
-import { buildSkinVars, resolveFontClass, DEFAULT_BG_GRADIENT } from '@/lib/ui/build-skin-vars'
+import { buildSkinVars, resolveFontClass } from '@/lib/ui/build-skin-vars'
 import { useCampaignSkin } from '@/lib/ui/campaign-skin-provider'
+import { THE_CROSSING_CAMPAIGN_REF } from '@/lib/the-crossing-support-moves'
+import { TheCrossingSupportSection } from './TheCrossingSupportSection'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -53,11 +55,13 @@ export function CampaignLanding({
   staticSkin,
   visitorStatus = 'unauthenticated',
   inviteToken,
+  supportStatus,
 }: {
   campaign: CampaignPageData
   staticSkin: CampaignSkin | null
   visitorStatus?: VisitorStatus
   inviteToken?: string | null
+  supportStatus?: { thanks?: boolean; error?: string | null; role?: string | null }
 }) {
   // Use campaign skin from provider (layout-level resolution) when available;
   // fall back to direct buildSkinVars for backward compatibility.
@@ -192,6 +196,13 @@ export function CampaignLanding({
               {campaign.storyBridgeCopy}
             </div>
           </section>
+        )}
+
+        {campaign.slug === THE_CROSSING_CAMPAIGN_REF && (
+          <TheCrossingSupportSection
+            thanksRole={supportStatus?.thanks ? supportStatus.role : null}
+            error={supportStatus?.error}
+          />
         )}
       </main>
 

--- a/src/app/campaign/[ref]/TheCrossingSupportSection.tsx
+++ b/src/app/campaign/[ref]/TheCrossingSupportSection.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import Link from 'next/link'
+import { submitTheCrossingSupport } from '@/actions/the-crossing-support'
+import {
+  THE_CROSSING_PARENT_CAMPAIGN_REF,
+  THE_CROSSING_PARENT_LABEL,
+  THE_CROSSING_SUPPORT_ROLES,
+  getTheCrossingSupportRole,
+} from '@/lib/the-crossing-support-moves'
+
+function domainLabel(domain: string): string {
+  const labels: Record<string, string> = {
+    GATHERING_RESOURCES: 'Gather Resources',
+    RAISE_AWARENESS: 'Raise Awareness',
+    DIRECT_ACTION: 'Direct Action',
+    SKILLFUL_ORGANIZING: 'Skillful Organizing',
+  }
+  return labels[domain] ?? domain
+}
+
+export function TheCrossingSupportSection({
+  thanksRole,
+  error,
+}: {
+  thanksRole?: string | null
+  error?: string | null
+}) {
+  const thankedRole = getTheCrossingSupportRole(thanksRole)
+  const errorCopy =
+    error === 'missing'
+      ? 'Add your name, contact, and a short summary so Wendell can follow up.'
+      : error === 'steward'
+        ? 'Support capture is not connected to a steward yet.'
+        : error === 'role'
+          ? 'Choose a support role before submitting.'
+          : null
+
+  return (
+    <section
+      className="space-y-8 border-t pt-8"
+      style={{ borderColor: 'var(--cs-border, rgba(200, 160, 255, 0.15))' }}
+    >
+      <div className="space-y-4">
+        <Link
+          href={`/campaign/${THE_CROSSING_PARENT_CAMPAIGN_REF}`}
+          className="inline-flex text-xs font-semibold uppercase tracking-wide transition-colors"
+          style={{ color: 'var(--cs-accent-1, #c8a0ff)' }}
+        >
+          Part of {THE_CROSSING_PARENT_LABEL}
+        </Link>
+
+        <div className="space-y-3">
+          <h2 className="text-2xl font-bold leading-tight text-[var(--cs-text-primary,#e8e6e0)]">
+            Want to help but not sure what your move is?
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-[var(--cs-text-secondary,#9090c0)]">
+            Pick the kind of help that feels natural. Money helps, and so do car leads,
+            introductions, signal boosts, judgment, and encouragement.
+          </p>
+        </div>
+
+        {thankedRole && (
+          <div
+            className="rounded-lg p-4 text-sm"
+            style={{
+              background: 'rgba(74, 222, 128, 0.12)',
+              border: '1px solid rgba(74, 222, 128, 0.28)',
+              color: 'var(--cs-text-primary,#e8e6e0)',
+            }}
+          >
+            Got it. Your {thankedRole.label} offer was captured for The Crossing.
+          </div>
+        )}
+
+        {errorCopy && (
+          <div
+            className="rounded-lg p-4 text-sm"
+            style={{
+              background: 'rgba(248, 113, 113, 0.12)',
+              border: '1px solid rgba(248, 113, 113, 0.28)',
+              color: 'var(--cs-text-primary,#e8e6e0)',
+            }}
+          >
+            {errorCopy}
+          </div>
+        )}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {THE_CROSSING_SUPPORT_ROLES.map((role) => (
+          <article
+            key={role.id}
+            className="flex min-h-[420px] flex-col justify-between rounded-lg p-5"
+            style={{
+              background: 'var(--cs-surface, rgba(10, 10, 40, 0.6))',
+              border: '1px solid var(--cs-border, rgba(200, 160, 255, 0.15))',
+            }}
+          >
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-2">
+                  <span
+                    className="rounded px-2 py-1 text-[11px] font-semibold uppercase"
+                    style={{
+                      color: 'var(--cs-accent-2, #00d4ff)',
+                      background: 'rgba(0, 212, 255, 0.1)',
+                    }}
+                  >
+                    {domainLabel(role.primaryDomain)}
+                  </span>
+                  {role.secondaryDomains.map((domain) => (
+                    <span
+                      key={domain}
+                      className="rounded px-2 py-1 text-[11px] font-semibold uppercase text-[var(--cs-text-muted,#6060a0)]"
+                      style={{ background: 'rgba(255,255,255,0.05)' }}
+                    >
+                      {domainLabel(domain)}
+                    </span>
+                  ))}
+                </div>
+                <h3 className="text-xl font-bold text-[var(--cs-text-primary,#e8e6e0)]">
+                  {role.label}
+                </h3>
+                <p className="text-sm leading-relaxed text-[var(--cs-text-secondary,#9090c0)]">
+                  {role.description}
+                </p>
+              </div>
+
+              <div className="space-y-3 text-sm">
+                <p className="text-[var(--cs-text-secondary,#9090c0)]">
+                  <span className="font-semibold text-[var(--cs-text-primary,#e8e6e0)]">
+                    Tiny move:
+                  </span>{' '}
+                  {role.tinyMove}
+                </p>
+                <p className="text-[var(--cs-text-secondary,#9090c0)]">
+                  <span className="font-semibold text-[var(--cs-text-primary,#e8e6e0)]">
+                    Impact:
+                  </span>{' '}
+                  {role.impact}
+                </p>
+                <p className="text-xs leading-relaxed text-[var(--cs-text-muted,#6060a0)]">
+                  {role.boundary}
+                </p>
+              </div>
+            </div>
+
+            <form action={submitTheCrossingSupport} className="mt-5 space-y-3">
+              <input type="hidden" name="role" value={role.id} />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1 text-xs font-medium text-[var(--cs-text-secondary,#9090c0)]">
+                  Name
+                  <input
+                    name="name"
+                    required
+                    className="w-full rounded border bg-transparent px-3 py-2 text-sm text-[var(--cs-text-primary,#e8e6e0)] outline-none"
+                    style={{ borderColor: 'var(--cs-border, rgba(200, 160, 255, 0.15))' }}
+                  />
+                </label>
+                <label className="space-y-1 text-xs font-medium text-[var(--cs-text-secondary,#9090c0)]">
+                  Contact
+                  <input
+                    name="contact"
+                    required
+                    placeholder="text, email, IG"
+                    className="w-full rounded border bg-transparent px-3 py-2 text-sm text-[var(--cs-text-primary,#e8e6e0)] outline-none"
+                    style={{ borderColor: 'var(--cs-border, rgba(200, 160, 255, 0.15))' }}
+                  />
+                </label>
+              </div>
+              <label className="block space-y-1 text-xs font-medium text-[var(--cs-text-secondary,#9090c0)]">
+                What are you offering?
+                <input
+                  name="offerSummary"
+                  required
+                  placeholder={role.artifact}
+                  className="w-full rounded border bg-transparent px-3 py-2 text-sm text-[var(--cs-text-primary,#e8e6e0)] outline-none"
+                  style={{ borderColor: 'var(--cs-border, rgba(200, 160, 255, 0.15))' }}
+                />
+              </label>
+              <label className="block space-y-1 text-xs font-medium text-[var(--cs-text-secondary,#9090c0)]">
+                Link or details
+                <textarea
+                  name="details"
+                  rows={3}
+                  placeholder="Add the listing, intro context, share plan, encouragement, or resource details."
+                  className="w-full resize-y rounded border bg-transparent px-3 py-2 text-sm text-[var(--cs-text-primary,#e8e6e0)] outline-none"
+                  style={{ borderColor: 'var(--cs-border, rgba(200, 160, 255, 0.15))' }}
+                />
+              </label>
+              <input name="url" type="url" className="hidden" tabIndex={-1} autoComplete="off" />
+              <button
+                type="submit"
+                className="w-full rounded-lg px-4 py-3 text-sm font-bold transition-transform hover:scale-[1.01] active:scale-[0.99]"
+                style={{
+                  background: 'var(--cs-cta-bg, #f0d000)',
+                  color: 'var(--cs-cta-text, #12124a)',
+                }}
+              >
+                {role.ctaLabel}
+              </button>
+            </form>
+          </article>
+        ))}
+      </div>
+
+      <div className="space-y-2 text-sm leading-relaxed text-[var(--cs-text-muted,#6060a0)]">
+        <p>
+          This is an early version of BARS Engine in the wild: care becomes a role, a role becomes
+          a move, and a move becomes evidence the campaign can follow up on.
+        </p>
+      </div>
+    </section>
+  )
+}
+

--- a/src/app/campaign/[ref]/layout.tsx
+++ b/src/app/campaign/[ref]/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { resolveCampaignPageSkin, toSerializableSkin } from '@/lib/ui/resolve-campaign-skin'
 import { CampaignSkinProvider } from '@/lib/ui/campaign-skin-provider'
+import { THE_CROSSING_CAMPAIGN_REF } from '@/lib/the-crossing-support-moves'
 
 /**
  * Campaign layout — resolves the campaign skin server-side and wraps
@@ -41,7 +42,8 @@ export default async function CampaignRefLayout({
 
   // Resolve campaign skin server-side (DB + static skin merge)
   // Returns null if campaign doesn't exist — child page handles notFound()
-  const resolvedSkin = await resolveCampaignPageSkin(slug)
+  const resolvedSkin =
+    slug === THE_CROSSING_CAMPAIGN_REF ? null : await resolveCampaignPageSkin(slug)
 
   // Convert to serializable form for client boundary crossing
   const serializedSkin = resolvedSkin ? toSerializableSkin(resolvedSkin) : null

--- a/src/app/campaign/[ref]/page.tsx
+++ b/src/app/campaign/[ref]/page.tsx
@@ -4,6 +4,10 @@ import { cookies } from 'next/headers'
 import { db } from '@/lib/db'
 import { getCampaignSkin } from '@/lib/ui/campaign-skin'
 import { CampaignLanding } from './CampaignLanding'
+import {
+  THE_CROSSING_CAMPAIGN_REF,
+  THE_CROSSING_PARENT_CAMPAIGN_REF,
+} from '@/lib/the-crossing-support-moves'
 
 /**
  * @page /campaign/:slug
@@ -34,6 +38,8 @@ export type CampaignPageData = {
   instanceName: string
   createdByName: string | null
   shareUrl: string | null
+  parentCampaignRef?: string | null
+  parentCampaignName?: string | null
   theme: {
     bgGradient: string | null
     bgDeep: string | null
@@ -108,6 +114,7 @@ async function getApprovedCampaign(slug: string): Promise<CampaignPageData | nul
     instanceId: campaign.instanceId,
     instanceName: campaign.instance.name,
     createdByName: campaign.createdBy.name,
+    shareUrl: campaign.shareUrl,
     theme: campaign.theme
       ? {
           bgGradient: campaign.theme.bgGradient,
@@ -124,12 +131,40 @@ async function getApprovedCampaign(slug: string): Promise<CampaignPageData | nul
   }
 }
 
+function getTheCrossingFallbackCampaign(slug: string): CampaignPageData | null {
+  if (slug !== THE_CROSSING_CAMPAIGN_REF) return null
+
+  return {
+    id: 'static-the-crossing',
+    slug: THE_CROSSING_CAMPAIGN_REF,
+    name: 'The Crossing Car Fundraiser',
+    description:
+      'A reliable car is the next practical bridge: getting Wendell back on the road while the Mastering the Game of Allyship launch + barn raising keeps moving.',
+    allyshipDomain: 'GATHERING_RESOURCES',
+    wakeUpContent:
+      'The car died at the exact moment the work is starting to gather real momentum. The fundraising side is moving, and now the next bottleneck is practical: find the actual car, reduce the risk, and keep the campaign in motion.',
+    showUpContent:
+      'You can help by sending car leads, evaluating listings, making warm introductions, sharing the ask, offering encouragement, donating money, or contributing time and resources.',
+    storyBridgeCopy: null,
+    startDate: null,
+    endDate: null,
+    instanceId: 'static-mtgoa-barn-raising',
+    instanceName: 'Mastering the Game of Allyship Launch + Barn Raising',
+    createdByName: 'Wendell Britt',
+    shareUrl: null,
+    parentCampaignRef: THE_CROSSING_PARENT_CAMPAIGN_REF,
+    parentCampaignName: 'Mastering the Game of Allyship Launch + Barn Raising',
+    theme: null,
+  }
+}
+
 export async function generateMetadata(props: {
   params: Promise<{ ref: string }>
 }): Promise<Metadata> {
   const { ref } = await props.params
   const slug = decodeURIComponent(ref)
-  const campaign = await getApprovedCampaign(slug)
+  const campaign =
+    getTheCrossingFallbackCampaign(slug) ?? (await getApprovedCampaign(slug))
 
   if (!campaign) {
     return { title: 'Campaign Not Found' }
@@ -185,12 +220,13 @@ async function resolveVisitorStatus(
 
 export default async function CampaignPage(props: {
   params: Promise<{ ref: string }>
-  searchParams: Promise<{ invite?: string }>
+  searchParams: Promise<{ invite?: string; thanks?: string; error?: string; role?: string }>
 }) {
   const { ref } = await props.params
-  const { invite: inviteToken } = await props.searchParams
+  const { invite: inviteToken, thanks, error, role } = await props.searchParams
   const slug = decodeURIComponent(ref)
-  const campaign = await getApprovedCampaign(slug)
+  const campaign =
+    getTheCrossingFallbackCampaign(slug) ?? (await getApprovedCampaign(slug))
 
   if (!campaign) {
     notFound()
@@ -208,6 +244,7 @@ export default async function CampaignPage(props: {
       staticSkin={staticSkin}
       visitorStatus={visitorStatus}
       inviteToken={inviteToken}
+      supportStatus={{ thanks: thanks === '1', error: error ?? null, role: role ?? null }}
     />
   )
 }

--- a/src/app/campaign/[ref]/page.tsx
+++ b/src/app/campaign/[ref]/page.tsx
@@ -114,7 +114,6 @@ async function getApprovedCampaign(slug: string): Promise<CampaignPageData | nul
     instanceId: campaign.instanceId,
     instanceName: campaign.instance.name,
     createdByName: campaign.createdBy.name,
-    shareUrl: campaign.shareUrl,
     theme: campaign.theme
       ? {
           bgGradient: campaign.theme.bgGradient,

--- a/src/lib/the-crossing-support-moves.ts
+++ b/src/lib/the-crossing-support-moves.ts
@@ -1,0 +1,120 @@
+export const THE_CROSSING_CAMPAIGN_REF = 'the-crossing'
+export const THE_CROSSING_PARENT_CAMPAIGN_REF = 'mtgoa-barn-raising'
+export const THE_CROSSING_PARENT_LABEL = 'Mastering the Game of Allyship Launch + Barn Raising'
+
+export type TheCrossingSupportRoleId =
+  | 'car_scout'
+  | 'car_person'
+  | 'connector'
+  | 'signal_booster'
+  | 'encourager'
+  | 'donor'
+
+export type AllyshipDomain =
+  | 'GATHERING_RESOURCES'
+  | 'RAISE_AWARENESS'
+  | 'DIRECT_ACTION'
+  | 'SKILLFUL_ORGANIZING'
+
+export type TheCrossingSupportRole = {
+  id: TheCrossingSupportRoleId
+  label: string
+  primaryDomain: AllyshipDomain
+  secondaryDomains: AllyshipDomain[]
+  description: string
+  boundary: string
+  tinyMove: string
+  impact: string
+  artifact: string
+  ctaLabel: string
+  starterCardIds: string[]
+}
+
+export const THE_CROSSING_SUPPORT_ROLES: readonly TheCrossingSupportRole[] = [
+  {
+    id: 'car_scout',
+    label: 'Car Scout',
+    primaryDomain: 'GATHERING_RESOURCES',
+    secondaryDomains: ['SKILLFUL_ORGANIZING'],
+    description: 'Find viable cars, listings, and vehicle paths.',
+    boundary: 'Use this when you found a car or vehicle lead.',
+    tinyMove: 'Send one promising car listing.',
+    impact: 'Turns the open field into concrete options.',
+    artifact: 'Listing lead',
+    ctaLabel: 'Send a car lead',
+    starterCardIds: ['OPEN-GR-ARCHITECT', 'WAKE-SO-ARCHITECT'],
+  },
+  {
+    id: 'car_person',
+    label: 'Car Person',
+    primaryDomain: 'SKILLFUL_ORGANIZING',
+    secondaryDomains: ['DIRECT_ACTION'],
+    description: 'Evaluate listings, repairs, title risk, scams, and buying strategy.',
+    boundary: 'Use this when you know cars or can sanity-check a specific option.',
+    tinyMove: 'Sanity-check one listing.',
+    impact: 'Reduces risk and helps a good decision happen faster.',
+    artifact: 'Listing review',
+    ctaLabel: 'Offer car judgment',
+    starterCardIds: ['SHOW-SO-ARCHITECT', 'WAKE-DA-CHALLENGER'],
+  },
+  {
+    id: 'connector',
+    label: 'Connector',
+    primaryDomain: 'GATHERING_RESOURCES',
+    secondaryDomains: ['SKILLFUL_ORGANIZING'],
+    description: 'Make warm human introductions that unlock resources.',
+    boundary: 'Use this when you know a person who should talk to Wendell.',
+    tinyMove: 'Make one warm introduction.',
+    impact: 'Creates a person-to-person bridge that would not exist otherwise.',
+    artifact: 'Warm intro',
+    ctaLabel: 'Make an intro',
+    starterCardIds: ['WAKE-GR-DIPLOMAT', 'SHOW-GR-DIPLOMAT'],
+  },
+  {
+    id: 'signal_booster',
+    label: 'Signal Booster',
+    primaryDomain: 'RAISE_AWARENESS',
+    secondaryDomains: [],
+    description: 'Share the ask strategically with context.',
+    boundary: 'Use this when your useful move is reaching your people.',
+    tinyMove: 'Share the post with one sentence about why it matters.',
+    impact: 'Extends the campaign beyond Wendell’s immediate reach.',
+    artifact: 'Signal boost',
+    ctaLabel: 'Share the ask',
+    starterCardIds: ['SHOW-RA-DIPLOMAT', 'SHOW-RA-SAGE'],
+  },
+  {
+    id: 'encourager',
+    label: 'Encourager',
+    primaryDomain: 'DIRECT_ACTION',
+    secondaryDomains: ['GATHERING_RESOURCES'],
+    description: 'Reach out, reflect momentum, and encourage aligned action.',
+    boundary: 'Use this when your gift is helping the person stay in motion.',
+    tinyMove: 'Send one check-in or encouragement message.',
+    impact: 'Reduces isolation and keeps the next move alive.',
+    artifact: 'Encouragement note',
+    ctaLabel: 'Send encouragement',
+    starterCardIds: ['SHOW-DA-REGENT', 'OPEN-GR-DIPLOMAT'],
+  },
+  {
+    id: 'donor',
+    label: 'Donor',
+    primaryDomain: 'GATHERING_RESOURCES',
+    secondaryDomains: [],
+    description: 'Contribute money, time, expertise, space, temporary transportation, or resources.',
+    boundary: 'Use this when you can materially support the campaign.',
+    tinyMove: 'Donate, offer time, or share the donation link.',
+    impact: 'Adds real fuel to the car replacement effort.',
+    artifact: 'Contribution',
+    ctaLabel: 'Offer support',
+    starterCardIds: ['WAKE-GR-DIPLOMAT', 'SHOW-GR-ARCHITECT'],
+  },
+] as const
+
+export function getTheCrossingSupportRole(
+  roleId: string | null | undefined,
+): TheCrossingSupportRole | null {
+  if (!roleId) return null
+  return THE_CROSSING_SUPPORT_ROLES.find((role) => role.id === roleId) ?? null
+}
+


### PR DESCRIPTION
## Summary

Adds a clean The Crossing campaign landing-page slice plus design handoff material for Claude Design.

## What changed

- Adds the Pick Your Move invitation spec kit that defines campaign-captured BARs, support roles, and `mtgoa-barn-raising` lineage.
- Adds a focused The Crossing landing-page spec kit with a Claude Design handoff.
- Adds `/campaign/the-crossing` fallback content so the campaign page can render before the campaign DB record exists.
- Adds The Crossing support role definitions and role cards.
- Adds a support submission action that creates campaign-tagged `CustomBar` records with `campaignRef: the-crossing` and `parentCampaignRef: mtgoa-barn-raising`.

## Design handoff focus

The MVP page is intentionally marked as functionally useful but not experientially correct. The design handoff asks Claude Design to shift the experience from form-first intake into a choose-your-own-adventure role selection flow:

- Story preview links to a full story page.
- "How to Contribute" becomes "How To Play."
- Role cards become clickable path cards.
- Role detail pages expose relevant Allyship Deck moves.
- Visitors can use a Superpower Quiz if they are unsure of their role.
- Donors get a fast Venmo path.

## Validation

- Targeted ESLint passed for the changed app/action/lib files.
- `/campaign/the-crossing` rendered locally in browser verification.
- Mobile viewport check at 390px showed all six role cards and no horizontal overflow.

## Notes

Local BAR submission was not fully tested because the local dev server did not have `DATABASE_URL`; Vercel env pull required project linking and was not completed in this pass.