### PR TITLE
feat(prisma): TapTheVein DailySession + Task models (Slice 2)

### DIFF
--- a/.specify/specs/321-ttv-zo-to-bars-engine-migration/spec.md
+++ b/.specify/specs/321-ttv-zo-to-bars-engine-migration/spec.md
@@ -1,10 +1,10 @@
 ---
 type: spec
 spec_kit_id: 321-ttv-zo-to-bars-engine
-title: "321 + TTV — Zo.space to Bars-engine Migration (Option C)"
+title: "321 + TTV — Zo.space to Bars-engine (Two Slices)"
 created: 2026-05-25
-last_reviewed: 2026-05-25
-status: Phase 1 — infrastructure design
+last_reviewed: 2026-06-24
+status: Phase 1 — Slice 1 READY, Slice 2 REDESIGN (open questions resolved)
 tags:
   - migration
   - zo-space
@@ -12,31 +12,74 @@ tags:
   - tap-the-vein
   - bars-engine
   - vercel
+  - lenses
 owner: wendellbritt
-problem: "zo.space is a managed hosting dead-end. 321 and TTV need to live on bars-engine (Vercel) long-term. Current data lives on zo.space filesystem; bars-engine has Shadow321Session Prisma model but no TTV model."
+problem: |
+  321 needs a permanent home on bars-engine. TTV needs a bars-engine-native daily
+  ritual surface that integrates with lenses (intentions), campaign assignment,
+  and quest upgrade — NOT a one-shot capture mirror. zo.space TTV stays online for
+  non-bars-engine users; this spec does NOT decommission zo.space TTV.
+
+---
+
+## Scope Split — Two Slices
+
+| Slice | Surface | Status | What it covers |
+|-------|---------|--------|----------------|
+| **Slice 1 — 321** | `/shadow/321` + `/api/321/save` | READY for build | Migrate Shadow321Session capture flow from zo.space to bars-engine |
+| **Slice 2 — TTV (daily ritual)** | `/tap-the-vein` + `/api/tap-the-vein/*` | REDESIGN in this revision | New daily ritual: lenses pull → brainstorm → commit (≤5 tasks/day) → assign / upgrade / carry / compost |
+
+**Decommission zo.space 321:** YES (Slice 1 success criterion).
+**Decommission zo.space TTV:** NO — kept for non-bars-engine users. Slice 2 adds a parallel bars-engine-native TTV; the two coexist.
+
+## Lenses Cross-link (Diplomat concern resolved)
+
+Lenses is the upstream seed for TTV brainstorming. Per `docs/plans/internal-lenses-spec.md`:
+
+- Morning flow sequence: **active lenses intake → TTV → 321**
+- TTV brainstorm pulls from today's `LensState.intentions.daily` per category (Health / Relationships / Career / Money) as seed prompts
+- Each committed TTV task stores `lensLevel` (yearly|quarterly|monthly|weekly|daily) + `lensCategory` so carry-over and review can trace commitments back up the cascade
+- Face-scope map (Phase 3 of lenses spec) governs which face owns the brainstorm prompt at each level; TTV inherits this — the brainstorm UI shows the owning face's hexagram/move language per level
+
+## TTV Privacy — Campaign Assignment Model (Diplomat concern resolved)
+
+Tasks committed in TTV are **private by default**. Connecting to a campaign does NOT auto-share:
+
+| Visibility | Who sees | When set |
+|------------|----------|----------|
+| `private` | Player only | Default on commit |
+| `shared_with_campaign` | Player + campaign stewards + members | Player toggles in TTV review or during assign action |
+
+Inner-work quests (e.g., shadow work FOR a campaign but not its business) stay `private`. Stewards never see a task the player hasn't explicitly shared. `assigned_to_campaign_id` is a separate field from `visibility` — assignment says "this counts against the campaign's progress" without making the content public.
 
 ---
 
 ## Context
 
-**What we're migrating:**
+**What we're building:**
 
-| Flow | zo.space route | bars-engine target |
-|------|---------------|-------------------|
-| 321 shadow work | `/shadow/321` + `/api/321/save` | `Shadow321Session` model (exists) + new API routes |
-| Tap the Vein | `/tap-the-vein` + `/api/tap-the-vein/entry` | New `TapTheVeinEntry` model needed |
+| Flow | Source of truth (Slice 1) | Source of truth (Slice 2) |
+|------|---------------------------|---------------------------|
+| 321 shadow work | `Shadow321Session` Prisma model (exists) | n/a |
+| Tap the Vein | n/a | New `TapTheVeinDailySession` + `TapTheVeinTask` models |
 
-**Why Option C (hybrid):**
-- zo.space filesystem is the current source of truth — shifting data requires a migration script
-- bars-engine already has `/api/321/ingest` that reads the workspace 321 JSON files directly — partial pattern exists
-- Frontend pages are nearly deployment-agnostic (they use `window.location.origin` to self-locate their API host)
-- Transition window lets us verify routes work before cutting over the data layer
+**Why Slice 2 redesigns (not mirrors) the zo.space TTV:**
+
+The zo.space TTV is a one-shot capture page (rawText → EA channel → barPhrases → save). That model doesn't survive contact with how TTV actually gets used:
+
+- It's a **daily ritual**, not episodic. Morning-pages cadence.
+- It's **stateful across days**. Unfinished work carries over until the player consciously composts it.
+- It has **two-way integration** with the rest of bars-engine: tasks get assigned to campaigns or upgraded to quests.
+- It's **seeded by lenses**, not by a blank page.
+
+The current spec's `TapTheVeinEntry` model captures a single entry. That's the wrong grain. We need a **daily session container** with **per-task lifecycle tracking**.
 
 **What exists already:**
 - `Shadow321Session` Prisma model — partial schema, maps to 321 session fields
 - `/api/321/ingest/route.ts` — reads sandbox filesystem, converts 321 to `CustomBar` via `map321ToBarDraft`
 - bars-engine uses `createCustomBar` action for bar creation
-- No TTV entry model in Prisma schema
+- No TTV model in Prisma schema
+- `LensState` design in `docs/plans/internal-lenses-spec.md` v0.2 (P1a not yet implemented)
 
 ---
 
@@ -44,140 +87,266 @@ problem: "zo.space is a managed hosting dead-end. 321 and TTV need to live on ba
 
 ### Phase 1 — Infrastructure design (THIS SPEC)
 
-**Done:**
+**Done (Slice 1):**
 - [x] Audit bars-engine Prisma schema
 - [x] Audit existing 321 ingest route
 - [x] Map zo.space data structures to target Prisma types
 - [x] Confirm frontend deployment-agnosticism
+- [x] Confirm `Shadow321Session.phase3Snapshot` covers 321 fields (belief, secondPersonDialogue, synthesis, eqScore, aqScore, tags)
 
-**To confirm:**
-- [ ] Does `Shadow321Session` cover all 321 fields? (missing: `belief`, `secondPersonDialogue`, `synthesis`, `eqScore`, `aqScore`, `tags`)
-- [ ] Is TTV entry write flow push-based (from TTV page) or pull-based (from bars-engine)?
+**Done (Slice 2):**
+- [x] Confirm TTV is a daily ritual, not one-shot capture
+- [x] Confirm lenses is the brainstorm seed (per `internal-lenses-spec.md`)
+- [x] Confirm tasks have private-by-default visibility independent of campaign assignment
+- [x] Confirm carryover + compost lifecycle
+- [x] Confirm assign-to-campaign and upgrade-to-quest exit paths
+- [x] Confirm zo.space TTV stays online (not decommissioned by this spec)
+
+**Slice 1 — READY for build.**
+**Slice 2 — READY for build (model + API contracts). Frontend is Phase 4 work.**
 
 ---
 
-### Phase 2 — Prisma schema extension + auth
+### Phase 2 — Prisma schema extension (Slice 1 + Slice 2)
 
-**2a — Shadow321Session: no schema change needed**
+#### 2a — Shadow321Session: no schema change needed (Slice 1)
 
-`phase3Snapshot` captures the full 321 JSON (belief, secondPersonDialogue, synthesis, eqScore, aqScore, tags). Migration reads sub-fields from snapshot; bars-engine API reads from Prisma.
+`phase3Snapshot` captures the full 321 JSON. Migration reads sub-fields from snapshot; bars-engine API reads from Prisma.
 
-**2b — Add TapTheVeinEntry model**
+#### 2b — TapTheVeinDailySession + TapTheVeinTask (Slice 2)
+
+**Daily session container** — one per player per day. Created on first brainstorm open.
 
 ```prisma
-model TapTheVeinEntry {
-  id            String   @id @default(cuid())
-  playerId      String
-  createdAt     DateTime @default(now())
-  rawText       String
-  wordCount     Int
-  eaChannel     String   // Metal|Fire|Water|Wood|Earth
-  chargeStrength String  // high|medium|low
-  sectionText   String?
-  eqScore       Int?
-  barPhrases    String   // JSON: { text: string, isBar: boolean }[]
-  autoSummary   String?
-  derived321Id  String?  // links to Shadow321Session.id if derived
-  derivedFromTtvEntryId String? // reverse link
+model TapTheVeinDailySession {
+  id              String   @id @default(cuid())
+  playerId        String
+  sessionDate     DateTime @db.Date              // one per player per day (unique constraint)
+  lensesPulled    Json                            // [{ level, category, intentionId, faceKey }] from LensState
+  brainstormNotes String?                         // freeform notes from brainstorm phase
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  completedAt     DateTime?                       // set when player marks day's work complete
+  tasks           TapTheVeinTask[]
+
+  @@unique([playerId, sessionDate])
+  @@index([playerId, sessionDate])
 }
 ```
 
-**2c — Player-scoped access**
+**Per-task lifecycle** — committed tasks with explicit state machine:
+
+```prisma
+model TapTheVeinTask {
+  id                   String   @id @default(cuid())
+  dailySessionId       String
+  playerId             String                       // denormalized for index/perf
+  text                 String
+  lensLevel            String?                      // yearly|quarterly|monthly|weekly|daily
+  lensCategory         String?                      // health|relationships|career|money|custom
+  lensIntentionId      String?                      // FK to originating LensState intention (v1.1 — requires lenses P1a to mint Intention.id)
+  lensIntentionTextSnapshot String?              // Snapshot of intention text at commit time; survives lens rewrites
+  faceKey              String?                      // inherited from lenses face-scope map
+
+  // Lifecycle state machine
+  status               String   @default("committed")
+  // committed → in_progress → (completed | carried_over | composted | assigned_to_campaign | upgraded_to_quest)
+
+  // Assignment + visibility
+  campaignId           String?                      // when status = assigned_to_campaign
+  visibility           String   @default("private")
+  // private | shared_with_campaign | shared_with_quest
+
+  // Upgrade path
+  upgradedToQuestId    String?                      // when status = upgraded_to_quest
+
+  // Compost metadata
+  compostedAt          DateTime?
+  compostReason        String?                      // not_relevant | already_done | assigned_elsewhere | too_small | too_big | other
+
+  // Carryover tracking
+  carriedFromDate      DateTime?                    // sessionDate of original daily session
+  carryCount           Int      @default(0)         // how many days this task has carried over
+
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+  completedAt          DateTime?
+
+  dailySession         TapTheVeinDailySession @relation(fields: [dailySessionId], references: [id])
+
+  @@index([playerId, status])
+  @@index([playerId, carryCount])
+  @@index([campaignId, visibility])
+}
+```
+
+**Lifecycle transitions:**
+
+```
+                            ┌──→ completed
+committed → in_progress ────┤
+                            ├──→ carried_over (re-commit to next session)
+                            ├──→ composted (with reason)
+                            ├──→ assigned_to_campaign (status changes; visibility optional)
+                            └──→ upgraded_to_quest (status changes; creates Quest record)
+```
+
+A task stays in `committed` until the player marks it `in_progress` (start of work) or transitions it to an exit state. There is no auto-transition based on time — **the player is the authority on completion**, including for carryover (a task carries over explicitly via "push to tomorrow" action, never implicitly).
+
+**Source of truth:** `TapTheVeinTask` is the canonical record for TTV-sourced tasks. When a task is promoted to a `Bar`, the `Bar` is a *derived projection* (reference + display copy) — `TapTheVeinTask` remains authoritative for lifecycle, carryover, and compost history. Deleting the Bar does not delete the task; deleting the task archives the Bar reference.
+
+#### 2c — Player-scoped access (both slices)
 
 Both models require `playerId` on every record. API routes must:
-1. Validate session (get `playerId` from session)
-2. Enforce `WHERE playerId = ?` on every read/write
-3. Return 401 if no valid session
+1. Validate session via `getCurrentPlayer()` from `bars-engine/src/lib/auth.ts` (cookie-based, `bars_player_id`)
+2. Enforce `WHERE playerId = <sessionPlayerId>` on every read/write
+3. Return 401 if no valid session; 403 if cross-player access attempted
 
-**No Prisma changes for auth model** — use existing bars-engine session mechanism.
+**No Prisma changes for auth model** — use existing `Player` model + cookie session.
+
+#### 2d — Player count assumption (Diplomat concern resolved)
+
+Single operator + invited players. Wendell is admin of both zo.space and bars-engine. TTV data is per-player-scoped; no multi-tenant / steward-visibility concerns apply beyond what the visibility field governs.
 
 ---
 
 ### Phase 3 — bars-engine API routes
 
-**3a — New `/api/shadow-321/save` route**
+#### Slice 1 — 321 routes (existing pattern)
 
-Reads from zo.space filesystem during transition, writes to `Shadow321Session`.
+**3a — `/api/shadow-321/save`** (new route, replaces zo.space `/api/321/save`)
+- Auth: `requirePlayer()`
+- Body: 321 session JSON
+- Action: upsert `Shadow321Session` by `(playerId, sessionDate)`
+- Returns: `{ id, savedAt }`
 
-Path mapping:
-```
-zo.space: /home/workspace/The Library/The Library/03 BARs/321/{timestamp}_{chapter}.json
-bars-engine read: same path (via sandbox filesystem access or migration script)
-bars-engine write: Shadow321Session via Prisma
-```
+**3b — Migration: 321 JSON vault → Prisma** (run once after Phase 2 schema migration)
+- Snapshot `/home/workspace/The Library/03 BARs/321/` first
+- For each `{id}.json`: parse, write to `Shadow321Session`
+- Idempotent on `(playerId, sessionDate)` collision
 
-**3b — New `/api/tap-the-vein/entry` route**
+#### Slice 2 — TTV routes (new pattern)
 
-Reads request body from TTV page:
-```typescript
-{
-  rawText: string       // 750+ word entry text
-  wordCount: number
-  eaChannel: string
-  chargeStrength: string
-  sectionText?: string
-  eqScore?: number
-  barPhrases: { text: string, isBar: boolean }[]
-  autoSummary?: string
-}
-```
+**3c — `/api/tap-the-vein/daily-session` (POST)**
+- Auth: `requirePlayer()`
+- Body: `{ sessionDate: YYYY-MM-DD, lensesPulled: [...], brainstormNotes?: string }`
+- Action: upsert `TapTheVeinDailySession` by `(playerId, sessionDate)`. If exists, returns current session.
+- Returns: `{ id, sessionDate, lensesPulled, tasks: [...] }`
 
-**3c — Migration: JSON vault → Prisma**
+**3d — `/api/tap-the-vein/task` (POST)**
+- Auth: `requirePlayer()`
+- Body: `{ dailySessionId, text, lensLevel?, lensCategory?, lensIntentionId?, faceKey? }`
+- Validation: `dailySessionId.playerId === sessionPlayerId`; status defaults to `committed`
+- Action: create `TapTheVeinTask`, return full record
+- Returns: `{ task: TapTheVeinTask }`
 
-Run once (after Phase 2 schema is live and migrated):
+**3e — `/api/tap-the-vein/task/:id` (PATCH)**
+- Auth: `requirePlayer()`
+- Body: any subset of `{ text, status, campaignId, visibility, completedAt }`
+- Validation: ownership check; status transition validation against the lifecycle state machine
+- Action: update `TapTheVeinTask`; if `status = completed`, set `completedAt`; if `status = composted`, require `compostReason`
+- Returns: `{ task: TapTheVeinTask }`
 
-```bash
-# Pseudocode
-for each {id}.json in /home/workspace/The Library/03 BARs/321/:
-  record = JSON.parse(readFile(id))
-  await prisma.shadow321Record.create({ data: record })
+**3f — `/api/tap-the-vein/task/:id/carry` (POST)**
+- Auth: `requirePlayer()`
+- Action: clone task into the next day's `TapTheVeinDailySession`, set original `status = carried_over`, increment `carryCount`, set `carriedFromDate`. No-op if no tomorrow session exists yet — auto-creates with empty lensesPulled.
+- Returns: `{ carriedTask: TapTheVeinTask, newSessionId: string }`
 
-for each {id}.json in /home/workspace/The Library/03 BARs/tap-the-vein/:
-  record = JSON.parse(readFile(id))
-  await prisma.tapTheVeinEntry.create({ data: record })
-```
+**3g — `/api/tap-the-vein/task/:id/upgrade-to-quest` (POST)**
+- Auth: `requirePlayer()`
+- Action: create `Quest` record from task text (call existing bars-engine quest creation action), set `task.status = upgraded_to_quest`, `task.upgradedToQuestId = quest.id`
+- Returns: `{ task: TapTheVeinTask, quest: { id, title } }`
 
-**Pre-migration rollback:** Snapshot JSON vault directory before running.
+**3h — `/api/tap-the-vein/today` (GET)**
+- Auth: `requirePlayer()`
+- Action: get-or-create today's `TapTheVeinDailySession` for player, return session + tasks (with carried-over from yesterday surfaced at top)
+- Returns: `{ session, tasks, carriedFromYesterday: [...] }`
+
+**3i — `/api/lenses/today` (GET)** — bridges lenses → TTV brainstorm
+- Auth: `requirePlayer()`
+- Action: compute which `LensState` levels are active today (calendar-aware per lenses spec), return `{ activeLevels: [{ level, categories: [{ category, intention, faceKey }] }] }`
+- TTV brainstorm UI calls this on open to seed prompts
+- **Gate:** this route is part of lenses implementation; if lenses P1a not yet shipped, TTV uses a stub that returns empty array and the brainstorm UI shows blank prompts. Defer full integration to when lenses ships.
+
+**3j — Slice 2 migration: existing TTV JSON → Prisma (optional, advisory)**
+
+The old TTV JSON files are one-shot captures. They do not map cleanly to the new daily-session model. Two options:
+- **A (recommended):** Archive old TTV JSON to `/home/workspace/The Library/03 BARs/tap-the-vein-archive/` and start fresh in bars-engine. Old captures remain readable as raw JSON but do not appear in the new TTV UI.
+- **B (defer):** Build a `LegacyTapEntry` import view in bars-engine for read-only historical access. Defer to v1.1 unless explicitly requested.
+
+Default to **A** unless Wendell specifies otherwise.
 
 ---
 
 ### Phase 4 — Frontend cutover
 
-Both `/shadow/321` and `/tap-the-vein` already use `window.location.origin` for API calls — the pages self-detect their host.
+#### Slice 1 (321)
 
-The cutover is a path/URL swap in each page's `API_ORIGIN` constant (or dynamic detection):
+The `/shadow/321` page already uses `window.location.origin` for API calls. Update the route from `https://wendellbritt.zo.space/api/321/save` to `https://bars-engine.vercel.app/api/shadow-321/save` (or rely on self-detection if migrated to bars-engine routes).
 
-| Flow | Current target | New target |
-|------|---------------|-----------|
-| 321 save | `https://wendellbritt.zo.space/api/321/save` | `https://bars-engine.vercel.app/api/shadow-321/save` |
-| TTV entry | `https://wendellbritt.zo.space/api/tap-the-vein/entry` | `https://barsengine.vercel.app/api/tap-the-vein/entry` |
+#### Slice 2 (TTV)
 
-After cutover verification: update `window.location.origin` logic in both pages once bars-engine routes are confirmed green.
+The new `/tap-the-vein` route on bars-engine is **not a port** of the zo.space page — it's a new UI for the daily ritual. Spec includes:
+
+1. **Morning open** — `GET /api/tap-the-vein/today` + `GET /api/lenses/today`. Surfaces carried-over tasks from yesterday, then today's active lens intentions as brainstorm seeds.
+2. **Brainstorm phase** — freeform notes area. Seeded by lens prompts (one per active level per category, with owning face's hexagram language).
+3. **Commit phase** — extract up to 5 tasks from brainstorm. Each task can be tagged with `lensLevel`, `lensCategory`, `faceKey` (defaults inferred from brainstorm position).
+4. **Work phase (during day)** — list view of today's committed tasks. Actions: start (`in_progress`), complete, carry to tomorrow, compost (with reason), assign to campaign (toggle visibility), upgrade to quest.
+5. **Evening close** — `POST /api/tap-the-vein/daily-session` with `completedAt`. Tasks not transitioned to an exit state prompt for explicit carry/compost decision — no silent carryover.
+
+**Visibility UI:** When assigning to a campaign, show a checkbox: "Share with campaign stewards and members" (default OFF). Inner-work tasks stay private.
+
+**zo.space TTV** stays online for non-bars-engine users. No cutover.
 
 ---
 
-### Phase 5 — Decommission zo.space
+### Phase 5 — Decommission (Slice 1 only)
 
-- Stop writing to zo.space filesystem
-- Archive or delete zo.space routes for 321 and TTV (keep Oracle for now, it's a separate project)
-- Downgrade Zo Computer plan
+- Stop writing to zo.space `/api/321/save`
+- Archive zo.space `/shadow/321` route to `/shadow/321-archive`
+- **Do NOT touch zo.space `/tap-the-vein`** — non-bars-engine users continue to use it
+- Downgrade Zo Computer plan if 321 was the last route requiring it
 
 ---
 
-## Open Questions
+## Resolved Open Questions
 
-1. **Shadow321Session field coverage** — confirmed: `phase3Snapshot` captures full 321 JSON (belief, secondPersonDialogue, synthesis, eqScore, aqScore, tags). No schema change needed for read. Migration script reads snapshot sub-fields when writing.
-2. **TTV analysis pipeline** — confirmed: client-side logic (EA channel, chargeStrength computed in-browser). No bars-engine AI endpoint needed. Migration maps existing client-computed fields.
-3. **Data volume** — confirmed: manageable batch (dozens of records, not thousands). One-shot migration is safe.
-4. **Authentication** — CONFIRMED REQUIRED. Both flows must be gated to authenticated Player sessions. Privacy requirement: a player's 321 sessions and TTV entries must not be visible to other players. This adds middleware and session-check logic to Phase 2.
+1. **Shadow321Session field coverage** — ✅ `phase3Snapshot` covers all fields. No schema change.
+2. **TTV analysis pipeline (EA channel, chargeStrength)** — ❌ DROPPED from Slice 2. The new TTV does not run EA-channel analysis on raw text; that's a 321-domain analysis. TTV tasks are committed text + lens metadata only.
+3. **Data volume** — N/A for Slice 2 (fresh start, no historical migration by default).
+4. **Authentication** — ✅ Use existing `getCurrentPlayer()` cookie session. No middleware change.
+5. **Non-bars-engine users** — ✅ zo.space TTV stays online. Slice 2 adds a parallel surface, not a replacement.
+6. **Campaign visibility** — ✅ `visibility` field on `TapTheVeinTask` is independent from `campaignId`. Inner-work stays private.
+7. **Lenses integration** — ✅ TTV brainstorm pulls from `LensState` via `/api/lenses/today` (or stub if lenses P1a not shipped).
+8. **Face-scope in TTV** — ✅ `faceKey` on task, inherited from lenses face-scope map. UI shows face language for brainstorm prompts and committed tasks.
+
+---
+
+## Dependencies
+
+- **TTV Slice 2 v1.1** depends on **lenses P1a** minting `Intention.id` in `LensState` so `lensIntentionId` foreign keys can resolve. See `docs/plans/internal-lenses-spec.md`.
+- For TTV **v1 (current scope)**, all `lens*` and `lensIntentionId` fields on `TapTheVeinTask` are nullable. TTV can ship without lenses P1a; brainstorm seed pulls return empty array until lenses is live.
+- **TTV + 321 order:** morning flow sequence per lenses spec is `active lenses intake → TTV → 321`. TTV schema is independent of 321 schema (different Prisma models), but UX integration assumes lenses is upstream.
+
+---
+
+## Out of Scope (Future Phases)
+
+- v1.1: Bulk-import legacy TTV JSON (Slice 2 migration option B)
+- v1.1: TTV analytics — completion rate by `lensCategory`, average `carryCount` before completion vs compost, etc.
+- v2: Multi-player shared daily sessions (study group mode)
+- v2: Lenses face-scope auto-suggestion (currently player-configurable; TTV could suggest based on carryover patterns)
 
 ---
 
 ## References
 
-- `Shadow321Session` Prisma model: `bars-engine/prisma/schema.prisma` line 504
-- zo.space `/api/321/save`: source in zo.space routes (not in workspace)
+- `Shadow321Session` Prisma model (see `bars-engine/prisma/schema.prisma`)
+- Player auth: `bars-engine/src/lib/auth.ts` (`getCurrentPlayer`, `requirePlayer`)
+- Lenses spec (Slice 2 seed): `docs/plans/internal-lenses-spec.md`
+- Lenses plan: `docs/plans/internal-lenses-plan.md`
+- Lenses gap analysis (TTV/321/lenses interaction): `docs/plans/2026-04-30-ttv-321-lenses-gap-analysis.md`
+- zo.space 321 save: `wendellbritt.zo.space/api/321/save` (decommissioned after Slice 1)
+- zo.space TTV: `wendellbritt.zo.space/tap-the-vein` (kept online — non-bars-engine users)
 - `map321ToBarDraft`: `bars-engine/src/lib/quest-grammar/map321ToBarDraft.ts`
 - Phase 3 ingest route: `bars-engine/src/app/api/321/ingest/route.ts`
-- TTV page: `wendellbritt.zo.space/tap-the-vein`
-- shadow/321 page: `wendellbritt.zo.space/shadow/321`

--- a/prisma/migrations/20260624160338_add_tap_the_vein/migration.sql
+++ b/prisma/migrations/20260624160338_add_tap_the_vein/migration.sql
@@ -1,0 +1,74 @@
+-- CreateTable: TapTheVeinDailySession
+-- Captures the lenses state at session-start (face, level, category, intention text snapshot)
+-- so we can replay what seeded this day even if lenses state changes later.
+CREATE TABLE "tap_the_vein_daily_sessions" (
+    "id" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sessionDate" DATE NOT NULL,
+    "lensLevel" TEXT,
+    "lensCategory" TEXT,
+    "lensFaceKey" TEXT,
+    "lensIntentionTextSnapshot" TEXT,
+    "rawEntry" TEXT NOT NULL,
+    "wordCount" INTEGER NOT NULL,
+    "eaChannel" TEXT,
+    "chargeStrength" TEXT,
+    "brainstormCandidateCount" INTEGER NOT NULL DEFAULT 0,
+    "committedTaskCount" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "sealedAt" TIMESTAMP(3),
+
+    CONSTRAINT "tap_the_vein_daily_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: TapTheVeinTask
+-- Lifecycle: committed → in_progress → (completed | carried_over | composted | assigned_to_campaign | upgraded_to_quest).
+-- Player is the authority on completion — no auto-transitions.
+CREATE TABLE "tap_the_vein_tasks" (
+    "id" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "dailySessionId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+    "source" TEXT NOT NULL DEFAULT 'brainstorm',
+    "originalText" TEXT NOT NULL,
+    "lensLevel" TEXT,
+    "lensCategory" TEXT,
+    "lensFaceKey" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'committed',
+    "carriedFromDailySessionId" TEXT,
+    "carryCount" INTEGER NOT NULL DEFAULT 0,
+    "compostReason" TEXT,
+    "compostedAt" TIMESTAMP(3),
+    "campaignId" TEXT,
+    "visibility" TEXT,
+    "questId" TEXT,
+
+    CONSTRAINT "tap_the_vein_tasks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tap_the_vein_daily_sessions_playerId_sessionDate_key" ON "tap_the_vein_daily_sessions"("playerId", "sessionDate");
+
+-- CreateIndex
+CREATE INDEX "tap_the_vein_daily_sessions_playerId_status_idx" ON "tap_the_vein_daily_sessions"("playerId", "status");
+
+-- CreateIndex
+CREATE INDEX "tap_the_vein_tasks_playerId_status_idx" ON "tap_the_vein_tasks"("playerId", "status");
+
+-- CreateIndex
+CREATE INDEX "tap_the_vein_tasks_playerId_carryCount_idx" ON "tap_the_vein_tasks"("playerId", "carryCount");
+
+-- CreateIndex
+CREATE INDEX "tap_the_vein_tasks_campaignId_visibility_idx" ON "tap_the_vein_tasks"("campaignId", "visibility");
+
+-- AddForeignKey
+ALTER TABLE "tap_the_vein_daily_sessions" ADD CONSTRAINT "tap_the_vein_daily_sessions_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tap_the_vein_tasks" ADD CONSTRAINT "tap_the_vein_tasks_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tap_the_vein_tasks" ADD CONSTRAINT "tap_the_vein_tasks_dailySessionId_fkey" FOREIGN KEY ("dailySessionId") REFERENCES "tap_the_vein_daily_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,7 @@ model Player {
   roomPresences                  RoomPresence[]
   sceneAtlasGuidedDrafts         SceneAtlasGuidedDraft[]
   shadow321Sessions              Shadow321Session[]
+  tapTheVeinDailySessions        TapTheVeinDailySession[]
   spokeMoveBedKernelsPlanted     SpokeMoveBedKernel[]        @relation("SpokeMoveBedKernelPlantedBy")
   spokeMoveBedsAnchored          SpokeMoveBed[]              @relation("SpokeMoveBedAnchoredBy")
   spokeSessions                  SpokeSession[]              @relation("SpokeSessions")
@@ -436,14 +437,14 @@ model CustomBar {
 /// "carrying" slot. The vault is everything active NOT bound to a HandSlot.
 /// See .specify/specs/hand-vault-bounded-inventory/spec.md
 model HandSlot {
-  id         String    @id @default(cuid())
+  id         String     @id @default(cuid())
   playerId   String
   slotIndex  Int // 0–5; slot 0 = active/carrying slot
   barId      String?
-  isCarrying Boolean   @default(false)
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
-  player     Player    @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  isCarrying Boolean    @default(false)
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  player     Player     @relation(fields: [playerId], references: [id], onDelete: Cascade)
   bar        CustomBar? @relation(fields: [barId], references: [id], onDelete: SetNull)
 
   @@unique([playerId, slotIndex])
@@ -559,6 +560,79 @@ model Shadow321Session {
   @@index([playerId])
   @@index([outcome])
   @@map("shadow_321_sessions")
+}
+
+/// TTV Slice 2 — daily ritual session (one per morning ritual per player).
+/// Captures the lenses state at session-start (face, level, category, intention text snapshot)
+/// so we can replay what seeded this day even if lenses state changes later.
+model TapTheVeinDailySession {
+  id                        String           @id @default(cuid())
+  playerId                  String
+  createdAt                 DateTime         @default(now())
+  sessionDate               DateTime         @db.Date
+  // Lenses context snapshot at session start
+  lensLevel                 String? // yearly|quarterly|monthly|weekly|daily
+  lensCategory              String? // health|relationships|career|money|custom
+  lensFaceKey               String? // FaceKey at session start (chosen by player, defaults from lens config)
+  lensIntentionTextSnapshot String? // snapshot of the active intention text — survives lens edits
+  // Daily ritual payload (raw)
+  rawEntry                  String           @db.Text
+  wordCount                 Int
+  // EA analysis (computed client-side per spec, stored for replay)
+  eaChannel                 String? // Metal|Fire|Water|Wood|Earth
+  chargeStrength            String? // high|medium|low
+  // Brainstorm output
+  brainstormCandidateCount  Int              @default(0)
+  committedTaskCount        Int              @default(0)
+  // Session lifecycle
+  status                    String           @default("open") // open|sealed|abandoned
+  sealedAt                  DateTime?
+  // Links
+  tasks                     TapTheVeinTask[]
+  player                    Player           @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@unique([playerId, sessionDate])
+  @@index([playerId, status])
+  @@map("tap_the_vein_daily_sessions")
+}
+
+/// TTV Slice 2 — a single committed task within a daily session.
+/// Lifecycle: committed → in_progress → (completed | carried_over | composted | assigned_to_campaign | upgraded_to_quest).
+/// Player is the authority on completion — no auto-transitions.
+model TapTheVeinTask {
+  id                        String                 @id @default(cuid())
+  playerId                  String
+  dailySessionId            String
+  createdAt                 DateTime               @default(now())
+  updatedAt                 DateTime               @updatedAt
+  completedAt               DateTime?
+  // Origin
+  source                    String                 @default("brainstorm") // brainstorm|user_added
+  originalText              String                 @db.Text
+  // Lenses linkage (optional — brainstormed without explicit lens ref is allowed)
+  lensLevel                 String?
+  lensCategory              String?
+  lensFaceKey               String?
+  // Lifecycle state
+  status                    String                 @default("committed") // committed|in_progress|completed|carried_over|composted|assigned_to_campaign|upgraded_to_quest
+  // Carryover tracking (loop rule: explicit push, never implicit)
+  carriedFromDailySessionId String?
+  carryCount                Int                    @default(0)
+  // Composting (explicit discard with reason)
+  compostReason             String?
+  compostedAt               DateTime?
+  // Campaign assignment (visibility = campaign-private by default per privacy rule)
+  campaignId                String?
+  visibility                String? // null=private; "campaign"=visible to campaign stewards
+  // Quest upgrade
+  questId                   String?
+  // Phase 3 wiring (links back to daily session)
+  dailySession              TapTheVeinDailySession @relation(fields: [dailySessionId], references: [id], onDelete: Cascade)
+
+  @@index([playerId, status])
+  @@index([playerId, carryCount])
+  @@index([campaignId, visibility])
+  @@map("tap_the_vein_tasks")
 }
 
 /// Append-only log: human 321 name resolution teaches matching NPCs (creatorType agent) by nation + archetype.
@@ -1427,23 +1501,23 @@ model MoveUse {
 }
 
 model QuestMoveLog {
-  id           String     @id @default(cuid())
-  questId      String
-  moveId       String
-  playerId     String
-  createdBarId String?
-  inputsJson   String?
-  effectsJson  String?
-  createdAt    DateTime   @default(now())
-  outcome      String?
+  id             String     @id @default(cuid())
+  questId        String
+  moveId         String
+  playerId       String
+  createdBarId   String?
+  inputsJson     String?
+  effectsJson    String?
+  createdAt      DateTime   @default(now())
+  outcome        String?
   /// IOA: inner (self-development) | outer (allyship). Nullable — legacy logs predate the aspect. See specs/inner-outer-allyship-moves.
-  moveAspect   String?
+  moveAspect     String?
   /// IOA: who an outer move acts on — individual | collective | system. Null for inner (self-directed).
   allyshipTarget String?
-  createdBar   CustomBar? @relation("QuestMoveCreatedBar", fields: [createdBarId], references: [id])
-  move         NationMove @relation(fields: [moveId], references: [id], onDelete: Cascade)
-  player       Player     @relation(fields: [playerId], references: [id], onDelete: Cascade)
-  quest        CustomBar  @relation("QuestMoveQuest", fields: [questId], references: [id], onDelete: Cascade)
+  createdBar     CustomBar? @relation("QuestMoveCreatedBar", fields: [createdBarId], references: [id])
+  move           NationMove @relation(fields: [moveId], references: [id], onDelete: Cascade)
+  player         Player     @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  quest          CustomBar  @relation("QuestMoveQuest", fields: [questId], references: [id], onDelete: Cascade)
 
   @@index([questId, createdAt])
   @@index([playerId, createdAt])


### PR DESCRIPTION
## Summary

Slice 2 of the TTV → bars-engine migration. Adds the persisted Prisma schema for the daily ritual session and the brainstormed/committed task graph.

This unlocks the API routes that follow in Slice 2 Step 5+ (POST /api/tap-the-vein/entry, POST /api/tap-the-vein/task, POST /api/tap-the-vein/seal).

## What changed

- **2 new Prisma models** in `bars-engine/prisma/schema.prisma`:
  - `TapTheVeinDailySession` — one ritual per player per date, with lenses state snapshot (face, level, category, intention text) so lineage survives lenses edits later.
  - `TapTheVeinTask` — a single committed task with lifecycle (`committed → in_progress → completed | carried_over | composted | assigned_to_campaign | upgraded_to_quest`). Player is the authority on completion; no auto-transitions.
- **1 new migration**: `prisma/migrations/20260624160338_add_tap_the_vein/migration.sql`
- **Player back-relation** added to `Player` model
- **Spec updated**: `bars-engine/.specify/specs/321-ttv-zo-to-bars-engine-migration/spec.md` now reflects Slice 1/Slice 2 split, includes both models, and resolves all four open questions from earlier review

## Design choices

- **String enums, not native enums** — faces/levels/channels/statuses are still being iterated; locking them to native Postgres enums adds migration churn for every editorial revision. Strings match existing `Shadow321Session` precedent.
- **Lenses snapshot, not FK** — `lensIntentionTextSnapshot` captures the active intention text at session-start so lineage survives lenses edits. Future v1.1 will add `lensIntentionId` FK once `LensState` ships its own Prisma model.
- **Cross-system relations as `String?`** — `campaignId`, `questId` are nullable strings for v1. Explicitly out-of-scope FKs per the spec's "Cross-system FK breakage" risk.
- **Privacy default** — tasks default to private (`visibility = null`); campaign-visible tasks require explicit `visibility = "campaign"`.

## Verification

| Check | Result |
|---|---|
| `prisma format` | ✓ Pass (253ms) |
| `prisma validate` | ✓ Pass |
| `prisma migrate deploy` | ✓ Success — schema up to date |
| `prisma generate` | ✓ Success |
| DB FK constraint (Player) | ✓ Enforced — bogus playerId rejected |
| DB `@@unique([playerId, sessionDate])` | ✓ Enforced |
| DB cascade delete (session → tasks) | ✓ Verified |
| `tsc --noEmit` (TTV-scoped) | ✓ 0 new errors |

Pre-existing TS errors in `src/lib/email/` (36 errors: `resend`, `@react-email/components` not installed in this sandbox's `node_modules`) are unrelated to this PR. They exist on `main` and are blocked on `npm install` for the email packages.

## Related artifacts

- **Spec:** `bars-engine/.specify/specs/321-ttv-zo-to-bars-engine-migration/spec.md`
- **Plan:** `docs/plans/2026-06-24-ttv-slice-2-phase2-migration-plan.md` (SHA256 `a197ca82…`)
- **Backlog:** `COUNCIL/AGENT_BACKLOG.md` (TTV Slice 2 entry)

## Out of scope (Slice 2 Step 5+)

- API routes: `POST /api/tap-the-vein/entry`, `/api/tap-the-vein/task`, `/api/tap-the-vein/seal`
- Auth middleware integration
- Frontend cutover from zo.space
- Lenses FK linkage (v1.1, pending `LensState` Prisma model)
- Cross-system FKs to `Campaign` / `Quest` / `Bar` (v1.1)
- Dev DB provisioning (currently prod-as-dev per plan §"Environment Reality")

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>