### PR TITLE
Mobility Quest: make it discoverable in-app (campaign seed + nav)

### DIFF
--- a/scripts/seed-mobility-quest.ts
+++ b/scripts/seed-mobility-quest.ts
@@ -59,6 +59,22 @@ async function seed() {
   const creator = await db.player.findFirst()
   if (!creator) throw new Error('No player found for proposedByPlayerId — seed players first.')
 
+  const blurb =
+    'Gathering resources for an accessible vehicle — so the book tour can actually reach the people it’s for.'
+
+  // Instance + Campaign so /campaign/mobility-quest resolves and lens lookup works.
+  const instance = await db.instance.upsert({
+    where: { slug: CAMPAIGN_REF },
+    update: { name: 'Mobility Quest', campaignRef: CAMPAIGN_REF },
+    create: { slug: CAMPAIGN_REF, name: 'Mobility Quest', domainType: 'gathering_resources', campaignRef: CAMPAIGN_REF },
+  })
+  const campaign = await db.campaign.upsert({
+    where: { slug: CAMPAIGN_REF },
+    update: { name: 'Mobility Quest', status: 'LIVE', allyshipDomain: 'GATHERING_RESOURCES', description: blurb, instanceId: instance.id },
+    create: { slug: CAMPAIGN_REF, name: 'Mobility Quest', status: 'LIVE', allyshipDomain: 'GATHERING_RESOURCES', description: blurb, instanceId: instance.id, createdById: creator.id },
+  })
+  console.log(`✅ campaign ${campaign.slug} (instance ${instance.id})`)
+
   for (const m of MILESTONES) {
     await db.campaignMilestone.upsert({
       where: { id: m.id },

--- a/src/app/campaign/[ref]/home/CampaignHomeView.tsx
+++ b/src/app/campaign/[ref]/home/CampaignHomeView.tsx
@@ -165,6 +165,40 @@ export function CampaignHomeView({
         )}
       </main>
 
+      {/* ── Superpower discovery + scoped contribution ──────────────────── */}
+      <section className="px-6 sm:px-10 pb-2 max-w-2xl mx-auto w-full">
+        <h2
+          className="text-xs font-semibold uppercase tracking-[0.2em] mb-3"
+          style={{ color: 'var(--cs-text-secondary,#9090c0)' }}
+        >
+          Bring your superpower
+        </h2>
+        <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+          <Link
+            href={`/superpower?ref=${encodeURIComponent(data.campaign.slug)}`}
+            className="flex-1 py-3 px-5 rounded-xl text-sm font-medium transition-colors text-center"
+            style={{
+              background: 'var(--cs-cta-secondary-bg, rgba(200, 160, 255, 0.15))',
+              color: 'var(--cs-cta-secondary-text, #c8a0ff)',
+              border: '1px solid var(--cs-cta-secondary-border, rgba(200, 160, 255, 0.4))',
+            }}
+          >
+            Discover your superpower
+          </Link>
+          <Link
+            href={`/campaign/${encodeURIComponent(data.campaign.slug)}/needs`}
+            className="flex-1 py-3 px-5 rounded-xl text-sm font-medium transition-colors text-center"
+            style={{
+              background: 'var(--cs-cta-secondary-bg, rgba(200, 160, 255, 0.15))',
+              color: 'var(--cs-cta-secondary-text, #c8a0ff)',
+              border: '1px solid var(--cs-cta-secondary-border, rgba(200, 160, 255, 0.4))',
+            }}
+          >
+            Ways to help
+          </Link>
+        </div>
+      </section>
+
       {/* ── Footer navigation (thumb-first: nav in bottom zone) ─────────── */}
       <footer className="px-6 sm:px-10 py-6 max-w-2xl mx-auto w-full">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">


### PR DESCRIPTION
Follow-up to #135 — makes the merged superpower campaign reachable inside the app (it was direct-URL only).

## Changes
- **Real Campaign + Instance** — `seed-mobility-quest.ts` now upserts an `Instance` and a **LIVE `Campaign`** (slug `mobility-quest`, `GATHERING_RESOURCES`), so `/campaign/mobility-quest` resolves and the needs board's membership-lens lookup (`CampaignMembership.superpower`) works.
- **Campaign-home CTAs** — `CampaignHomeView` gains a "Bring your superpower" row: **Discover your superpower** → `/superpower?ref=<slug>` and **Ways to help** → `/campaign/<slug>/needs`, in the campaign-skin style.

## Run (DB env)
```bash
npm run db:migrate:deploy && npm run seed:mobility-quest   # now also seeds the Campaign/Instance
npm run dev   # join /campaign/mobility-quest → home shows the CTAs
```

## Verification
- `npm run check` (prisma generate + build-reliability + lint + tsc) → 0 errors; husky precommit passed.
- Superpower unit suites green (score / needs / card-view).
- Note: re-ran `npm ci` for new `main` deps (`resend`, `@react-email/components`) added by another merge — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cgVyjkRce17Cc5TopefTf)_