### PR TITLE
Add playable Inner Garden Chapter 1

### DIFF
--- a/.specify/specs/six-guide-calrunia-orientation/plan.md
+++ b/.specify/specs/six-guide-calrunia-orientation/plan.md
@@ -216,6 +216,7 @@ Implementation decisions:
 - Let a player start from either:
   - an existing eligible raw Hand/Vault BAR, or
   - a new "Call to Play" BAR created from the Chapter 1 form.
+- Provide three starter situations for first playtests so a player can try the loop without bringing private material or already knowing BAR capture.
 - Store all output in `CustomBar`.
 - Do not introduce campaign progress tables in v1.
 - Use `questSource: "inner_garden_chapter_1"` to distinguish Chapter 1 completions from generic Shaman runs.
@@ -226,6 +227,7 @@ Implementation decisions:
   - `moveType: "wakeUp"`
   - `sourceBarId` when a source BAR exists or is created
   - `agentMetadata` with signal, resistance, emotion, cultivation action, seed quality, harvested insight, and first move
+- Store optional playtest feedback in `agentMetadata` so the team can assess whether Chapter 1 felt clear and useful outside the app.
 - Link MTGOA Spoke I to `/inner-garden/chapter-1` so the public hub's first card opens the playable chapter instead of only a reading surface.
 
 Runtime files:
@@ -243,7 +245,9 @@ Acceptance criteria:
 
 - `/inner-garden/chapter-1` requires auth.
 - The page lists eligible raw Hand/Vault BARs and also supports creating a new Chapter 1 source BAR.
+- The page offers starter situations for first-time playtesters.
 - Completing the Chapter 1 form creates exactly one result BAR and, when needed, one source BAR.
 - The result BAR is linked to the source BAR, tagged as Shaman + Chapter 1, and includes the player's first outer-world move.
+- The result BAR preserves optional playtest feedback in `agentMetadata`.
 - MTGOA hub Spoke I points to the playable Inner Garden Chapter 1 route.
 - Pure tests prove the Chapter 1 metadata and BAR draft builders are stable.

--- a/.specify/specs/six-guide-calrunia-orientation/plan.md
+++ b/.specify/specs/six-guide-calrunia-orientation/plan.md
@@ -198,3 +198,52 @@ Acceptance criteria:
 - `/inner-garden/shaman?barId=...` rejects ineligible BARs.
 - Completing the Shaman form creates a new Vault BAR linked to the source.
 - Normal Pixi world traffic redirects to Inner Garden unless the prototype flag is enabled.
+
+## Phase 7 — Inner Garden Chapter 1: Answer The Call
+
+This phase turns the bridge into the first playable Mastering the Game of Allyship chapter.
+
+Product frame:
+
+- Chapter 1 is **The Call to Play / Answer the Call**.
+- It is a threshold ritual, not a lore reader.
+- It teaches the first allyship practice: notice the signal, name the charge/resistance, and choose one concrete first move.
+- It uses the Shaman loop because the first thing the player must learn is that charged inner material is playable, not disqualifying.
+
+Implementation decisions:
+
+- Add `/inner-garden/chapter-1` as the authenticated playable route.
+- Let a player start from either:
+  - an existing eligible raw Hand/Vault BAR, or
+  - a new "Call to Play" BAR created from the Chapter 1 form.
+- Store all output in `CustomBar`.
+- Do not introduce campaign progress tables in v1.
+- Use `questSource: "inner_garden_chapter_1"` to distinguish Chapter 1 completions from generic Shaman runs.
+- Set Chapter 1 result metadata:
+  - `gameMasterFace: "shaman"`
+  - `campaignRef: "mtgoa-chapter-1"`
+  - `allyshipDomain: "RAISE_AWARENESS"`
+  - `moveType: "wakeUp"`
+  - `sourceBarId` when a source BAR exists or is created
+  - `agentMetadata` with signal, resistance, emotion, cultivation action, seed quality, harvested insight, and first move
+- Link MTGOA Spoke I to `/inner-garden/chapter-1` so the public hub's first card opens the playable chapter instead of only a reading surface.
+
+Runtime files:
+
+```text
+src/lib/inner-garden/chapter-one.ts
+src/actions/inner-garden.ts
+src/app/inner-garden/page.tsx
+src/app/inner-garden/chapter-1/page.tsx
+src/lib/mastering-allyship/spoke-funnel-map.ts
+src/lib/inner-garden/__tests__/chapter-one.test.ts
+```
+
+Acceptance criteria:
+
+- `/inner-garden/chapter-1` requires auth.
+- The page lists eligible raw Hand/Vault BARs and also supports creating a new Chapter 1 source BAR.
+- Completing the Chapter 1 form creates exactly one result BAR and, when needed, one source BAR.
+- The result BAR is linked to the source BAR, tagged as Shaman + Chapter 1, and includes the player's first outer-world move.
+- MTGOA hub Spoke I points to the playable Inner Garden Chapter 1 route.
+- Pure tests prove the Chapter 1 metadata and BAR draft builders are stable.

--- a/.specify/specs/six-guide-calrunia-orientation/spec.md
+++ b/.specify/specs/six-guide-calrunia-orientation/spec.md
@@ -324,6 +324,12 @@ This does not require a full character sheet in the first slice, but the orienta
 
 **Acceptance**: I Ching output can identify visible/hidden forces, relevant sect discipline, and one outer-world move.
 
+### P5: I can play Chapter 1 inside Inner Garden
+
+**As a new Mastering the Game of Allyship player**, I want Chapter 1 to give me a short playable threshold ritual, so I can answer the call to allyship by naming what brought me here and choosing one real first move.
+
+**Acceptance**: `/inner-garden/chapter-1` lets an authenticated player either use an eligible raw Hand/Vault BAR or create a new "Call to Play" BAR, complete a Shaman-flavored cultivation step, and receive a linked result BAR in Vault with a concrete outer-world first move.
+
 ## Functional Requirements
 
 ### FR1: Define the orientation ladder
@@ -378,6 +384,18 @@ BAR capture and basic productivity must remain usable without Calrunian lore.
 
 No first-run experience should require players to understand nations, sects, hexagrams, or full Calrunian history before creating value.
 
+### FR8: Make Chapter 1 playable as an Inner Garden threshold
+
+The first playable Chapter 1 slice must:
+
+- use the MTGOA Chapter 1 frame: **Answer the Call / The Call to Play**
+- be Shaman-first but not require the player to know the six Guide system
+- accept an existing eligible raw BAR or create a new raw BAR from the player's call
+- ask for the signal, the resistance/charge, a harvested insight, and one immediate outer-world move
+- create the completed artifact as a new `CustomBar` result linked to its source BAR
+- tag the result with `gameMasterFace: "shaman"`, `questSource: "inner_garden_chapter_1"`, `campaignRef: "mtgoa-chapter-1"`, and `moveType: "wakeUp"`
+- avoid new tables in v1
+
 ## Non-Goals
 
 - Implement the Guide campaign UI in this spec.
@@ -394,6 +412,7 @@ No first-run experience should require players to understand nations, sects, hex
 - Lore depth is tied to player action and app capability.
 - Sects become legible as disciplines after nations/emotional terrain are established.
 - The I Ching has a clear role as a bridge artifact between outer-world problem, inner-world narrative data, and outer-world move.
+- A player can complete Chapter 1 inside Inner Garden and leave with a Vault BAR that names both an insight and a first real-world move.
 
 ## Open Questions
 

--- a/.specify/specs/six-guide-calrunia-orientation/spec.md
+++ b/.specify/specs/six-guide-calrunia-orientation/spec.md
@@ -330,6 +330,8 @@ This does not require a full character sheet in the first slice, but the orienta
 
 **Acceptance**: `/inner-garden/chapter-1` lets an authenticated player either use an eligible raw Hand/Vault BAR or create a new "Call to Play" BAR, complete a Shaman-flavored cultivation step, and receive a linked result BAR in Vault with a concrete outer-world first move.
 
+For first playtests, Chapter 1 must also offer starter situations so a new player can complete the loop without already understanding BAR capture. The result BAR should preserve optional playtest feedback so the team can learn whether the loop was clear and useful in outer-world terms.
+
 ## Functional Requirements
 
 ### FR1: Define the orientation ladder
@@ -391,9 +393,11 @@ The first playable Chapter 1 slice must:
 - use the MTGOA Chapter 1 frame: **Answer the Call / The Call to Play**
 - be Shaman-first but not require the player to know the six Guide system
 - accept an existing eligible raw BAR or create a new raw BAR from the player's call
+- offer starter situations for players who need a quick way into the chapter
 - ask for the signal, the resistance/charge, a harvested insight, and one immediate outer-world move
 - create the completed artifact as a new `CustomBar` result linked to its source BAR
 - tag the result with `gameMasterFace: "shaman"`, `questSource: "inner_garden_chapter_1"`, `campaignRef: "mtgoa-chapter-1"`, and `moveType: "wakeUp"`
+- store optional playtest feedback in `agentMetadata`
 - avoid new tables in v1
 
 ## Non-Goals

--- a/.specify/specs/six-guide-calrunia-orientation/tasks.md
+++ b/.specify/specs/six-guide-calrunia-orientation/tasks.md
@@ -49,6 +49,15 @@
 - [x] T28: Deprecate normal Pixi `/world/:instanceSlug/:roomSlug` runtime via redirect unless the prototype flag is enabled.
 - [x] T29: Add and run eligibility/bridge tests.
 
+## Inner Garden Chapter 1 Playable Slice
+
+- [x] T30: Add Phase 7 to `plan.md` defining Chapter 1 as the first playable Inner Garden threshold ritual.
+- [x] T31: Add pure Chapter 1 constants/builders for source BAR and result BAR metadata.
+- [x] T32: Extend Inner Garden server actions to complete Chapter 1 from an existing raw BAR or a newly named call.
+- [x] T33: Add authenticated `/inner-garden/chapter-1` route with eligible BAR selection and create-from-call flow.
+- [x] T34: Link MTGOA Spoke I to `/inner-garden/chapter-1`.
+- [x] T35: Add pure tests for Chapter 1 builders and run targeted verification.
+
 ## Acceptance Review
 
 - [ ] T19: Confirm the team can state the Calrunia portal rule in one sentence.

--- a/.specify/specs/six-guide-calrunia-orientation/tasks.md
+++ b/.specify/specs/six-guide-calrunia-orientation/tasks.md
@@ -57,6 +57,8 @@
 - [x] T33: Add authenticated `/inner-garden/chapter-1` route with eligible BAR selection and create-from-call flow.
 - [x] T34: Link MTGOA Spoke I to `/inner-garden/chapter-1`.
 - [x] T35: Add pure tests for Chapter 1 builders and run targeted verification.
+- [x] T36: Add three Chapter 1 starter situations for first-time playtesters who do not bring a raw BAR.
+- [x] T37: Capture optional Chapter 1 playtest feedback in result BAR metadata.
 
 ## Acceptance Review
 

--- a/src/actions/inner-garden.ts
+++ b/src/actions/inner-garden.ts
@@ -16,6 +16,12 @@ import {
   type InnerGardenBarCandidate,
   type InnerGardenEligibleBar,
 } from '@/lib/inner-garden/bridge'
+import {
+  buildChapterOneResultBarDraft,
+  buildChapterOneSourceBarDraft,
+  normalizeChapterOneText,
+  type ChapterOneDraft,
+} from '@/lib/inner-garden/chapter-one'
 
 type ErrorResult = { error: string }
 
@@ -199,3 +205,88 @@ export async function completeInnerGardenShamanRun(formData: FormData): Promise<
   redirect(`/bars/${result.id}?innerGarden=shaman`)
 }
 
+export async function completeInnerGardenChapterOneRun(formData: FormData): Promise<void> {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const sourceBarId = normalizeChapterOneText(formData.get('sourceBarId'), 120)
+  const draft: ChapterOneDraft = {
+    signal: normalizeChapterOneText(formData.get('signal')),
+    resistance: normalizeChapterOneText(formData.get('resistance')),
+    emotionId: normalizeChapterOneText(formData.get('emotionId'), 60),
+    seedQuality: normalizeSeedQuality(formData.get('seedQuality')),
+    cultivationAction: normalizeChapterOneText(formData.get('cultivationAction'), 120),
+    harvestedInsight: normalizeChapterOneText(formData.get('harvestedInsight')),
+    firstMove: normalizeChapterOneText(formData.get('firstMove')),
+  }
+
+  if (
+    draft.signal.length < 3 ||
+    draft.resistance.length < 3 ||
+    draft.emotionId.length < 2 ||
+    draft.cultivationAction.length < 3 ||
+    draft.harvestedInsight.length < 3 ||
+    draft.firstMove.length < 3
+  ) {
+    redirect('/inner-garden/chapter-1?error=missing')
+  }
+
+  let source: InnerGardenBarCandidate
+
+  if (sourceBarId) {
+    const sourceRaw = await findCandidateBar(sourceBarId)
+    if (!sourceRaw) redirect('/inner-garden/chapter-1?error=not-found')
+
+    const reason = getInnerGardenEligibilityReason(sourceRaw, player.id)
+    if (reason) redirect(`/inner-garden/chapter-1?error=${encodeURIComponent(reason)}`)
+
+    source = sourceRaw
+  } else {
+    const sourceDraft = buildChapterOneSourceBarDraft(draft)
+    const createdSource = await dbBase.customBar.create({
+      data: {
+        creatorId: player.id,
+        ...sourceDraft,
+      },
+      select: BAR_SELECT,
+    })
+    await dbBase.customBar.update({
+      where: { id: createdSource.id },
+      data: { rootId: createdSource.id },
+    })
+    source = createdSource
+  }
+
+  const resultDraft = buildChapterOneResultBarDraft({
+    sourceBarId: source.id,
+    sourceTitle: source.title,
+    sourceSeedMetabolization: source.seedMetabolization,
+    sourceNation: source.nation,
+    sourceIntensity: source.intensity,
+    draft,
+    completedAt: new Date().toISOString(),
+  })
+
+  const result = await dbBase.customBar.create({
+    data: {
+      creatorId: player.id,
+      ...resultDraft,
+    },
+    select: { id: true },
+  })
+
+  await dbBase.customBar.update({
+    where: { id: result.id },
+    data: { rootId: result.id },
+  })
+
+  revalidatePath('/inner-garden')
+  revalidatePath('/inner-garden/chapter-1')
+  revalidatePath('/mastering-allyship/hub')
+  revalidatePath('/bars/garden')
+  revalidatePath('/vault')
+  revalidatePath(`/bars/${source.id}`)
+  revalidatePath(`/bars/${result.id}`)
+
+  redirect(`/bars/${result.id}?innerGarden=chapter-1`)
+}

--- a/src/actions/inner-garden.ts
+++ b/src/actions/inner-garden.ts
@@ -19,6 +19,7 @@ import {
 import {
   buildChapterOneResultBarDraft,
   buildChapterOneSourceBarDraft,
+  findChapterOneStarterScenario,
   normalizeChapterOneText,
   type ChapterOneDraft,
 } from '@/lib/inner-garden/chapter-one'
@@ -47,6 +48,12 @@ const BAR_SELECT = {
 function asCandidate(bar: Awaited<ReturnType<typeof findCandidateBar>>): InnerGardenBarCandidate | null {
   if (!bar) return null
   return bar
+}
+
+function normalizeRating(value: FormDataEntryValue | null): number | null {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return null
+  return Math.min(5, Math.max(1, Math.round(parsed)))
 }
 
 async function findCandidateBar(barId: string) {
@@ -210,14 +217,20 @@ export async function completeInnerGardenChapterOneRun(formData: FormData): Prom
   if (!player) redirect('/login')
 
   const sourceBarId = normalizeChapterOneText(formData.get('sourceBarId'), 120)
+  const starterScenarioId = normalizeChapterOneText(formData.get('starterScenarioId'), 80)
+  const starterScenario = findChapterOneStarterScenario(starterScenarioId)
   const draft: ChapterOneDraft = {
-    signal: normalizeChapterOneText(formData.get('signal')),
-    resistance: normalizeChapterOneText(formData.get('resistance')),
+    signal: normalizeChapterOneText(formData.get('signal')) || starterScenario?.signal || '',
+    resistance: normalizeChapterOneText(formData.get('resistance')) || starterScenario?.resistance || '',
     emotionId: normalizeChapterOneText(formData.get('emotionId'), 60),
     seedQuality: normalizeSeedQuality(formData.get('seedQuality')),
     cultivationAction: normalizeChapterOneText(formData.get('cultivationAction'), 120),
     harvestedInsight: normalizeChapterOneText(formData.get('harvestedInsight')),
     firstMove: normalizeChapterOneText(formData.get('firstMove')),
+    starterScenarioId: starterScenario?.id,
+    usefulnessRating: normalizeRating(formData.get('usefulnessRating')),
+    clarityRating: normalizeRating(formData.get('clarityRating')),
+    confusingPart: normalizeChapterOneText(formData.get('confusingPart'), 600),
   }
 
   if (

--- a/src/app/inner-garden/chapter-1/page.tsx
+++ b/src/app/inner-garden/chapter-1/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { completeInnerGardenChapterOneRun, listInnerGardenEligibleBars } from '@/actions/inner-garden'
 import { getCurrentPlayer } from '@/lib/auth'
+import { CHAPTER_ONE_STARTER_SCENARIOS } from '@/lib/inner-garden/chapter-one'
 import type { InnerGardenEligibleBar } from '@/lib/inner-garden/bridge'
 
 const EMOTIONS = [
@@ -115,8 +116,8 @@ export default async function InnerGardenChapterOnePage({
                 Starting material
               </h2>
               <p className="mt-1 text-xs leading-relaxed text-zinc-600">
-                Use something raw you are already carrying, or let Chapter 1 create the source BAR
-                from the signal you name here.
+                Use something raw you are already carrying, choose a starter situation, or let
+                Chapter 1 create the source BAR from the signal you name here.
               </p>
             </div>
 
@@ -139,6 +140,61 @@ export default async function InnerGardenChapterOnePage({
               </div>
             </label>
 
+            <div className="space-y-3">
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                  Starter situations
+                </h3>
+                <p className="mt-1 text-xs leading-relaxed text-zinc-600">
+                  Pick one when you want to play quickly without bringing a private example first.
+                </p>
+              </div>
+              <label className="block cursor-pointer rounded-lg border border-zinc-800 bg-zinc-950/70 p-4 transition hover:border-emerald-700/70">
+                <div className="flex items-start gap-3">
+                  <input
+                    type="radio"
+                    name="starterScenarioId"
+                    value=""
+                    defaultChecked
+                    className="mt-1 accent-emerald-500"
+                    aria-label="Bring my own situation"
+                  />
+                  <span>
+                    <span className="block text-sm font-semibold text-zinc-100">
+                      Bring my own situation
+                    </span>
+                    <span className="mt-1 block text-xs leading-relaxed text-zinc-500">
+                      Use the signal and resistance fields to name what is alive for you.
+                    </span>
+                  </span>
+                </div>
+              </label>
+              {CHAPTER_ONE_STARTER_SCENARIOS.map((scenario) => (
+                <label
+                  key={scenario.id}
+                  className="block cursor-pointer rounded-lg border border-zinc-800 bg-zinc-950/70 p-4 transition hover:border-emerald-700/70"
+                >
+                  <div className="flex items-start gap-3">
+                    <input
+                      type="radio"
+                      name="starterScenarioId"
+                      value={scenario.id}
+                      className="mt-1 accent-emerald-500"
+                      aria-label={`Use starter situation: ${scenario.title}`}
+                    />
+                    <span>
+                      <span className="block text-sm font-semibold text-zinc-100">
+                        {scenario.title}
+                      </span>
+                      <span className="mt-1 block text-xs leading-relaxed text-zinc-500">
+                        {scenario.resistance}
+                      </span>
+                    </span>
+                  </div>
+                </label>
+              ))}
+            </div>
+
             {eligibleBars.length > 0 && (
               <div className="space-y-3">
                 {eligibleBars.map((bar) => (
@@ -153,10 +209,9 @@ export default async function InnerGardenChapterOnePage({
               <span className="block text-zinc-300">Signal</span>
               <textarea
                 name="signal"
-                required
                 minLength={3}
                 rows={3}
-                placeholder="What signal brought you to allyship work?"
+                placeholder="What signal brought you to allyship work? Leave blank if you chose a starter situation."
                 className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
               />
             </label>
@@ -165,10 +220,9 @@ export default async function InnerGardenChapterOnePage({
               <span className="block text-zinc-300">Charge or resistance</span>
               <textarea
                 name="resistance"
-                required
                 minLength={3}
                 rows={3}
-                placeholder="What part of this feels charged, tender, doubtful, or alive?"
+                placeholder="What part of this feels charged, tender, doubtful, or alive? Leave blank if you chose a starter situation."
                 className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
               />
             </label>
@@ -237,6 +291,50 @@ export default async function InnerGardenChapterOnePage({
                 minLength={3}
                 rows={3}
                 placeholder="What is one honest move you are willing to make now?"
+                className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+              />
+            </label>
+
+            <div className="grid gap-4 border-t border-zinc-900 pt-5 sm:grid-cols-2">
+              <label className="space-y-2 text-sm">
+                <span className="block text-zinc-300">Usefulness for real life</span>
+                <select
+                  name="usefulnessRating"
+                  defaultValue=""
+                  className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+                >
+                  <option value="">Skip</option>
+                  <option value="5">5 · immediately useful</option>
+                  <option value="4">4 · useful</option>
+                  <option value="3">3 · mixed</option>
+                  <option value="2">2 · not yet useful</option>
+                  <option value="1">1 · missed me</option>
+                </select>
+              </label>
+
+              <label className="space-y-2 text-sm">
+                <span className="block text-zinc-300">Clarity of the game loop</span>
+                <select
+                  name="clarityRating"
+                  defaultValue=""
+                  className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+                >
+                  <option value="">Skip</option>
+                  <option value="5">5 · very clear</option>
+                  <option value="4">4 · mostly clear</option>
+                  <option value="3">3 · uneven</option>
+                  <option value="2">2 · confusing</option>
+                  <option value="1">1 · lost</option>
+                </select>
+              </label>
+            </div>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">What was confusing?</span>
+              <textarea
+                name="confusingPart"
+                rows={2}
+                placeholder="Optional playtest note"
                 className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
               />
             </label>

--- a/src/app/inner-garden/chapter-1/page.tsx
+++ b/src/app/inner-garden/chapter-1/page.tsx
@@ -1,0 +1,260 @@
+/**
+ * @page /inner-garden/chapter-1
+ * @entity BAR
+ * @description Playable MTGOA Chapter 1 Inner Garden threshold: Answer the Call
+ * @permissions authenticated
+ * @searchParams error:string (optional)
+ * @relationships PLAYER (auth), BAR (optional source and returned Chapter 1 result)
+ * @dimensions WHO:player, WHAT:mtgoa_chapter_1, WHERE:inner_garden, ENERGY:call_to_play
+ * @example /inner-garden/chapter-1
+ * @agentDiscoverable true
+ */
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { completeInnerGardenChapterOneRun, listInnerGardenEligibleBars } from '@/actions/inner-garden'
+import { getCurrentPlayer } from '@/lib/auth'
+import type { InnerGardenEligibleBar } from '@/lib/inner-garden/bridge'
+
+const EMOTIONS = [
+  ['fear', 'Fear'],
+  ['anger', 'Anger'],
+  ['sadness', 'Sadness'],
+  ['joy', 'Joy'],
+  ['neutrality', 'Neutrality'],
+] as const
+
+const ACTIONS = [
+  ['name_the_charge', 'Name the charge'],
+  ['sit_with_seed', 'Sit with the seed'],
+  ['compost_projection', 'Compost projection'],
+  ['harvest_witness', 'Harvest witness'],
+] as const
+
+function SourceOption({ bar }: { bar: InnerGardenEligibleBar }) {
+  const location =
+    bar.location.kind === 'hand' ? `Hand slot ${bar.location.slotIndex + 1}` : 'Vault'
+
+  return (
+    <label className="block cursor-pointer rounded-lg border border-zinc-800 bg-zinc-950/70 p-4 transition hover:border-emerald-700/70">
+      <div className="flex items-start gap-3">
+        <input
+          type="radio"
+          name="sourceBarId"
+          value={bar.id}
+          className="mt-1 accent-emerald-500"
+          aria-label={`Use ${bar.title}`}
+        />
+        <span className="min-w-0">
+          <span className="mb-2 flex flex-wrap items-center gap-2">
+            <span className="rounded border border-zinc-800 px-2 py-0.5 text-[10px] uppercase tracking-wider text-zinc-500">
+              {location}
+            </span>
+            <span className="text-[10px] uppercase tracking-wider text-zinc-600">
+              raw {bar.type === 'charge_capture' ? 'charge' : 'BAR'}
+            </span>
+          </span>
+          <span className="block truncate text-sm font-semibold text-zinc-100">{bar.title}</span>
+          <span className="mt-1 line-clamp-2 block text-xs leading-relaxed text-zinc-500">
+            {bar.description}
+          </span>
+        </span>
+      </div>
+    </label>
+  )
+}
+
+export default async function InnerGardenChapterOnePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>
+}) {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const [{ error }, result] = await Promise.all([searchParams, listInnerGardenEligibleBars()])
+  if ('error' in result) redirect('/login')
+
+  const eligibleBars = [...result.hand, ...result.vault]
+
+  return (
+    <main className="min-h-screen bg-black px-4 py-8 text-zinc-200 sm:px-8">
+      <div className="mx-auto max-w-5xl space-y-8">
+        <header className="space-y-3">
+          <nav className="flex flex-wrap items-center gap-2 text-sm text-zinc-500">
+            <Link href="/inner-garden" className="transition hover:text-zinc-300">
+              Inner Garden
+            </Link>
+            <span>›</span>
+            <Link href="/mastering-allyship/hub" className="transition hover:text-zinc-300">
+              Mastering Allyship
+            </Link>
+          </nav>
+          <div className="max-w-3xl">
+            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-400">
+              Chapter 1 · Answer the Call
+            </p>
+            <h1 className="mt-2 text-3xl font-bold text-white">The Call to Play</h1>
+            <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+              You have already heard it: the signal that something could be better. Cross the
+              threshold by naming what brought you here, tending the charge around it, and choosing
+              one first move you can make outside the app.
+            </p>
+          </div>
+        </header>
+
+        {error && (
+          <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 p-3 text-sm text-amber-300">
+            Chapter 1 could not be completed: {error}.
+          </div>
+        )}
+
+        <form action={completeInnerGardenChapterOneRun} className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-300">
+                Starting material
+              </h2>
+              <p className="mt-1 text-xs leading-relaxed text-zinc-600">
+                Use something raw you are already carrying, or let Chapter 1 create the source BAR
+                from the signal you name here.
+              </p>
+            </div>
+
+            <label className="block cursor-pointer rounded-lg border border-emerald-900/60 bg-emerald-950/20 p-4">
+              <div className="flex items-start gap-3">
+                <input
+                  type="radio"
+                  name="sourceBarId"
+                  value=""
+                  defaultChecked
+                  className="mt-1 accent-emerald-500"
+                  aria-label="Create a new Chapter 1 source BAR"
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-emerald-100">Name a new call</span>
+                  <span className="mt-1 block text-xs leading-relaxed text-emerald-300/75">
+                    Chapter 1 will create the raw source BAR and the completed result BAR.
+                  </span>
+                </span>
+              </div>
+            </label>
+
+            {eligibleBars.length > 0 && (
+              <div className="space-y-3">
+                {eligibleBars.map((bar) => (
+                  <SourceOption key={bar.id} bar={bar} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-5 rounded-xl border border-zinc-800 bg-zinc-950/70 p-5">
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Signal</span>
+              <textarea
+                name="signal"
+                required
+                minLength={3}
+                rows={3}
+                placeholder="What signal brought you to allyship work?"
+                className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+              />
+            </label>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Charge or resistance</span>
+              <textarea
+                name="resistance"
+                required
+                minLength={3}
+                rows={3}
+                placeholder="What part of this feels charged, tender, doubtful, or alive?"
+                className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+              />
+            </label>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-2 text-sm">
+                <span className="block text-zinc-300">Seed emotion</span>
+                <select
+                  name="emotionId"
+                  defaultValue="fear"
+                  className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+                >
+                  {EMOTIONS.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-2 text-sm">
+                <span className="block text-zinc-300">Cultivation action</span>
+                <select
+                  name="cultivationAction"
+                  defaultValue="name_the_charge"
+                  className="w-full rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100"
+                >
+                  {ACTIONS.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Seed quality</span>
+              <input
+                name="seedQuality"
+                type="range"
+                min="1"
+                max="100"
+                defaultValue="60"
+                className="w-full accent-emerald-500"
+              />
+            </label>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">Harvested insight</span>
+              <textarea
+                name="harvestedInsight"
+                required
+                minLength={3}
+                rows={4}
+                placeholder="What becomes clearer when you tend the charge instead of carrying it alone?"
+                className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+              />
+            </label>
+
+            <label className="space-y-2 text-sm">
+              <span className="block text-zinc-300">First outer-world move</span>
+              <textarea
+                name="firstMove"
+                required
+                minLength={3}
+                rows={3}
+                placeholder="What is one honest move you are willing to make now?"
+                className="w-full resize-y rounded-lg border border-zinc-800 bg-black px-3 py-2 text-zinc-100 placeholder:text-zinc-700"
+              />
+            </label>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-zinc-900 pt-4">
+              <p className="max-w-md text-xs leading-relaxed text-zinc-600">
+                Completion saves a Chapter 1 Shaman BAR in your Vault and keeps the source traceable.
+              </p>
+              <button
+                type="submit"
+                className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-600"
+              >
+                Answer the call
+              </button>
+            </div>
+          </section>
+        </form>
+      </div>
+    </main>
+  )
+}

--- a/src/app/inner-garden/page.tsx
+++ b/src/app/inner-garden/page.tsx
@@ -89,6 +89,27 @@ export default async function InnerGardenPage({
           </div>
         )}
 
+        <section className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-5">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.2em] text-emerald-400">
+                Mastering Allyship · Chapter 1
+              </p>
+              <h2 className="mt-1 text-lg font-semibold text-emerald-50">Answer the Call</h2>
+              <p className="mt-1 max-w-2xl text-sm leading-relaxed text-emerald-200/70">
+                Begin the first playable Inner Garden chapter by naming the signal, tending the
+                charge, and choosing one outer-world move.
+              </p>
+            </div>
+            <Link
+              href="/inner-garden/chapter-1"
+              className="inline-flex shrink-0 items-center justify-center rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-600"
+            >
+              Play Chapter 1
+            </Link>
+          </div>
+        </section>
+
         {!hasAny ? (
           <section className="rounded-xl border border-dashed border-zinc-800 p-10 text-center">
             <h2 className="text-lg font-semibold text-zinc-200">No raw captures are ready</h2>
@@ -146,4 +167,3 @@ export default async function InnerGardenPage({
     </main>
   )
 }
-

--- a/src/lib/inner-garden/__tests__/chapter-one.test.ts
+++ b/src/lib/inner-garden/__tests__/chapter-one.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { parseSeedMetabolization, effectiveMaturity } from '@/lib/bar-seed-metabolization'
+import {
+  INNER_GARDEN_CHAPTER_ONE_SOURCE,
+  INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR,
+  MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN,
+  MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
+  MTGOA_CHAPTER_ONE_MOVE_TYPE,
+  buildChapterOneResultBarDraft,
+  buildChapterOneSourceBarDraft,
+} from '@/lib/inner-garden/chapter-one'
+
+const draft = {
+  signal: 'I keep noticing people talk around the actual problem.',
+  resistance: 'I am afraid naming it will make me difficult.',
+  emotionId: 'fear',
+  seedQuality: 72,
+  cultivationAction: 'name_the_charge',
+  harvestedInsight: 'The fear is asking for a cleaner question, not silence.',
+  firstMove: 'Ask one honest question in the planning thread.',
+}
+
+function testSourceDraft() {
+  const source = buildChapterOneSourceBarDraft(draft)
+  assert.equal(source.type, 'bar')
+  assert.equal(source.questSource, INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR)
+  assert.equal(source.campaignRef, MTGOA_CHAPTER_ONE_CAMPAIGN_REF)
+  assert.equal(source.allyshipDomain, MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN)
+  assert.equal(source.moveType, MTGOA_CHAPTER_ONE_MOVE_TYPE)
+  assert.equal(source.gameMasterFace, 'shaman')
+
+  const metadata = JSON.parse(source.agentMetadata)
+  assert.equal(metadata.chapter, 1)
+  assert.equal(metadata.signal, draft.signal)
+  assert.equal(metadata.resistance, draft.resistance)
+}
+
+function testResultDraft() {
+  const result = buildChapterOneResultBarDraft({
+    sourceBarId: 'bar_source',
+    sourceTitle: 'Call to Play: people talk around the problem',
+    sourceSeedMetabolization: null,
+    sourceNation: 'metal',
+    sourceIntensity: '4',
+    draft,
+    completedAt: '2026-06-24T00:00:00.000Z',
+  })
+
+  assert.equal(result.sourceBarId, 'bar_source')
+  assert.equal(result.questSource, INNER_GARDEN_CHAPTER_ONE_SOURCE)
+  assert.equal(result.campaignRef, MTGOA_CHAPTER_ONE_CAMPAIGN_REF)
+  assert.equal(result.allyshipDomain, MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN)
+  assert.equal(result.moveType, MTGOA_CHAPTER_ONE_MOVE_TYPE)
+  assert.equal(result.nation, 'metal')
+  assert.match(result.description, /First move: Ask one honest question/)
+
+  const metadata = JSON.parse(result.agentMetadata)
+  assert.equal(metadata.source, INNER_GARDEN_CHAPTER_ONE_SOURCE)
+  assert.equal(metadata.chapter, 1)
+  assert.equal(metadata.firstMove, draft.firstMove)
+  assert.equal(metadata.seedQuality, 72)
+
+  const parsed = parseSeedMetabolization(result.seedMetabolization)
+  assert.equal(effectiveMaturity(parsed), 'context_named')
+  assert.equal(parsed.contextNote, draft.harvestedInsight)
+}
+
+testSourceDraft()
+testResultDraft()
+
+console.log('inner-garden chapter one: BAR drafts OK')

--- a/src/lib/inner-garden/__tests__/chapter-one.test.ts
+++ b/src/lib/inner-garden/__tests__/chapter-one.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { parseSeedMetabolization, effectiveMaturity } from '@/lib/bar-seed-metabolization'
 import {
+  CHAPTER_ONE_STARTER_SCENARIOS,
   INNER_GARDEN_CHAPTER_ONE_SOURCE,
   INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR,
   MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN,
@@ -8,6 +9,7 @@ import {
   MTGOA_CHAPTER_ONE_MOVE_TYPE,
   buildChapterOneResultBarDraft,
   buildChapterOneSourceBarDraft,
+  findChapterOneStarterScenario,
 } from '@/lib/inner-garden/chapter-one'
 
 const draft = {
@@ -18,6 +20,10 @@ const draft = {
   cultivationAction: 'name_the_charge',
   harvestedInsight: 'The fear is asking for a cleaner question, not silence.',
   firstMove: 'Ask one honest question in the planning thread.',
+  starterScenarioId: 'stayed_quiet',
+  usefulnessRating: 5,
+  clarityRating: 4,
+  confusingPart: 'I wanted to know what seed quality changes later.',
 }
 
 function testSourceDraft() {
@@ -33,6 +39,7 @@ function testSourceDraft() {
   assert.equal(metadata.chapter, 1)
   assert.equal(metadata.signal, draft.signal)
   assert.equal(metadata.resistance, draft.resistance)
+  assert.equal(metadata.starterScenarioId, draft.starterScenarioId)
 }
 
 function testResultDraft() {
@@ -59,13 +66,26 @@ function testResultDraft() {
   assert.equal(metadata.chapter, 1)
   assert.equal(metadata.firstMove, draft.firstMove)
   assert.equal(metadata.seedQuality, 72)
+  assert.equal(metadata.starterScenarioId, draft.starterScenarioId)
+  assert.equal(metadata.playtestFeedback.usefulnessRating, 5)
+  assert.equal(metadata.playtestFeedback.clarityRating, 4)
+  assert.equal(metadata.playtestFeedback.confusingPart, draft.confusingPart)
 
   const parsed = parseSeedMetabolization(result.seedMetabolization)
   assert.equal(effectiveMaturity(parsed), 'context_named')
   assert.equal(parsed.contextNote, draft.harvestedInsight)
 }
 
+function testStarterScenarios() {
+  assert.equal(CHAPTER_ONE_STARTER_SCENARIOS.length, 3)
+  const scenario = findChapterOneStarterScenario('make_it_worse')
+  assert.ok(scenario)
+  assert.match(scenario.signal, /afraid/)
+  assert.equal(findChapterOneStarterScenario('missing'), null)
+}
+
 testSourceDraft()
 testResultDraft()
+testStarterScenarios()
 
 console.log('inner-garden chapter one: BAR drafts OK')

--- a/src/lib/inner-garden/chapter-one.ts
+++ b/src/lib/inner-garden/chapter-one.ts
@@ -1,0 +1,157 @@
+import { INNER_GARDEN_TO_BARS_SCHEMA_VERSION, buildShamanResultSeedMetabolization } from './bridge'
+
+export const INNER_GARDEN_CHAPTER_ONE_SOURCE = 'inner_garden_chapter_1'
+export const INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR = 'inner_garden_chapter_1_call'
+export const MTGOA_CHAPTER_ONE_CAMPAIGN_REF = 'mtgoa-chapter-1'
+export const MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN = 'RAISE_AWARENESS'
+export const MTGOA_CHAPTER_ONE_MOVE_TYPE = 'wakeUp'
+
+export type ChapterOneDraft = {
+  signal: string
+  resistance: string
+  emotionId: string
+  seedQuality: number
+  cultivationAction: string
+  harvestedInsight: string
+  firstMove: string
+}
+
+export type ChapterOneSourceBarDraft = {
+  title: string
+  description: string
+  type: 'bar'
+  reward: 0
+  visibility: 'private'
+  status: 'active'
+  inputs: '[]'
+  rootId: 'temp'
+  campaignRef: typeof MTGOA_CHAPTER_ONE_CAMPAIGN_REF
+  allyshipDomain: typeof MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN
+  moveType: typeof MTGOA_CHAPTER_ONE_MOVE_TYPE
+  gameMasterFace: 'shaman'
+  questSource: typeof INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR
+  agentMetadata: string
+}
+
+export type ChapterOneResultBarDraft = {
+  title: string
+  description: string
+  type: 'bar'
+  reward: 0
+  visibility: 'private'
+  status: 'active'
+  inputs: '[]'
+  rootId: 'temp'
+  sourceBarId: string
+  gameMasterFace: 'shaman'
+  questSource: typeof INNER_GARDEN_CHAPTER_ONE_SOURCE
+  campaignRef: typeof MTGOA_CHAPTER_ONE_CAMPAIGN_REF
+  allyshipDomain: typeof MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN
+  moveType: typeof MTGOA_CHAPTER_ONE_MOVE_TYPE
+  nation: string | null
+  intensity: string | null
+  seedMetabolization: string | null
+  agentMetadata: string
+}
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function truncate(value: string, max: number): string {
+  const clean = compactWhitespace(value)
+  if (clean.length <= max) return clean
+  return `${clean.slice(0, Math.max(0, max - 1)).trim()}...`
+}
+
+export function normalizeChapterOneText(value: FormDataEntryValue | null, max = 2000): string {
+  return String(value ?? '').trim().slice(0, max)
+}
+
+export function buildChapterOneSourceBarDraft(draft: Pick<ChapterOneDraft, 'signal' | 'resistance'>): ChapterOneSourceBarDraft {
+  const signal = draft.signal.trim()
+  const resistance = draft.resistance.trim()
+
+  return {
+    title: truncate(`Call to Play: ${signal}`, 80),
+    description: [`Signal: ${signal}`, `Charge or resistance: ${resistance}`].join('\n\n'),
+    type: 'bar',
+    reward: 0,
+    visibility: 'private',
+    status: 'active',
+    inputs: '[]',
+    rootId: 'temp',
+    campaignRef: MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
+    allyshipDomain: MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN,
+    moveType: MTGOA_CHAPTER_ONE_MOVE_TYPE,
+    gameMasterFace: 'shaman',
+    questSource: INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR,
+    agentMetadata: JSON.stringify({
+      schemaVersion: INNER_GARDEN_TO_BARS_SCHEMA_VERSION,
+      source: INNER_GARDEN_CHAPTER_ONE_SOURCE_BAR,
+      chapter: 1,
+      campaignRef: MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
+      signal,
+      resistance,
+    }),
+  }
+}
+
+export function buildChapterOneResultBarDraft(input: {
+  sourceBarId: string
+  sourceTitle: string
+  sourceSeedMetabolization: string | null | undefined
+  sourceNation: string | null
+  sourceIntensity: string | null
+  draft: ChapterOneDraft
+  completedAt: string
+}): ChapterOneResultBarDraft {
+  const signal = input.draft.signal.trim()
+  const resistance = input.draft.resistance.trim()
+  const harvestedInsight = input.draft.harvestedInsight.trim()
+  const firstMove = input.draft.firstMove.trim()
+
+  return {
+    title: truncate(`Chapter 1 answered: ${input.sourceTitle}`, 80),
+    description: [
+      `Signal: ${signal}`,
+      `Charge or resistance: ${resistance}`,
+      `Harvested insight: ${harvestedInsight}`,
+      `First move: ${firstMove}`,
+    ].join('\n\n'),
+    type: 'bar',
+    reward: 0,
+    visibility: 'private',
+    status: 'active',
+    inputs: '[]',
+    rootId: 'temp',
+    sourceBarId: input.sourceBarId,
+    gameMasterFace: 'shaman',
+    questSource: INNER_GARDEN_CHAPTER_ONE_SOURCE,
+    campaignRef: MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
+    allyshipDomain: MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN,
+    moveType: MTGOA_CHAPTER_ONE_MOVE_TYPE,
+    nation: input.sourceNation,
+    intensity: input.sourceIntensity,
+    seedMetabolization: buildShamanResultSeedMetabolization(
+      input.sourceSeedMetabolization,
+      harvestedInsight
+    ),
+    agentMetadata: JSON.stringify({
+      schemaVersion: INNER_GARDEN_TO_BARS_SCHEMA_VERSION,
+      source: INNER_GARDEN_CHAPTER_ONE_SOURCE,
+      chapter: 1,
+      campaignRef: MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
+      sourceBarId: input.sourceBarId,
+      guideFace: 'shaman',
+      signal,
+      resistance,
+      emotionId: input.draft.emotionId,
+      seedQuality: input.draft.seedQuality,
+      cultivationAction: input.draft.cultivationAction,
+      harvestedInsight,
+      firstMove,
+      completedAt: input.completedAt,
+    }),
+  }
+}

--- a/src/lib/inner-garden/chapter-one.ts
+++ b/src/lib/inner-garden/chapter-one.ts
@@ -6,6 +6,29 @@ export const MTGOA_CHAPTER_ONE_CAMPAIGN_REF = 'mtgoa-chapter-1'
 export const MTGOA_CHAPTER_ONE_ALLYSHIP_DOMAIN = 'RAISE_AWARENESS'
 export const MTGOA_CHAPTER_ONE_MOVE_TYPE = 'wakeUp'
 
+export const CHAPTER_ONE_STARTER_SCENARIOS = [
+  {
+    id: 'stayed_quiet',
+    title: 'I noticed something unfair but stayed quiet.',
+    signal: 'I noticed something unfair but stayed quiet.',
+    resistance: 'I was worried that naming it would make me difficult or derail the moment.',
+  },
+  {
+    id: 'dont_know_lane',
+    title: "I want to help but do not know my lane.",
+    signal: "I want to help in a situation that matters, but I am not sure what role is mine to play.",
+    resistance: 'I do not want to overstep, disappear, or make the moment about me.',
+  },
+  {
+    id: 'make_it_worse',
+    title: "I am worried I will make it worse.",
+    signal: 'I can feel a real invitation to act, but I am afraid my move could create more harm.',
+    resistance: 'The fear of making a mistake is pulling me toward silence.',
+  },
+] as const
+
+export type ChapterOneStarterScenarioId = (typeof CHAPTER_ONE_STARTER_SCENARIOS)[number]['id']
+
 export type ChapterOneDraft = {
   signal: string
   resistance: string
@@ -14,6 +37,10 @@ export type ChapterOneDraft = {
   cultivationAction: string
   harvestedInsight: string
   firstMove: string
+  starterScenarioId?: string
+  usefulnessRating?: number | null
+  clarityRating?: number | null
+  confusingPart?: string
 }
 
 export type ChapterOneSourceBarDraft = {
@@ -68,7 +95,13 @@ export function normalizeChapterOneText(value: FormDataEntryValue | null, max = 
   return String(value ?? '').trim().slice(0, max)
 }
 
-export function buildChapterOneSourceBarDraft(draft: Pick<ChapterOneDraft, 'signal' | 'resistance'>): ChapterOneSourceBarDraft {
+export function findChapterOneStarterScenario(id: string) {
+  return CHAPTER_ONE_STARTER_SCENARIOS.find((scenario) => scenario.id === id) ?? null
+}
+
+export function buildChapterOneSourceBarDraft(
+  draft: Pick<ChapterOneDraft, 'signal' | 'resistance' | 'starterScenarioId'>
+): ChapterOneSourceBarDraft {
   const signal = draft.signal.trim()
   const resistance = draft.resistance.trim()
 
@@ -93,6 +126,7 @@ export function buildChapterOneSourceBarDraft(draft: Pick<ChapterOneDraft, 'sign
       campaignRef: MTGOA_CHAPTER_ONE_CAMPAIGN_REF,
       signal,
       resistance,
+      starterScenarioId: draft.starterScenarioId,
     }),
   }
 }
@@ -151,6 +185,12 @@ export function buildChapterOneResultBarDraft(input: {
       cultivationAction: input.draft.cultivationAction,
       harvestedInsight,
       firstMove,
+      starterScenarioId: input.draft.starterScenarioId,
+      playtestFeedback: {
+        usefulnessRating: input.draft.usefulnessRating ?? null,
+        clarityRating: input.draft.clarityRating ?? null,
+        confusingPart: input.draft.confusingPart ?? '',
+      },
       completedAt: input.completedAt,
     }),
   }

--- a/src/lib/mastering-allyship/spoke-funnel-map.ts
+++ b/src/lib/mastering-allyship/spoke-funnel-map.ts
@@ -35,7 +35,7 @@ export const SPOKE_FUNNEL_MAP: readonly SpokeFunnel[] = [
     numeral: "I",
     band: "free-door",
     ribbon: "Begin free",
-    href: "/handbook",
+    href: "/inner-garden/chapter-1",
     wallTint: null,
   },
   {


### PR DESCRIPTION
## Summary
- Adds `/inner-garden/chapter-1` as the playable MTGOA Chapter 1 threshold ritual: Answer the Call.
- Lets a player start from an eligible raw BAR or create a new Call to Play source BAR from the Chapter 1 form.
- Saves completion as a linked Shaman/Chapter 1 result BAR with harvested insight and first outer-world move.
- Adds Chapter 1 BAR draft builders/tests and updates the six-guide spec kit Phase 7.
- Points MTGOA Spoke I (`Begin free`) to `/inner-garden/chapter-1`.

## Verification
- `tsx src/lib/inner-garden/__tests__/bridge.test.ts`
- `tsx src/lib/inner-garden/__tests__/chapter-one.test.ts`
- Targeted ESLint for the Inner Garden Chapter 1 slice
- Focused TypeScript check for the Inner Garden Chapter 1 slice
- `npm run diagnose:db`
- Runtime local dev server on port 3011 with `DEV_PLAYER_ID=test-argyra-danger-walker`
- Fetched `/mastering-allyship/hub` and confirmed Spoke I href is `/inner-garden/chapter-1`
- Fetched authenticated `/inner-garden/chapter-1` and confirmed the playable form renders
- Submitted the Chapter 1 form locally; server action returned `303` to `/bars/cmqsfkc3c0003byogce9c1zbx?innerGarden=chapter-1`
- Verified DB created linked source/result BARs with `questSource`, `campaignRef`, `moveType`, `gameMasterFace`, `sourceBarId`, and first-move metadata
- Fetched the result BAR URL and confirmed `200 OK`

## Notes
- Route validator still reports pre-existing unrelated annotation debt in other routes; the new Chapter 1 route was not flagged.
- The local playthrough created two dev DB BARs for `test-argyra-danger-walker`: source `cmqsfkbrx0001byog0chfim5w`, result `cmqsfkc3c0003byogce9c1zbx`.