### PR TITLE
Declutter logged-in nav: fold Observatory into Now, retarget Events

### DIFF
--- a/public/registry.json
+++ b/public/registry.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-17T12:09:39.363Z",
+  "generatedAt": "2026-06-26T18:32:35.461Z",
   "entities": {
     "BAR": {
       "name": "BAR",
@@ -95,7 +95,7 @@
         "admin"
       ],
       "example": "/api/admin/forge/forge_123/complete",
-      "id": "post_quest_1781698181628"
+      "id": "post_quest_1782498757600"
     },
     {
       "sourceFile": "/src/app/api/admin/forge/[id]/route.ts",
@@ -121,7 +121,7 @@
         "admin"
       ],
       "example": "/api/admin/forge/forge_123",
-      "id": "patch_quest_1781698181629"
+      "id": "patch_quest_1782498757600"
     },
     {
       "sourceFile": "/src/app/api/admin/forge/check-eligibility/route.ts",
@@ -146,7 +146,7 @@
         "admin"
       ],
       "example": "/api/admin/forge/check-eligibility",
-      "id": "post_player_1781698181629"
+      "id": "post_player_1782498757601"
     },
     {
       "sourceFile": "/src/app/api/admin/forge/start/route.ts",
@@ -172,7 +172,7 @@
         "admin"
       ],
       "example": "/api/admin/forge/start",
-      "id": "post_quest_1781698181629"
+      "id": "post_quest_1782498757601"
     },
     {
       "sourceFile": "/src/app/api/admin/onboarding/draft/passages/[id]/route.ts",
@@ -198,7 +198,7 @@
         "admin"
       ],
       "example": "/api/admin/onboarding/draft/passages/Start",
-      "id": "patch_campaign_1781698181630"
+      "id": "patch_campaign_1782498757602"
     },
     {
       "sourceFile": "/src/app/api/admin/onboarding/draft/passages/route.ts",
@@ -223,7 +223,7 @@
         "admin"
       ],
       "example": "/api/admin/onboarding/draft/passages",
-      "id": "get_campaign_1781698181631"
+      "id": "get_campaign_1782498757602"
     },
     {
       "sourceFile": "/src/app/api/admin/onboarding/draft/route.ts",
@@ -248,7 +248,7 @@
         "admin"
       ],
       "example": "/api/admin/onboarding/draft",
-      "id": "get_campaign_1781698181631"
+      "id": "get_campaign_1782498757603"
     },
     {
       "sourceFile": "/src/app/api/admin/onboarding/draft/route.ts",
@@ -274,7 +274,7 @@
         "admin"
       ],
       "example": "/api/admin/onboarding/draft",
-      "id": "put_campaign_1781698181631"
+      "id": "put_campaign_1782498757603"
     },
     {
       "sourceFile": "/src/app/api/admin/onboarding/flow/route.ts",
@@ -299,7 +299,7 @@
         "admin"
       ],
       "example": "/api/admin/onboarding/flow?campaign=bruised-banana",
-      "id": "get_campaign_1781698181631"
+      "id": "get_campaign_1782498757603"
     },
     {
       "sourceFile": "/src/app/api/admin/story/validate/route.ts",
@@ -325,7 +325,7 @@
         "admin"
       ],
       "example": "/api/admin/story/validate",
-      "id": "post_campaign_1781698181632"
+      "id": "post_campaign_1782498757603"
     },
     {
       "sourceFile": "/src/app/api/admin/twee/compile/route.ts",
@@ -351,7 +351,7 @@
         "admin"
       ],
       "example": "/api/admin/twee/compile",
-      "id": "post_campaign_1781698181632"
+      "id": "post_campaign_1782498757603"
     },
     {
       "sourceFile": "/src/app/api/admin/twee/publish/route.ts",
@@ -377,7 +377,7 @@
         "admin"
       ],
       "example": "/api/admin/twee/publish",
-      "id": "post_campaign_1781698181632"
+      "id": "post_campaign_1782498757604"
     },
     {
       "sourceFile": "/src/app/api/backlog/[id]/route.ts",
@@ -401,7 +401,7 @@
         "admin"
       ],
       "example": "PATCH /api/backlog/item_123 {\"status\": \"done\", \"ownerFace\": \"shaman\"}",
-      "id": "patch_bar_1781698181633"
+      "id": "patch_bar_1782498757605"
     },
     {
       "sourceFile": "/src/app/api/backlog/route.ts",
@@ -425,7 +425,7 @@
         "public"
       ],
       "example": "/api/backlog?ownerFace=architect",
-      "id": "get_bar_1781698181633"
+      "id": "get_bar_1782498757605"
     },
     {
       "sourceFile": "/src/app/api/feedback/cert/route.ts",
@@ -451,7 +451,7 @@
         "authenticated"
       ],
       "example": "POST /api/feedback/cert {questId:\"cert_001\",passageName:\"ending\",feedback:\"Great quest!\"}",
-      "id": "post_quest_1781698181635"
+      "id": "post_quest_1782498757607"
     },
     {
       "sourceFile": "/src/app/api/guidance/route.ts",
@@ -475,7 +475,7 @@
         "public"
       ],
       "example": "/api/guidance?flowId=bruised-banana&nodeId=start&role=librarian",
-      "id": "get_quest_1781698181657"
+      "id": "get_quest_1782498757607"
     },
     {
       "sourceFile": "/src/app/api/health/route.ts",
@@ -498,7 +498,7 @@
         "public"
       ],
       "example": "/api/health",
-      "id": "get_system_1781698181657"
+      "id": "get_system_1782498757607"
     },
     {
       "sourceFile": "/src/app/api/quests/[questId]/apply-move/route.ts",
@@ -525,7 +525,7 @@
         "participant_in_quest"
       ],
       "example": "POST /api/quests/quest_456/apply-move {\"moveKey\": \"wake_up_insight\", \"inputs\": {\"reflection\": \"...\"}}",
-      "id": "post_quest_1781698181659"
+      "id": "post_quest_1782498757609"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/page.tsx",
@@ -549,7 +549,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123?preview=1",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/page.tsx",
@@ -573,7 +573,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123?preview=1",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/passages/[passageId]/edit/page.tsx",
@@ -598,7 +598,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123/passages/pass_456/edit",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/passages/[passageId]/edit/page.tsx",
@@ -623,7 +623,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123/passages/pass_456/edit",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/passages/create/page.tsx",
@@ -647,7 +647,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123/passages/create",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/[id]/passages/create/page.tsx",
@@ -671,7 +671,7 @@
         "admin"
       ],
       "example": "/admin/adventures/adv_123/passages/create",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/create/page.tsx",
@@ -695,7 +695,7 @@
         "admin"
       ],
       "example": "/admin/adventures/create",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/create/page.tsx",
@@ -719,7 +719,7 @@
         "admin"
       ],
       "example": "/admin/adventures/create",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/merge/page.tsx",
@@ -743,7 +743,7 @@
         "admin"
       ],
       "example": "/admin/adventures/merge",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/merge/page.tsx",
@@ -767,7 +767,7 @@
         "admin"
       ],
       "example": "/admin/adventures/merge",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/page.tsx",
@@ -791,7 +791,7 @@
         "admin"
       ],
       "example": "/admin/adventures",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/adventures/page.tsx",
@@ -815,7 +815,7 @@
         "admin"
       ],
       "example": "/admin/adventures",
-      "id": "page_quest_1781698181660"
+      "id": "page_quest_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/agent-proposals/page.tsx",
@@ -839,7 +839,7 @@
         "admin"
       ],
       "example": "/admin/agent-proposals",
-      "id": "page_npc_1781698181661"
+      "id": "page_npc_1782498757611"
     },
     {
       "sourceFile": "/src/app/admin/agent-proposals/page.tsx",
@@ -863,7 +863,7 @@
         "admin"
       ],
       "example": "/admin/agent-proposals",
-      "id": "page_npc_1781698181661"
+      "id": "page_npc_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/avatars/assets/page.tsx",
@@ -887,7 +887,7 @@
         "admin"
       ],
       "example": "/admin/avatars/assets",
-      "id": "page_player_1781698181661"
+      "id": "page_player_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/avatars/assets/page.tsx",
@@ -911,7 +911,7 @@
         "admin"
       ],
       "example": "/admin/avatars/assets",
-      "id": "page_player_1781698181661"
+      "id": "page_player_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/avatars/page.tsx",
@@ -935,7 +935,7 @@
         "admin"
       ],
       "example": "/admin/avatars",
-      "id": "page_player_1781698181661"
+      "id": "page_player_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/avatars/page.tsx",
@@ -959,7 +959,7 @@
         "admin"
       ],
       "example": "/admin/avatars",
-      "id": "page_player_1781698181661"
+      "id": "page_player_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/backlog/page.tsx",
@@ -983,7 +983,7 @@
         "admin"
       ],
       "example": "/admin/backlog?ownerFace=Coordinator",
-      "id": "page_system_1781698181661"
+      "id": "page_system_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/backlog/page.tsx",
@@ -1007,7 +1007,7 @@
         "admin"
       ],
       "example": "/admin/backlog?ownerFace=Coordinator",
-      "id": "page_system_1781698181661"
+      "id": "page_system_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/bar-candidates/page.tsx",
@@ -1032,7 +1032,7 @@
         "admin"
       ],
       "example": "/admin/bar-candidates",
-      "id": "page_bar_1781698181661"
+      "id": "page_bar_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/bar-candidates/page.tsx",
@@ -1057,7 +1057,7 @@
         "admin"
       ],
       "example": "/admin/bar-candidates",
-      "id": "page_bar_1781698181661"
+      "id": "page_bar_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/moves/page.tsx",
@@ -1081,7 +1081,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123/moves",
-      "id": "page_wiki_1781698181661"
+      "id": "page_wiki_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/moves/page.tsx",
@@ -1105,7 +1105,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123/moves",
-      "id": "page_wiki_1781698181661"
+      "id": "page_wiki_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/page.tsx",
@@ -1130,7 +1130,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123",
-      "id": "page_wiki_1781698181661"
+      "id": "page_wiki_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/page.tsx",
@@ -1155,7 +1155,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123",
-      "id": "page_wiki_1781698181661"
+      "id": "page_wiki_1782498757612"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/quests/page.tsx",
@@ -1179,7 +1179,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123/quests",
-      "id": "page_quest_1781698181662"
+      "id": "page_quest_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/quests/page.tsx",
@@ -1203,7 +1203,7 @@
         "admin"
       ],
       "example": "/admin/books/book_123/quests",
-      "id": "page_quest_1781698181662"
+      "id": "page_quest_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/sections/page.tsx",
@@ -1229,7 +1229,7 @@
         "admin"
       ],
       "example": "/admin/books/clxyz123/sections",
-      "id": "page_wiki_1781698181662"
+      "id": "page_wiki_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/books/[id]/sections/page.tsx",
@@ -1255,7 +1255,7 @@
         "admin"
       ],
       "example": "/admin/books/clxyz123/sections",
-      "id": "page_wiki_1781698181662"
+      "id": "page_wiki_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/books/page.tsx",
@@ -1280,7 +1280,7 @@
         "admin"
       ],
       "example": "/admin/books",
-      "id": "page_wiki_1781698181662"
+      "id": "page_wiki_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/books/page.tsx",
@@ -1305,7 +1305,7 @@
         "admin"
       ],
       "example": "/admin/books",
-      "id": "page_wiki_1781698181662"
+      "id": "page_wiki_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/author/page.tsx",
@@ -1330,7 +1330,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bb-residency/author",
-      "id": "page_campaign_1781698181662"
+      "id": "page_campaign_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/author/page.tsx",
@@ -1355,7 +1355,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bb-residency/author",
-      "id": "page_campaign_1781698181662"
+      "id": "page_campaign_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/deck/page.tsx",
@@ -1380,7 +1380,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bb-residency/deck",
-      "id": "page_campaign_1781698181662"
+      "id": "page_campaign_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/deck/page.tsx",
@@ -1405,7 +1405,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bb-residency/deck",
-      "id": "page_campaign_1781698181662"
+      "id": "page_campaign_1782498757613"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/theme/page.tsx",
@@ -1432,7 +1432,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bruised-banana/theme",
-      "id": "page_campaign_theme_1781698181662"
+      "id": "page_campaign_theme_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign/[ref]/theme/page.tsx",
@@ -1459,7 +1459,7 @@
         "admin"
       ],
       "example": "/admin/campaign/bruised-banana/theme",
-      "id": "page_campaign_theme_1781698181662"
+      "id": "page_campaign_theme_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-events/[eventId]/page.tsx",
@@ -1484,7 +1484,7 @@
         "admin"
       ],
       "example": "/admin/campaign-events/evt_123?instanceId=inst_456",
-      "id": "page_event_1781698181662"
+      "id": "page_event_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-events/[eventId]/page.tsx",
@@ -1509,7 +1509,7 @@
         "admin"
       ],
       "example": "/admin/campaign-events/evt_123?instanceId=inst_456",
-      "id": "page_event_1781698181662"
+      "id": "page_event_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-events/page.tsx",
@@ -1534,7 +1534,7 @@
         "admin"
       ],
       "example": "/admin/campaign-events?instanceId=inst_123",
-      "id": "page_event_1781698181663"
+      "id": "page_event_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-events/page.tsx",
@@ -1559,7 +1559,7 @@
         "admin"
       ],
       "example": "/admin/campaign-events?instanceId=inst_123",
-      "id": "page_event_1781698181663"
+      "id": "page_event_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-seeds/page.tsx",
@@ -1583,7 +1583,7 @@
         "admin"
       ],
       "example": "/admin/campaign-seeds",
-      "id": "page_campaign_1781698181663"
+      "id": "page_campaign_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaign-seeds/page.tsx",
@@ -1607,7 +1607,7 @@
         "admin"
       ],
       "example": "/admin/campaign-seeds",
-      "id": "page_campaign_1781698181663"
+      "id": "page_campaign_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaigns/review/page.tsx",
@@ -1629,7 +1629,7 @@
       "permissions": [
         "admin"
       ],
-      "id": "page_campaign_1781698181663"
+      "id": "page_campaign_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/campaigns/review/page.tsx",
@@ -1651,7 +1651,7 @@
       "permissions": [
         "admin"
       ],
-      "id": "page_campaign_1781698181663"
+      "id": "page_campaign_1782498757614"
     },
     {
       "sourceFile": "/src/app/admin/config/page.tsx",
@@ -1675,7 +1675,7 @@
         "admin"
       ],
       "example": "/admin/config",
-      "id": "page_system_1781698181663"
+      "id": "page_system_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/config/page.tsx",
@@ -1699,7 +1699,7 @@
         "admin"
       ],
       "example": "/admin/config",
-      "id": "page_system_1781698181663"
+      "id": "page_system_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/discovery/page.tsx",
@@ -1724,7 +1724,7 @@
         "admin"
       ],
       "example": "/admin/discovery",
-      "id": "page_quest_1781698181663"
+      "id": "page_quest_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/discovery/page.tsx",
@@ -1749,7 +1749,7 @@
         "admin"
       ],
       "example": "/admin/discovery",
-      "id": "page_quest_1781698181663"
+      "id": "page_quest_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/docs/page.tsx",
@@ -1773,7 +1773,7 @@
         "admin"
       ],
       "example": "/admin/docs",
-      "id": "page_wiki_1781698181663"
+      "id": "page_wiki_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/docs/page.tsx",
@@ -1797,7 +1797,7 @@
         "admin"
       ],
       "example": "/admin/docs",
-      "id": "page_wiki_1781698181663"
+      "id": "page_wiki_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/first-aid/page.tsx",
@@ -1821,7 +1821,7 @@
         "admin"
       ],
       "example": "/admin/first-aid",
-      "id": "page_system_1781698181664"
+      "id": "page_system_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/first-aid/page.tsx",
@@ -1845,7 +1845,7 @@
         "admin"
       ],
       "example": "/admin/first-aid",
-      "id": "page_system_1781698181664"
+      "id": "page_system_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/forge/page.tsx",
@@ -1869,7 +1869,7 @@
         "admin"
       ],
       "example": "/admin/forge",
-      "id": "page_bar_1781698181664"
+      "id": "page_bar_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/forge/page.tsx",
@@ -1893,7 +1893,7 @@
         "admin"
       ],
       "example": "/admin/forge",
-      "id": "page_bar_1781698181664"
+      "id": "page_bar_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/instances/page.tsx",
@@ -1918,7 +1918,7 @@
         "admin"
       ],
       "example": "/admin/instances?saved=true",
-      "id": "page_campaign_1781698181664"
+      "id": "page_campaign_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/instances/page.tsx",
@@ -1943,7 +1943,7 @@
         "admin"
       ],
       "example": "/admin/instances?saved=true",
-      "id": "page_campaign_1781698181664"
+      "id": "page_campaign_1782498757615"
     },
     {
       "sourceFile": "/src/app/admin/journeys/pack/[id]/page.tsx",
@@ -1968,7 +1968,7 @@
         "admin"
       ],
       "example": "/admin/journeys/pack/pack_123",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/journeys/pack/[id]/page.tsx",
@@ -1993,7 +1993,7 @@
         "admin"
       ],
       "example": "/admin/journeys/pack/pack_123",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/journeys/page.tsx",
@@ -2017,7 +2017,7 @@
         "admin"
       ],
       "example": "/admin/journeys",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/journeys/page.tsx",
@@ -2041,7 +2041,7 @@
         "admin"
       ],
       "example": "/admin/journeys",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/journeys/thread/[id]/page.tsx",
@@ -2067,7 +2067,7 @@
         "admin"
       ],
       "example": "/admin/journeys/thread/thread_123",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/journeys/thread/[id]/page.tsx",
@@ -2093,7 +2093,7 @@
         "admin"
       ],
       "example": "/admin/journeys/thread/thread_123",
-      "id": "page_quest_1781698181664"
+      "id": "page_quest_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/library/page.tsx",
@@ -2117,7 +2117,7 @@
         "admin"
       ],
       "example": "/admin/library",
-      "id": "page_wiki_1781698181664"
+      "id": "page_wiki_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/library/page.tsx",
@@ -2141,7 +2141,7 @@
         "admin"
       ],
       "example": "/admin/library",
-      "id": "page_wiki_1781698181664"
+      "id": "page_wiki_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/[id]/editor/page.tsx",
@@ -2166,7 +2166,7 @@
         "admin"
       ],
       "example": "/admin/maps/map_123/editor",
-      "id": "page_system_1781698181664"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/[id]/editor/page.tsx",
@@ -2191,7 +2191,7 @@
         "admin"
       ],
       "example": "/admin/maps/map_123/editor",
-      "id": "page_system_1781698181664"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/[id]/page.tsx",
@@ -2216,7 +2216,7 @@
         "admin"
       ],
       "example": "/admin/maps/map_123",
-      "id": "page_system_1781698181664"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/[id]/page.tsx",
@@ -2241,7 +2241,7 @@
         "admin"
       ],
       "example": "/admin/maps/map_123",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/page.tsx",
@@ -2266,7 +2266,7 @@
         "admin"
       ],
       "example": "/admin/maps",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/maps/page.tsx",
@@ -2291,7 +2291,7 @@
         "admin"
       ],
       "example": "/admin/maps",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/moves/page.tsx",
@@ -2316,7 +2316,7 @@
         "admin"
       ],
       "example": "/admin/moves?tier=CANONICAL&moveType=wakeUp",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/moves/page.tsx",
@@ -2341,7 +2341,7 @@
         "admin"
       ],
       "example": "/admin/moves?tier=CANONICAL&moveType=wakeUp",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/memories/page.tsx",
@@ -2366,7 +2366,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123/memories",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/memories/page.tsx",
@@ -2391,7 +2391,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123/memories",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757616"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/page.tsx",
@@ -2416,7 +2416,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/page.tsx",
@@ -2441,7 +2441,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/reflections/page.tsx",
@@ -2465,7 +2465,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123/reflections",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/npcs/[id]/reflections/page.tsx",
@@ -2489,7 +2489,7 @@
         "admin"
       ],
       "example": "/admin/npcs/npc_123/reflections",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/npcs/page.tsx",
@@ -2513,7 +2513,7 @@
         "admin"
       ],
       "example": "/admin/npcs?status=active&tier=2",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/npcs/page.tsx",
@@ -2537,7 +2537,7 @@
         "admin"
       ],
       "example": "/admin/npcs?status=active&tier=2",
-      "id": "page_npc_1781698181665"
+      "id": "page_npc_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/onboarding/page.tsx",
@@ -2562,7 +2562,7 @@
         "admin"
       ],
       "example": "/admin/onboarding",
-      "id": "page_quest_1781698181665"
+      "id": "page_quest_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/onboarding/page.tsx",
@@ -2587,7 +2587,7 @@
         "admin"
       ],
       "example": "/admin/onboarding",
-      "id": "page_quest_1781698181665"
+      "id": "page_quest_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/page.tsx",
@@ -2611,7 +2611,7 @@
         "admin"
       ],
       "example": "/admin",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/page.tsx",
@@ -2635,7 +2635,7 @@
         "admin"
       ],
       "example": "/admin",
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/player-signal-backlog/page.tsx",
@@ -2654,7 +2654,7 @@
       "permissions": [
         "admin"
       ],
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/player-signal-backlog/page.tsx",
@@ -2673,7 +2673,7 @@
       "permissions": [
         "admin"
       ],
-      "id": "page_system_1781698181665"
+      "id": "page_system_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/players/page.tsx",
@@ -2698,7 +2698,7 @@
         "admin"
       ],
       "example": "/admin/players",
-      "id": "page_player_1781698181666"
+      "id": "page_player_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/players/page.tsx",
@@ -2723,7 +2723,7 @@
         "admin"
       ],
       "example": "/admin/players",
-      "id": "page_player_1781698181666"
+      "id": "page_player_1782498757617"
     },
     {
       "sourceFile": "/src/app/admin/quest-from-context/page.tsx",
@@ -2748,7 +2748,7 @@
         "admin"
       ],
       "example": "/admin/quest-from-context",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-from-context/page.tsx",
@@ -2773,7 +2773,7 @@
         "admin"
       ],
       "example": "/admin/quest-from-context",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-grammar/page.tsx",
@@ -2798,7 +2798,7 @@
         "admin"
       ],
       "example": "/admin/quest-grammar?appendTo=adv_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-grammar/page.tsx",
@@ -2823,7 +2823,7 @@
         "admin"
       ],
       "example": "/admin/quest-grammar?appendTo=adv_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-proposals/[id]/page.tsx",
@@ -2847,7 +2847,7 @@
         "admin"
       ],
       "example": "/admin/quest-proposals/prop_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-proposals/[id]/page.tsx",
@@ -2871,7 +2871,7 @@
         "admin"
       ],
       "example": "/admin/quest-proposals/prop_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-proposals/page.tsx",
@@ -2895,7 +2895,7 @@
         "admin"
       ],
       "example": "/admin/quest-proposals?status=pending",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quest-proposals/page.tsx",
@@ -2919,7 +2919,7 @@
         "admin"
       ],
       "example": "/admin/quest-proposals?status=pending",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quests/[id]/page.tsx",
@@ -2945,7 +2945,7 @@
         "admin"
       ],
       "example": "/admin/quests/quest_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quests/[id]/page.tsx",
@@ -2971,7 +2971,7 @@
         "admin"
       ],
       "example": "/admin/quests/quest_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quests/page.tsx",
@@ -2995,7 +2995,7 @@
         "admin"
       ],
       "example": "/admin/quests",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/quests/page.tsx",
@@ -3019,7 +3019,7 @@
         "admin"
       ],
       "example": "/admin/quests",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/sprites/review/page.tsx",
@@ -3043,7 +3043,7 @@
         "admin"
       ],
       "example": "/admin/sprites/review",
-      "id": "page_player_1781698181666"
+      "id": "page_player_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/sprites/review/page.tsx",
@@ -3067,7 +3067,7 @@
         "admin"
       ],
       "example": "/admin/sprites/review",
-      "id": "page_player_1781698181666"
+      "id": "page_player_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/templates/page.tsx",
@@ -3092,7 +3092,7 @@
         "admin"
       ],
       "example": "/admin/templates",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/templates/page.tsx",
@@ -3117,7 +3117,7 @@
         "admin"
       ],
       "example": "/admin/templates",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/twine/[id]/ir/page.tsx",
@@ -3141,7 +3141,7 @@
         "admin"
       ],
       "example": "/admin/twine/story_123/ir",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/twine/[id]/ir/page.tsx",
@@ -3165,7 +3165,7 @@
         "admin"
       ],
       "example": "/admin/twine/story_123/ir",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757618"
     },
     {
       "sourceFile": "/src/app/admin/twine/[id]/page.tsx",
@@ -3190,7 +3190,7 @@
         "admin"
       ],
       "example": "/admin/twine/story_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/twine/[id]/page.tsx",
@@ -3215,7 +3215,7 @@
         "admin"
       ],
       "example": "/admin/twine/story_123",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/twine/page.tsx",
@@ -3239,7 +3239,7 @@
         "admin"
       ],
       "example": "/admin/twine?status=published&search=onboarding",
-      "id": "page_quest_1781698181666"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/twine/page.tsx",
@@ -3263,7 +3263,7 @@
         "admin"
       ],
       "example": "/admin/twine?status=published&search=onboarding",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/twine/stitcher/page.tsx",
@@ -3288,7 +3288,7 @@
         "admin"
       ],
       "example": "/admin/twine/stitcher?id=story_123",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/twine/stitcher/page.tsx",
@@ -3313,7 +3313,7 @@
         "admin"
       ],
       "example": "/admin/twine/stitcher?id=story_123",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/archetype/[id]/page.tsx",
@@ -3338,7 +3338,7 @@
         "admin"
       ],
       "example": "/admin/world/archetype/archetype_123",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/archetype/[id]/page.tsx",
@@ -3363,7 +3363,7 @@
         "admin"
       ],
       "example": "/admin/world/archetype/archetype_123",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/nation/[id]/page.tsx",
@@ -3388,7 +3388,7 @@
         "admin"
       ],
       "example": "/admin/world/nation/nation_123",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/nation/[id]/page.tsx",
@@ -3413,7 +3413,7 @@
         "admin"
       ],
       "example": "/admin/world/nation/nation_123",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/page.tsx",
@@ -3438,7 +3438,7 @@
         "admin"
       ],
       "example": "/admin/world",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/admin/world/page.tsx",
@@ -3463,7 +3463,7 @@
         "admin"
       ],
       "example": "/admin/world",
-      "id": "page_system_1781698181667"
+      "id": "page_system_1782498757619"
     },
     {
       "sourceFile": "/src/app/adventure/[id]/play/page.tsx",
@@ -3488,7 +3488,7 @@
         "authenticated"
       ],
       "example": "/adventure/abc123/play?questId=quest-456&ref=bruised-banana&start=Node-1",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/adventure/[id]/play/page.tsx",
@@ -3513,7 +3513,7 @@
         "authenticated"
       ],
       "example": "/adventure/abc123/play?questId=quest-456&ref=bruised-banana&start=Node-1",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/adventure/hub/[questId]/page.tsx",
@@ -3538,7 +3538,7 @@
         "authenticated"
       ],
       "example": "/adventure/hub/quest-123?ref=bruised-banana",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/adventure/hub/[questId]/page.tsx",
@@ -3563,7 +3563,7 @@
         "authenticated"
       ],
       "example": "/adventure/hub/quest-123?ref=bruised-banana",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/adventures/[id]/play/page.tsx",
@@ -3588,7 +3588,7 @@
         "authenticated"
       ],
       "example": "/adventures/story-abc/play?questId=quest-123&ritual=true",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/adventures/[id]/play/page.tsx",
@@ -3613,7 +3613,7 @@
         "authenticated"
       ],
       "example": "/adventures/story-abc/play?questId=quest-123&ritual=true",
-      "id": "page_quest_1781698181667"
+      "id": "page_quest_1782498757620"
     },
     {
       "sourceFile": "/src/app/archetype/page.tsx",
@@ -3638,7 +3638,7 @@
         "authenticated"
       ],
       "example": "/archetype",
-      "id": "page_player_1781698181668"
+      "id": "page_player_1782498757620"
     },
     {
       "sourceFile": "/src/app/archetype/page.tsx",
@@ -3663,7 +3663,7 @@
         "authenticated"
       ],
       "example": "/archetype",
-      "id": "page_player_1781698181668"
+      "id": "page_player_1782498757620"
     },
     {
       "sourceFile": "/src/app/arrival/page.tsx",
@@ -3687,7 +3687,7 @@
         "authenticated (requires active player session)"
       ],
       "example": "/arrival",
-      "id": "page_player_1781698181668"
+      "id": "page_player_1782498757620"
     },
     {
       "sourceFile": "/src/app/arrival/page.tsx",
@@ -3711,11 +3711,11 @@
         "authenticated (requires active player session)"
       ],
       "example": "/arrival",
-      "id": "page_player_1781698181668"
+      "id": "page_player_1782498757620"
     },
     {
       "sourceFile": "/src/app/bars/[id]/page.tsx",
-      "lineNumber": 33,
+      "lineNumber": 38,
       "params": [],
       "query": [],
       "relationships": [],
@@ -3736,11 +3736,11 @@
         "authenticated"
       ],
       "example": "/bars/bar-123?share=external",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bars/[id]/page.tsx",
-      "lineNumber": 33,
+      "lineNumber": 38,
       "params": [],
       "query": [],
       "relationships": [],
@@ -3761,7 +3761,7 @@
         "authenticated"
       ],
       "example": "/bars/bar-123?share=external",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bars/capture/page.tsx",
@@ -3786,7 +3786,7 @@
         "authenticated"
       ],
       "example": "/bars/capture",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bars/capture/page.tsx",
@@ -3811,7 +3811,7 @@
         "authenticated"
       ],
       "example": "/bars/capture",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bars/page.tsx",
@@ -3835,7 +3835,7 @@
         "authenticated"
       ],
       "example": "/bars",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bars/page.tsx",
@@ -3859,7 +3859,7 @@
         "authenticated"
       ],
       "example": "/bars",
-      "id": "page_bar_1781698181668"
+      "id": "page_bar_1782498757621"
     },
     {
       "sourceFile": "/src/app/bb/page.tsx",
@@ -3878,7 +3878,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181668"
+      "id": "page_campaign_1782498757621"
     },
     {
       "sourceFile": "/src/app/bb/page.tsx",
@@ -3897,7 +3897,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181668"
+      "id": "page_campaign_1782498757621"
     },
     {
       "sourceFile": "/src/app/campaign/[ref]/home/page.tsx",
@@ -3922,7 +3922,7 @@
         "authenticated member of the campaign's instance"
       ],
       "example": "/campaign/bruised-banana/home",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757621"
     },
     {
       "sourceFile": "/src/app/campaign/[ref]/spoke/[n]/seeds/page.tsx",
@@ -3946,7 +3946,7 @@
       "permissions": [
         "authenticated"
       ],
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/[ref]/spoke/[n]/seeds/page.tsx",
@@ -3970,7 +3970,7 @@
       "permissions": [
         "authenticated"
       ],
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/lobby/page.tsx",
@@ -3994,7 +3994,7 @@
         "authenticated"
       ],
       "example": "/campaign/lobby?ref=bruised-banana",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/lobby/page.tsx",
@@ -4018,7 +4018,7 @@
         "authenticated"
       ],
       "example": "/campaign/lobby?ref=bruised-banana",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/slot/[slotId]/enter/[adventureId]/page.tsx",
@@ -4043,7 +4043,7 @@
         "authenticated"
       ],
       "example": "/campaign/slot/cld123/enter/adv456?ref=bruised-banana",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/slot/[slotId]/enter/[adventureId]/page.tsx",
@@ -4068,7 +4068,7 @@
         "authenticated"
       ],
       "example": "/campaign/slot/cld123/enter/adv456?ref=bruised-banana",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757622"
     },
     {
       "sourceFile": "/src/app/campaign/slot/[slotId]/page.tsx",
@@ -4093,7 +4093,7 @@
         "authenticated"
       ],
       "example": "/campaign/slot/cld123",
-      "id": "page_campaign_1781698181669"
+      "id": "page_campaign_1782498757623"
     },
     {
       "sourceFile": "/src/app/campaign/spoke/[index]/generated/page.tsx",
@@ -4112,7 +4112,7 @@
       "permissions": [
         "authenticated"
       ],
-      "id": "page_campaign_1781698181670"
+      "id": "page_campaign_1782498757623"
     },
     {
       "sourceFile": "/src/app/campaign/spoke/[index]/generated/page.tsx",
@@ -4131,7 +4131,7 @@
       "permissions": [
         "authenticated"
       ],
-      "id": "page_campaign_1781698181670"
+      "id": "page_campaign_1782498757623"
     },
     {
       "sourceFile": "/src/app/campaigns/landing/[slug]/page.tsx",
@@ -4156,7 +4156,7 @@
         "public"
       ],
       "example": "/campaigns/landing/bruised-banana?invite=abc123&shareToken=xyz789",
-      "id": "page_campaign_1781698181670"
+      "id": "page_campaign_1782498757623"
     },
     {
       "sourceFile": "/src/app/campaigns/landing/[slug]/page.tsx",
@@ -4181,7 +4181,7 @@
         "public"
       ],
       "example": "/campaigns/landing/bruised-banana?invite=abc123&shareToken=xyz789",
-      "id": "page_campaign_1781698181670"
+      "id": "page_campaign_1782498757624"
     },
     {
       "sourceFile": "/src/app/capture/explore/[barId]/page.tsx",
@@ -4206,7 +4206,7 @@
         "owner"
       ],
       "example": "/capture/explore/bar-charge-123",
-      "id": "page_bar_1781698181670"
+      "id": "page_bar_1782498757624"
     },
     {
       "sourceFile": "/src/app/capture/explore/[barId]/page.tsx",
@@ -4231,7 +4231,7 @@
         "owner"
       ],
       "example": "/capture/explore/bar-charge-123",
-      "id": "page_bar_1781698181670"
+      "id": "page_bar_1782498757624"
     },
     {
       "sourceFile": "/src/app/capture/page.tsx",
@@ -4257,7 +4257,7 @@
         "authenticated"
       ],
       "example": "/capture",
-      "id": "page_bar_1781698181670"
+      "id": "page_bar_1782498757624"
     },
     {
       "sourceFile": "/src/app/capture/page.tsx",
@@ -4283,7 +4283,7 @@
         "authenticated"
       ],
       "example": "/capture",
-      "id": "page_bar_1781698181670"
+      "id": "page_bar_1782498757624"
     },
     {
       "sourceFile": "/src/app/character/[shareToken]/page.tsx",
@@ -4308,7 +4308,7 @@
         "public"
       ],
       "example": "/character/abc123xyz",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/character/[shareToken]/page.tsx",
@@ -4333,7 +4333,7 @@
         "public"
       ],
       "example": "/character/abc123xyz",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/character/create/page.tsx",
@@ -4359,7 +4359,7 @@
         "authenticated"
       ],
       "example": "/character/create",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/character/create/page.tsx",
@@ -4385,7 +4385,7 @@
         "authenticated"
       ],
       "example": "/character/create",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/character-creator/page.tsx",
@@ -4410,7 +4410,7 @@
         "authenticated"
       ],
       "example": "/character-creator",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/character-creator/page.tsx",
@@ -4435,7 +4435,7 @@
         "authenticated"
       ],
       "example": "/character-creator",
-      "id": "page_player_1781698181670"
+      "id": "page_player_1782498757624"
     },
     {
       "sourceFile": "/src/app/conclave/space/[mapId]/page.tsx",
@@ -4461,7 +4461,7 @@
         "authenticated"
       ],
       "example": "/conclave/space/lobby_001",
-      "id": "page_system_1781698181671"
+      "id": "page_system_1782498757640"
     },
     {
       "sourceFile": "/src/app/conclave/space/[mapId]/page.tsx",
@@ -4487,7 +4487,7 @@
         "authenticated"
       ],
       "example": "/conclave/space/lobby_001",
-      "id": "page_system_1781698181671"
+      "id": "page_system_1782498757640"
     },
     {
       "sourceFile": "/src/app/conclave/space/page.tsx",
@@ -4513,7 +4513,7 @@
         "authenticated"
       ],
       "example": "/conclave/space",
-      "id": "page_system_1781698181671"
+      "id": "page_system_1782498757640"
     },
     {
       "sourceFile": "/src/app/conclave/space/page.tsx",
@@ -4539,7 +4539,7 @@
         "authenticated"
       ],
       "example": "/conclave/space",
-      "id": "page_system_1781698181671"
+      "id": "page_system_1782498757640"
     },
     {
       "sourceFile": "/src/app/create-bar/page.tsx",
@@ -4566,7 +4566,7 @@
         "profile_complete"
       ],
       "example": "/create-bar?setup=true&from321=1",
-      "id": "page_bar_1781698181671"
+      "id": "page_bar_1782498757640"
     },
     {
       "sourceFile": "/src/app/create-bar/page.tsx",
@@ -4593,7 +4593,7 @@
         "profile_complete"
       ],
       "example": "/create-bar?setup=true&from321=1",
-      "id": "page_bar_1781698181671"
+      "id": "page_bar_1782498757640"
     },
     {
       "sourceFile": "/src/app/creator-scene-deck/[slug]/page.tsx",
@@ -4620,7 +4620,7 @@
         "game_account_ready"
       ],
       "example": "/creator-scene-deck/bruised-banana",
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757640"
     },
     {
       "sourceFile": "/src/app/creator-scene-deck/[slug]/page.tsx",
@@ -4647,7 +4647,7 @@
         "game_account_ready"
       ],
       "example": "/creator-scene-deck/bruised-banana",
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757640"
     },
     {
       "sourceFile": "/src/app/creator-scene-deck/page.tsx",
@@ -4674,7 +4674,7 @@
         "game_account_ready"
       ],
       "example": "/creator-scene-deck → redirects to /creator-scene-deck/bruised-banana",
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757640"
     },
     {
       "sourceFile": "/src/app/creator-scene-deck/page.tsx",
@@ -4701,7 +4701,7 @@
         "game_account_ready"
       ],
       "example": "/creator-scene-deck → redirects to /creator-scene-deck/bruised-banana",
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757640"
     },
     {
       "sourceFile": "/src/app/daemons/321-wake-up/page.tsx",
@@ -4725,7 +4725,7 @@
         "authenticated"
       ],
       "example": "/daemons/321-wake-up",
-      "id": "page_daemon_1781698181671"
+      "id": "page_daemon_1782498757640"
     },
     {
       "sourceFile": "/src/app/daemons/321-wake-up/page.tsx",
@@ -4749,7 +4749,7 @@
         "authenticated"
       ],
       "example": "/daemons/321-wake-up",
-      "id": "page_daemon_1781698181671"
+      "id": "page_daemon_1782498757640"
     },
     {
       "sourceFile": "/src/app/daemons/page.tsx",
@@ -4775,7 +4775,7 @@
         "authenticated"
       ],
       "example": "/daemons",
-      "id": "page_daemon_1781698181671"
+      "id": "page_daemon_1782498757641"
     },
     {
       "sourceFile": "/src/app/daemons/page.tsx",
@@ -4801,7 +4801,7 @@
         "authenticated"
       ],
       "example": "/daemons",
-      "id": "page_daemon_1781698181671"
+      "id": "page_daemon_1782498757641"
     },
     {
       "sourceFile": "/src/app/dashboard/page.tsx",
@@ -4824,7 +4824,7 @@
         "authenticated"
       ],
       "example": "/dashboard",
-      "id": "page_player_1781698181671"
+      "id": "page_player_1782498757641"
     },
     {
       "sourceFile": "/src/app/dashboard/page.tsx",
@@ -4847,7 +4847,57 @@
         "authenticated"
       ],
       "example": "/dashboard",
-      "id": "page_player_1781698181671"
+      "id": "page_player_1782498757641"
+    },
+    {
+      "sourceFile": "/src/app/deck/preview/page.tsx",
+      "lineNumber": 23,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "visitor",
+        "WHAT": "SYSTEM",
+        "WHERE": "funnel",
+        "ENERGY": "N/A"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": true,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/deck/preview",
+      "entity": "SYSTEM",
+      "description": "Unauthenticated gallery of all 120 Allyship Deck cards (the high-fidelity\ncard primitive). Reads the public `allyship-deck.json` directly — no paywall — so the\ndeck is reviewable without the `deck-digital` entitlement. The full app lives at /deck.",
+      "permissions": [
+        "public"
+      ],
+      "example": "/deck/preview",
+      "id": "page_system_1782498757641"
+    },
+    {
+      "sourceFile": "/src/app/deck/preview/page.tsx",
+      "lineNumber": 23,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "visitor",
+        "WHAT": "SYSTEM",
+        "WHERE": "funnel",
+        "ENERGY": "N/A"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": true,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/deck/preview",
+      "entity": "SYSTEM",
+      "description": "Unauthenticated gallery of all 120 Allyship Deck cards (the high-fidelity\ncard primitive). Reads the public `allyship-deck.json` directly — no paywall — so the\ndeck is reviewable without the `deck-digital` entitlement. The full app lives at /deck.",
+      "permissions": [
+        "public"
+      ],
+      "example": "/deck/preview",
+      "id": "page_system_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/bruised-banana/donate/page.tsx",
@@ -4866,7 +4916,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/bruised-banana/donate/page.tsx",
@@ -4885,7 +4935,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181671"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/bruised-banana/page.tsx",
@@ -4904,7 +4954,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181672"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/bruised-banana/page.tsx",
@@ -4923,7 +4973,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_campaign_1781698181672"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/orientation/page.tsx",
@@ -4949,7 +4999,7 @@
         "public"
       ],
       "example": "/demo/orientation?s=bruised-banana-orientation",
-      "id": "page_campaign_1781698181672"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/demo/orientation/page.tsx",
@@ -4975,7 +5025,7 @@
         "public"
       ],
       "example": "/demo/orientation?s=bruised-banana-orientation",
-      "id": "page_campaign_1781698181672"
+      "id": "page_campaign_1782498757641"
     },
     {
       "sourceFile": "/src/app/dev/page.tsx",
@@ -5001,7 +5051,7 @@
         "dev_mode_only (NODE_ENV=development OR ENABLE_DEV_TOOLS=true)"
       ],
       "example": "/dev",
-      "id": "page_system_1781698181672"
+      "id": "page_system_1782498757646"
     },
     {
       "sourceFile": "/src/app/dev/page.tsx",
@@ -5027,7 +5077,7 @@
         "dev_mode_only (NODE_ENV=development OR ENABLE_DEV_TOOLS=true)"
       ],
       "example": "/dev",
-      "id": "page_system_1781698181672"
+      "id": "page_system_1782498757646"
     },
     {
       "sourceFile": "/src/app/docs/[slug]/page.tsx",
@@ -5053,7 +5103,7 @@
         "public (read-only)"
       ],
       "example": "/docs/how-to-create-bars",
-      "id": "page_wiki_1781698181672"
+      "id": "page_wiki_1782498757646"
     },
     {
       "sourceFile": "/src/app/docs/[slug]/page.tsx",
@@ -5079,7 +5129,7 @@
         "public (read-only)"
       ],
       "example": "/docs/how-to-create-bars",
-      "id": "page_wiki_1781698181672"
+      "id": "page_wiki_1782498757646"
     },
     {
       "sourceFile": "/src/app/docs/page.tsx",
@@ -5105,7 +5155,7 @@
         "public (read-only)"
       ],
       "example": "/docs",
-      "id": "page_wiki_1781698181672"
+      "id": "page_wiki_1782498757646"
     },
     {
       "sourceFile": "/src/app/docs/page.tsx",
@@ -5131,7 +5181,7 @@
         "public (read-only)"
       ],
       "example": "/docs",
-      "id": "page_wiki_1781698181672"
+      "id": "page_wiki_1782498757646"
     },
     {
       "sourceFile": "/src/app/emotional-first-aid/page.tsx",
@@ -5157,7 +5207,7 @@
         "guest-capable via party guest mode"
       ],
       "example": "/emotional-first-aid?questId=quest_123&returnTo=/game-map",
-      "id": "page_quest_1781698181672"
+      "id": "page_quest_1782498757646"
     },
     {
       "sourceFile": "/src/app/emotional-first-aid/page.tsx",
@@ -5183,7 +5233,7 @@
         "guest-capable via party guest mode"
       ],
       "example": "/emotional-first-aid?questId=quest_123&returnTo=/game-map",
-      "id": "page_quest_1781698181672"
+      "id": "page_quest_1782498757646"
     },
     {
       "sourceFile": "/src/app/event/barn/page.tsx",
@@ -5208,7 +5258,7 @@
         "public"
       ],
       "example": "/event/barn",
-      "id": "page_system_1781698181672"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/event/barn/page.tsx",
@@ -5233,7 +5283,7 @@
         "public"
       ],
       "example": "/event/barn",
-      "id": "page_system_1781698181672"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/event/donate/page.tsx",
@@ -5260,7 +5310,7 @@
         "authenticated (self-report + vibeulon mint)"
       ],
       "example": "/event/donate",
-      "id": "page_event_1781698181673"
+      "id": "page_event_1782498757647"
     },
     {
       "sourceFile": "/src/app/event/donate/page.tsx",
@@ -5287,7 +5337,7 @@
         "authenticated (self-report + vibeulon mint)"
       ],
       "example": "/event/donate",
-      "id": "page_event_1781698181673"
+      "id": "page_event_1782498757647"
     },
     {
       "sourceFile": "/src/app/fork-game/page.tsx",
@@ -5313,7 +5363,7 @@
         "authenticated"
       ],
       "example": "/fork-game",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/fork-game/page.tsx",
@@ -5339,7 +5389,7 @@
         "authenticated"
       ],
       "example": "/fork-game",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/fork-wizard/page.tsx",
@@ -5365,7 +5415,7 @@
         "public"
       ],
       "example": "/fork-wizard",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/fork-wizard/page.tsx",
@@ -5391,7 +5441,7 @@
         "public"
       ],
       "example": "/fork-wizard",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/game-map/page.tsx",
@@ -5418,7 +5468,7 @@
         "game_account_ready"
       ],
       "example": "/game-map#space-library",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/game-map/page.tsx",
@@ -5445,7 +5495,7 @@
         "game_account_ready"
       ],
       "example": "/game-map#space-library",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757647"
     },
     {
       "sourceFile": "/src/app/graveyard/page.tsx",
@@ -5471,7 +5521,7 @@
         "authenticated"
       ],
       "example": "/graveyard",
-      "id": "page_quest_1781698181673"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/graveyard/page.tsx",
@@ -5497,7 +5547,7 @@
         "authenticated"
       ],
       "example": "/graveyard",
-      "id": "page_quest_1781698181673"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/growth-scene/[id]/page.tsx",
@@ -5524,7 +5574,7 @@
         "owner_only"
       ],
       "example": "/growth-scene/scene_abc123",
-      "id": "page_quest_1781698181673"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/growth-scene/[id]/page.tsx",
@@ -5551,7 +5601,7 @@
         "owner_only"
       ],
       "example": "/growth-scene/scene_abc123",
-      "id": "page_quest_1781698181673"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/iching/page.tsx",
@@ -5577,7 +5627,7 @@
         "authenticated"
       ],
       "example": "/iching?instanceId=inst_001&campaignRef=bruised-banana",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757648"
     },
     {
       "sourceFile": "/src/app/iching/page.tsx",
@@ -5603,7 +5653,7 @@
         "authenticated"
       ],
       "example": "/iching?instanceId=inst_001&campaignRef=bruised-banana",
-      "id": "page_system_1781698181673"
+      "id": "page_system_1782498757648"
     },
     {
       "sourceFile": "/src/app/invite/[token]/page.tsx",
@@ -5629,7 +5679,7 @@
         "public (invite token required)"
       ],
       "example": "/invite/abc123xyz",
-      "id": "page_player_1781698181673"
+      "id": "page_player_1782498757648"
     },
     {
       "sourceFile": "/src/app/invite/claim/[barId]/page.tsx",
@@ -5655,7 +5705,7 @@
         "public"
       ],
       "example": "/invite/claim/bar_123 → redirects to /invite/abc123xyz",
-      "id": "page_bar_1781698181673"
+      "id": "page_bar_1782498757648"
     },
     {
       "sourceFile": "/src/app/invite/claim/[barId]/page.tsx",
@@ -5681,7 +5731,7 @@
         "public"
       ],
       "example": "/invite/claim/bar_123 → redirects to /invite/abc123xyz",
-      "id": "page_bar_1781698181673"
+      "id": "page_bar_1782498757648"
     },
     {
       "sourceFile": "/src/app/join/[instanceSlug]/page.tsx",
@@ -5707,7 +5757,7 @@
         "authenticated"
       ],
       "example": "/join/bruised-banana",
-      "id": "page_campaign_1781698181677"
+      "id": "page_campaign_1782498757648"
     },
     {
       "sourceFile": "/src/app/join/[instanceSlug]/page.tsx",
@@ -5733,7 +5783,7 @@
         "authenticated"
       ],
       "example": "/join/bruised-banana",
-      "id": "page_campaign_1781698181677"
+      "id": "page_campaign_1782498757648"
     },
     {
       "sourceFile": "/src/app/library/page.tsx",
@@ -5759,7 +5809,7 @@
         "authenticated"
       ],
       "example": "/library",
-      "id": "page_quest_1781698181677"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/library/page.tsx",
@@ -5785,7 +5835,7 @@
         "authenticated"
       ],
       "example": "/library",
-      "id": "page_quest_1781698181677"
+      "id": "page_quest_1782498757648"
     },
     {
       "sourceFile": "/src/app/lobby/[roomSlug]/page.tsx",
@@ -5811,7 +5861,7 @@
         "authenticated"
       ],
       "example": "/lobby/main-room",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757648"
     },
     {
       "sourceFile": "/src/app/lobby/[roomSlug]/page.tsx",
@@ -5837,7 +5887,7 @@
         "authenticated"
       ],
       "example": "/lobby/main-room",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757648"
     },
     {
       "sourceFile": "/src/app/lobby/new/page.tsx",
@@ -5864,7 +5914,7 @@
         "admin"
       ],
       "example": "/lobby/new?copyFrom=bruised-banana",
-      "id": "page_campaign_1781698181677"
+      "id": "page_campaign_1782498757649"
     },
     {
       "sourceFile": "/src/app/lobby/new/page.tsx",
@@ -5891,7 +5941,7 @@
         "admin"
       ],
       "example": "/lobby/new?copyFrom=bruised-banana",
-      "id": "page_campaign_1781698181677"
+      "id": "page_campaign_1782498757649"
     },
     {
       "sourceFile": "/src/app/lobby/page.tsx",
@@ -5917,7 +5967,7 @@
         "authenticated"
       ],
       "example": "/lobby",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757649"
     },
     {
       "sourceFile": "/src/app/lobby/page.tsx",
@@ -5943,7 +5993,7 @@
         "authenticated"
       ],
       "example": "/lobby",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757649"
     },
     {
       "sourceFile": "/src/app/login/page.tsx",
@@ -5964,12 +6014,12 @@
       "method": "PAGE",
       "pattern": "/login",
       "entity": "PLAYER",
-      "description": "Login page - email-based authentication with * 2. If already logged in, redirect home. We no longer use a standalone onboarding controller\nbehind the scenes; the dashboard handles orientation states.",
+      "description": "Plain MGA login — email/password, no Conclave story. Claims any\npending deck-card BAR (bars_deck_pending cookie) into the account on success.",
       "permissions": [
         "public"
       ],
-      "example": "/login?returnTo=/create-bar",
-      "id": "page_player_1781698181677"
+      "example": "/login?returnTo=/deck",
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/login/page.tsx",
@@ -5990,12 +6040,12 @@
       "method": "PAGE",
       "pattern": "/login",
       "entity": "PLAYER",
-      "description": "Login page - email-based authentication with * 2. If already logged in, redirect home. We no longer use a standalone onboarding controller\nbehind the scenes; the dashboard handles orientation states.",
+      "description": "Plain MGA login — email/password, no Conclave story. Claims any\npending deck-card BAR (bars_deck_pending cookie) into the account on success.",
       "permissions": [
         "public"
       ],
-      "example": "/login?returnTo=/create-bar",
-      "id": "page_player_1781698181677"
+      "example": "/login?returnTo=/deck",
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/map/page.tsx",
@@ -6021,7 +6071,7 @@
         "authenticated"
       ],
       "example": "/map?type=vibeulon → redirects to /wallet",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757649"
     },
     {
       "sourceFile": "/src/app/map/page.tsx",
@@ -6047,7 +6097,7 @@
         "authenticated"
       ],
       "example": "/map?type=vibeulon → redirects to /wallet",
-      "id": "page_system_1781698181677"
+      "id": "page_system_1782498757649"
     },
     {
       "sourceFile": "/src/app/nation/[id]/page.tsx",
@@ -6073,7 +6123,7 @@
         "public"
       ],
       "example": "/nation/argyra",
-      "id": "page_player_1781698181677"
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/nation/[id]/page.tsx",
@@ -6099,7 +6149,7 @@
         "public"
       ],
       "example": "/nation/argyra",
-      "id": "page_player_1781698181677"
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/nation/page.tsx",
@@ -6125,7 +6175,7 @@
         "authenticated"
       ],
       "example": "/nation → redirects to /nation/argyra",
-      "id": "page_player_1781698181677"
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/nation/page.tsx",
@@ -6151,7 +6201,7 @@
         "authenticated"
       ],
       "example": "/nation → redirects to /nation/argyra",
-      "id": "page_player_1781698181677"
+      "id": "page_player_1782498757649"
     },
     {
       "sourceFile": "/src/app/onboarding/page.tsx",
@@ -6177,7 +6227,7 @@
         "authenticated"
       ],
       "example": "/onboarding",
-      "id": "page_player_1781698181678"
+      "id": "page_player_1782498757650"
     },
     {
       "sourceFile": "/src/app/onboarding/page.tsx",
@@ -6203,57 +6253,7 @@
         "authenticated"
       ],
       "example": "/onboarding",
-      "id": "page_player_1781698181678"
-    },
-    {
-      "sourceFile": "/src/app/page.tsx",
-      "lineNumber": 102,
-      "params": [],
-      "query": [],
-      "relationships": [],
-      "dimensions": {
-        "WHO": "currentPlayer",
-        "WHAT": "PLAYER",
-        "WHERE": "allyshipDomain",
-        "ENERGY": "vibulon"
-      },
-      "energyCost": 0,
-      "agentDiscoverable": false,
-      "experimental": false,
-      "method": "PAGE",
-      "pattern": "/",
-      "entity": "PLAYER",
-      "description": "Home page dashboard with journey threads, quest packs, and charge capture",
-      "permissions": [
-        "authenticated (redirects to /arrival if not authenticated)"
-      ],
-      "example": "/?focusQuest=quest_123&ref=campaign_invite",
-      "id": "page_player_1781698181678"
-    },
-    {
-      "sourceFile": "/src/app/page.tsx",
-      "lineNumber": 102,
-      "params": [],
-      "query": [],
-      "relationships": [],
-      "dimensions": {
-        "WHO": "currentPlayer",
-        "WHAT": "PLAYER",
-        "WHERE": "allyshipDomain",
-        "ENERGY": "vibulon"
-      },
-      "energyCost": 0,
-      "agentDiscoverable": false,
-      "experimental": false,
-      "method": "PAGE",
-      "pattern": "/",
-      "entity": "PLAYER",
-      "description": "Home page dashboard with journey threads, quest packs, and charge capture",
-      "permissions": [
-        "authenticated (redirects to /arrival if not authenticated)"
-      ],
-      "example": "/?focusQuest=quest_123&ref=campaign_invite",
-      "id": "page_player_1781698181678"
+      "id": "page_player_1782498757650"
     },
     {
       "sourceFile": "/src/app/play/page.tsx",
@@ -6279,7 +6279,7 @@
         "authenticated"
       ],
       "example": "/play",
-      "id": "page_system_1781698181678"
+      "id": "page_system_1782498757650"
     },
     {
       "sourceFile": "/src/app/play/page.tsx",
@@ -6305,7 +6305,7 @@
         "authenticated"
       ],
       "example": "/play",
-      "id": "page_system_1781698181678"
+      "id": "page_system_1782498757650"
     },
     {
       "sourceFile": "/src/app/pricing/page.tsx",
@@ -6330,7 +6330,7 @@
         "public"
       ],
       "example": "/pricing",
-      "id": "page_system_1781698181678"
+      "id": "page_system_1782498757650"
     },
     {
       "sourceFile": "/src/app/pricing/page.tsx",
@@ -6355,7 +6355,7 @@
         "public"
       ],
       "example": "/pricing",
-      "id": "page_system_1781698181678"
+      "id": "page_system_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/[questId]/unpack/page.tsx",
@@ -6382,7 +6382,7 @@
         "owner_or_claimer"
       ],
       "example": "/quest/quest_123/unpack",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/[questId]/unpack/page.tsx",
@@ -6409,7 +6409,7 @@
         "owner_or_claimer"
       ],
       "example": "/quest/quest_123/unpack",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/create/page.tsx",
@@ -6436,7 +6436,7 @@
         "profile_complete"
       ],
       "example": "/quest/create?from=gameboard&questId=q123&slotId=s456&campaignRef=bruised-banana",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/create/page.tsx",
@@ -6463,7 +6463,7 @@
         "profile_complete"
       ],
       "example": "/quest/create?from=gameboard&questId=q123&slotId=s456&campaignRef=bruised-banana",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/page.tsx",
@@ -6490,7 +6490,7 @@
         "game_account_ready"
       ],
       "example": "/quest",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/quest/page.tsx",
@@ -6517,7 +6517,7 @@
         "game_account_ready"
       ],
       "example": "/quest",
-      "id": "page_quest_1781698181678"
+      "id": "page_quest_1782498757650"
     },
     {
       "sourceFile": "/src/app/reliquary/page.tsx",
@@ -6543,7 +6543,7 @@
         "authenticated"
       ],
       "example": "/reliquary",
-      "id": "page_player_1781698181678"
+      "id": "page_player_1782498757651"
     },
     {
       "sourceFile": "/src/app/reliquary/page.tsx",
@@ -6569,7 +6569,7 @@
         "authenticated"
       ],
       "example": "/reliquary",
-      "id": "page_player_1781698181678"
+      "id": "page_player_1782498757651"
     },
     {
       "sourceFile": "/src/app/shadow/321/page.tsx",
@@ -6595,7 +6595,7 @@
         "authenticated"
       ],
       "example": "/shadow/321?chargeBarId=bar_123&returnTo=/capture&personalMove=growUp",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
     },
     {
       "sourceFile": "/src/app/shadow/321/page.tsx",
@@ -6621,7 +6621,59 @@
         "authenticated"
       ],
       "example": "/shadow/321?chargeBarId=bar_123&returnTo=/capture&personalMove=growUp",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
+    },
+    {
+      "sourceFile": "/src/app/signup/page.tsx",
+      "lineNumber": 20,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "playerId",
+        "WHAT": "PLAYER",
+        "WHERE": "auth",
+        "ENERGY": "N/A",
+        "PERSONAL_THROUGHPUT": "open_up"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": false,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/signup",
+      "entity": "PLAYER",
+      "description": "Plain MGA signup — email/password account creation, no Conclave story.\nClaims any pending deck-card BAR (bars_deck_pending cookie) into the new account.",
+      "permissions": [
+        "public"
+      ],
+      "example": "/signup?returnTo=/deck",
+      "id": "page_player_1782498757651"
+    },
+    {
+      "sourceFile": "/src/app/signup/page.tsx",
+      "lineNumber": 20,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "playerId",
+        "WHAT": "PLAYER",
+        "WHERE": "auth",
+        "ENERGY": "N/A",
+        "PERSONAL_THROUGHPUT": "open_up"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": false,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/signup",
+      "entity": "PLAYER",
+      "description": "Plain MGA signup — email/password account creation, no Conclave story.\nClaims any pending deck-card BAR (bars_deck_pending cookie) into the new account.",
+      "permissions": [
+        "public"
+      ],
+      "example": "/signup?returnTo=/deck",
+      "id": "page_player_1782498757651"
     },
     {
       "sourceFile": "/src/app/story/[id]/page.tsx",
@@ -6647,7 +6699,7 @@
         "authenticated"
       ],
       "example": "/story/invitation",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
     },
     {
       "sourceFile": "/src/app/story/[id]/page.tsx",
@@ -6673,7 +6725,7 @@
         "authenticated"
       ],
       "example": "/story/invitation",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
     },
     {
       "sourceFile": "/src/app/story/page.tsx",
@@ -6699,7 +6751,7 @@
         "authenticated"
       ],
       "example": "/story",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
     },
     {
       "sourceFile": "/src/app/story/page.tsx",
@@ -6725,7 +6777,7 @@
         "authenticated"
       ],
       "example": "/story",
-      "id": "page_system_1781698181679"
+      "id": "page_system_1782498757651"
     },
     {
       "sourceFile": "/src/app/swap-organizer/[slug]/page.tsx",
@@ -6752,7 +6804,7 @@
         "organizer_or_admin"
       ],
       "example": "/swap-organizer/pdx-art-swap-2026",
-      "id": "page_event_1781698181679"
+      "id": "page_event_1782498757651"
     },
     {
       "sourceFile": "/src/app/swap-organizer/[slug]/page.tsx",
@@ -6779,7 +6831,7 @@
         "organizer_or_admin"
       ],
       "example": "/swap-organizer/pdx-art-swap-2026",
-      "id": "page_event_1781698181679"
+      "id": "page_event_1782498757651"
     },
     {
       "sourceFile": "/src/app/threshold-encounter/[id]/page.tsx",
@@ -6806,7 +6858,7 @@
         "owner_only"
       ],
       "example": "/threshold-encounter/enc_123",
-      "id": "page_quest_1781698181694"
+      "id": "page_quest_1782498757652"
     },
     {
       "sourceFile": "/src/app/threshold-encounter/[id]/page.tsx",
@@ -6833,7 +6885,7 @@
         "owner_only"
       ],
       "example": "/threshold-encounter/enc_123",
-      "id": "page_quest_1781698181694"
+      "id": "page_quest_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/charges/page.tsx",
@@ -6859,7 +6911,7 @@
         "authenticated"
       ],
       "example": "/vault/charges",
-      "id": "page_bar_1781698181694"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/charges/page.tsx",
@@ -6885,7 +6937,7 @@
         "authenticated"
       ],
       "example": "/vault/charges",
-      "id": "page_bar_1781698181694"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/compost/page.tsx",
@@ -6911,7 +6963,7 @@
         "authenticated"
       ],
       "example": "/vault/compost",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/compost/page.tsx",
@@ -6937,7 +6989,7 @@
         "authenticated"
       ],
       "example": "/vault/compost",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/drafts/page.tsx",
@@ -6963,7 +7015,7 @@
         "authenticated"
       ],
       "example": "/vault/drafts",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/drafts/page.tsx",
@@ -6989,7 +7041,7 @@
         "authenticated"
       ],
       "example": "/vault/drafts",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/invitations/page.tsx",
@@ -7015,7 +7067,7 @@
         "authenticated"
       ],
       "example": "/vault/invitations",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/invitations/page.tsx",
@@ -7041,11 +7093,61 @@
         "authenticated"
       ],
       "example": "/vault/invitations",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
+    },
+    {
+      "sourceFile": "/src/app/vault/open-up/page.tsx",
+      "lineNumber": 18,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "player",
+        "WHAT": "felt-sense room",
+        "WHERE": "vault",
+        "ENERGY": "open_up"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": false,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/vault/open-up",
+      "entity": "BAR",
+      "description": "Vault Open Up room (Felt sense) — feel into what's alive before acting on it",
+      "permissions": [
+        "authenticated"
+      ],
+      "example": "/vault/open-up",
+      "id": "page_bar_1782498757652"
+    },
+    {
+      "sourceFile": "/src/app/vault/open-up/page.tsx",
+      "lineNumber": 18,
+      "params": [],
+      "query": [],
+      "relationships": [],
+      "dimensions": {
+        "WHO": "player",
+        "WHAT": "felt-sense room",
+        "WHERE": "vault",
+        "ENERGY": "open_up"
+      },
+      "energyCost": 0,
+      "agentDiscoverable": false,
+      "experimental": false,
+      "method": "PAGE",
+      "pattern": "/vault/open-up",
+      "entity": "BAR",
+      "description": "Vault Open Up room (Felt sense) — feel into what's alive before acting on it",
+      "permissions": [
+        "authenticated"
+      ],
+      "example": "/vault/open-up",
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/page.tsx",
-      "lineNumber": 26,
+      "lineNumber": 23,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7062,16 +7164,16 @@
       "method": "PAGE",
       "pattern": "/vault",
       "entity": "SYSTEM",
-      "description": "Vault lobby showing player's personal workspace: charges, quests, BARs, compost, invites, and 4-move dashboard",
+      "description": "Personal Vault lobby for the individual practitioner: the five move-rooms (Wake · Open · Clean · Grow · Show) plus a compost nudge. Campaign/scene clutter lives behind campaign contexts, not here.",
       "permissions": [
         "authenticated"
       ],
       "example": "/vault?quest=quest-123",
-      "id": "page_system_1781698181695"
+      "id": "page_system_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/page.tsx",
-      "lineNumber": 26,
+      "lineNumber": 23,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7088,12 +7190,12 @@
       "method": "PAGE",
       "pattern": "/vault",
       "entity": "SYSTEM",
-      "description": "Vault lobby showing player's personal workspace: charges, quests, BARs, compost, invites, and 4-move dashboard",
+      "description": "Personal Vault lobby for the individual practitioner: the five move-rooms (Wake · Open · Clean · Grow · Show) plus a compost nudge. Campaign/scene clutter lives behind campaign contexts, not here.",
       "permissions": [
         "authenticated"
       ],
       "example": "/vault?quest=quest-123",
-      "id": "page_system_1781698181695"
+      "id": "page_system_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/quests/page.tsx",
@@ -7118,7 +7220,7 @@
         "authenticated"
       ],
       "example": "/vault/quests?quest=quest_123",
-      "id": "page_quest_1781698181695"
+      "id": "page_quest_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/quests/page.tsx",
@@ -7143,7 +7245,7 @@
         "authenticated"
       ],
       "example": "/vault/quests?quest=quest_123",
-      "id": "page_quest_1781698181695"
+      "id": "page_quest_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/who/page.tsx",
@@ -7169,7 +7271,7 @@
         "authenticated"
       ],
       "example": "/vault/who",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/vault/who/page.tsx",
@@ -7195,7 +7297,7 @@
         "authenticated"
       ],
       "example": "/vault/who",
-      "id": "page_bar_1781698181695"
+      "id": "page_bar_1782498757652"
     },
     {
       "sourceFile": "/src/app/wallet/page.tsx",
@@ -7221,7 +7323,7 @@
         "authenticated"
       ],
       "example": "/wallet",
-      "id": "page_player_1781698181695"
+      "id": "page_player_1782498757652"
     },
     {
       "sourceFile": "/src/app/wallet/page.tsx",
@@ -7247,7 +7349,7 @@
         "authenticated"
       ],
       "example": "/wallet",
-      "id": "page_player_1781698181695"
+      "id": "page_player_1782498757652"
     },
     {
       "sourceFile": "/src/app/wiki/321-shadow-process/page.tsx",
@@ -7266,7 +7368,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/321-shadow-process/page.tsx",
@@ -7285,11 +7387,11 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/archetypes/page.tsx",
-      "lineNumber": 15,
+      "lineNumber": 21,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7311,11 +7413,11 @@
         "public"
       ],
       "example": "/wiki/archetypes",
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/archetypes/page.tsx",
-      "lineNumber": 15,
+      "lineNumber": 21,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7337,7 +7439,7 @@
         "public"
       ],
       "example": "/wiki/archetypes",
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/campaign/bruised-banana/house/page.tsx",
@@ -7363,7 +7465,7 @@
         "public"
       ],
       "example": "/wiki/campaign/bruised-banana/house",
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/campaign/bruised-banana/house/page.tsx",
@@ -7389,7 +7491,7 @@
         "public"
       ],
       "example": "/wiki/campaign/bruised-banana/house",
-      "id": "page_wiki_1781698181695"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/glossary/page.tsx",
@@ -7415,7 +7517,7 @@
         "public"
       ],
       "example": "/wiki/glossary",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/glossary/page.tsx",
@@ -7441,7 +7543,7 @@
         "public"
       ],
       "example": "/wiki/glossary",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/grid-deck/page.tsx",
@@ -7467,7 +7569,7 @@
         "public"
       ],
       "example": "/wiki/grid-deck",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/grid-deck/page.tsx",
@@ -7493,7 +7595,7 @@
         "public"
       ],
       "example": "/wiki/grid-deck",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/handbook/play/page.tsx",
@@ -7512,7 +7614,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/handbook/play/page.tsx",
@@ -7531,7 +7633,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/grill-master/page.tsx",
@@ -7551,7 +7653,7 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/grill-master/page.tsx",
@@ -7571,7 +7673,7 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/page.tsx",
@@ -7591,7 +7693,7 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/page.tsx",
@@ -7611,7 +7713,7 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/signal/page.tsx",
@@ -7631,7 +7733,7 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757653"
     },
     {
       "sourceFile": "/src/app/wiki/hidden/signal/page.tsx",
@@ -7651,11 +7753,11 @@
         "public (hidden",
         "no nav link)"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757654"
     },
     {
       "sourceFile": "/src/app/wiki/nations/page.tsx",
-      "lineNumber": 15,
+      "lineNumber": 21,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7677,11 +7779,11 @@
         "public"
       ],
       "example": "/wiki/nations",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757654"
     },
     {
       "sourceFile": "/src/app/wiki/nations/page.tsx",
-      "lineNumber": 15,
+      "lineNumber": 21,
       "params": [],
       "query": [],
       "relationships": [],
@@ -7703,7 +7805,7 @@
         "public"
       ],
       "example": "/wiki/nations",
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757654"
     },
     {
       "sourceFile": "/src/app/wiki/privacy/page.tsx",
@@ -7722,7 +7824,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757654"
     },
     {
       "sourceFile": "/src/app/wiki/privacy/page.tsx",
@@ -7741,7 +7843,7 @@
       "permissions": [
         "public"
       ],
-      "id": "page_wiki_1781698181696"
+      "id": "page_wiki_1782498757654"
     }
   ],
   "relationships": {

--- a/src/actions/campaign-invitation.ts
+++ b/src/actions/campaign-invitation.ts
@@ -161,10 +161,13 @@ export async function playerCanAccessEventCalendar(playerId: string, eventArtifa
     where: { id: eventArtifactId },
     select: {
       instanceId: true,
+      visibility: true,
       campaign: { select: { instanceId: true } },
     },
   })
   if (!ev) return false
+  // Events made discoverable to all players are addable to calendar by anyone.
+  if (ev.visibility === 'public' || ev.visibility === 'discoverable') return true
   const inst = ev.instanceId ?? ev.campaign?.instanceId
   if (!inst) return false
   if (await canInviteToAnyEventOnInstance(playerId, inst)) return true

--- a/src/actions/event-artifact.ts
+++ b/src/actions/event-artifact.ts
@@ -5,6 +5,10 @@ import { db } from '@/lib/db'
 import { getCurrentPlayer } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
 import { validatePrimaryDomain, validateSecondaryDomain } from '@/lib/event-campaign/domains'
+import {
+  DISCOVERABLE_VISIBILITIES,
+  type PlayerEventOverviewItem,
+} from '@/lib/event-discoverability'
 
 export type CreateEventInput = {
   linkedCampaignId: string
@@ -280,23 +284,6 @@ export async function getEventCalendarExport(
     timezone: event.timezone,
   })
   return { success: true, ics }
-}
-
-/** Visibility values that make an event discoverable to all logged-in players. */
-export const DISCOVERABLE_VISIBILITIES = ['public', 'discoverable'] as const
-
-export type PlayerEventOverviewItem = {
-  id: string
-  title: string
-  description: string
-  startTime: Date | null
-  endTime: Date | null
-  timezone: string | null
-  locationType: string
-  locationDetails: string | null
-  instanceId: string | null
-  visibility: string
-  status: string
 }
 
 const PLAYER_EVENT_SELECT = {

--- a/src/actions/event-artifact.ts
+++ b/src/actions/event-artifact.ts
@@ -282,6 +282,100 @@ export async function getEventCalendarExport(
   return { success: true, ics }
 }
 
+/** Visibility values that make an event discoverable to all logged-in players. */
+export const DISCOVERABLE_VISIBILITIES = ['public', 'discoverable'] as const
+
+export type PlayerEventOverviewItem = {
+  id: string
+  title: string
+  description: string
+  startTime: Date | null
+  endTime: Date | null
+  timezone: string | null
+  locationType: string
+  locationDetails: string | null
+  instanceId: string | null
+  visibility: string
+  status: string
+}
+
+const PLAYER_EVENT_SELECT = {
+  id: true,
+  title: true,
+  description: true,
+  startTime: true,
+  endTime: true,
+  timezone: true,
+  locationType: true,
+  locationDetails: true,
+  instanceId: true,
+  visibility: true,
+  status: true,
+} as const
+
+/**
+ * Events surface for the EVENTS nav: events the current player is subscribed to
+ * (RSVP'd or invited) plus events made discoverable to everyone. Replaces the
+ * hardcoded single-instance (Bruised Banana) event page as the nav target.
+ */
+export async function getPlayerEventsOverview(): Promise<{
+  subscribed: PlayerEventOverviewItem[]
+  discoverable: PlayerEventOverviewItem[]
+}> {
+  const player = await getCurrentPlayer()
+  const empty = { subscribed: [], discoverable: [] }
+  if (!player) return empty
+
+  try {
+    const HIDDEN_STATUSES = ['draft', 'archived']
+
+    // Subscribed: player has RSVP'd yes, or has a non-declined invite.
+    const [participantRows, inviteRows] = await Promise.all([
+      db.eventParticipant.findMany({
+        where: { participantId: player.id, participantState: 'RSVP_yes' },
+        select: { event: { select: PLAYER_EVENT_SELECT } },
+      }),
+      db.eventInvite.findMany({
+        where: { actorId: player.id, inviteStatus: { not: 'declined' } },
+        select: { event: { select: PLAYER_EVENT_SELECT } },
+      }),
+    ])
+
+    const subscribedById = new Map<string, PlayerEventOverviewItem>()
+    for (const row of [...participantRows, ...inviteRows]) {
+      const ev = row.event
+      if (!ev || HIDDEN_STATUSES.includes(ev.status)) continue
+      subscribedById.set(ev.id, ev)
+    }
+
+    // Discoverable: visible to everyone, not draft/archived, upcoming or undated.
+    const now = new Date()
+    const discoverableRows = await db.eventArtifact.findMany({
+      where: {
+        visibility: { in: [...DISCOVERABLE_VISIBILITIES] },
+        status: { notIn: HIDDEN_STATUSES },
+        OR: [{ startTime: null }, { startTime: { gte: now } }],
+      },
+      orderBy: { startTime: 'asc' },
+      select: PLAYER_EVENT_SELECT,
+    })
+
+    const subscribed = [...subscribedById.values()].sort(sortByStartTime)
+    const discoverable = discoverableRows.filter((ev) => !subscribedById.has(ev.id))
+
+    return { subscribed, discoverable }
+  } catch (e: unknown) {
+    console.error('[event-artifact] getPlayerEventsOverview failed:', e)
+    return empty
+  }
+}
+
+function sortByStartTime(a: PlayerEventOverviewItem, b: PlayerEventOverviewItem): number {
+  const at = a.startTime ? a.startTime.getTime() : Number.POSITIVE_INFINITY
+  const bt = b.startTime ? b.startTime.getTime() : Number.POSITIVE_INFINITY
+  return at - bt
+}
+
 /**
  * Mark event complete.
  */

--- a/src/app/event/EditEventDetailsButton.tsx
+++ b/src/app/event/EditEventDetailsButton.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/actions/campaign-invitation'
 import type { EventArtifactListItem } from '@/lib/event-artifact-list-types'
 
-const VISIBILITY = ['campaign_visible', 'private', 'public'] as const
+const VISIBILITY = ['campaign_visible', 'private', 'public', 'discoverable'] as const
 const STATUS = ['draft', 'scheduled', 'live', 'completed', 'recorded', 'archived'] as const
 
 export function EditEventDetailsButton({

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,145 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { getCurrentPlayer } from '@/lib/auth'
+import {
+  getPlayerEventsOverview,
+  type PlayerEventOverviewItem,
+} from '@/actions/event-artifact'
+
+/**
+ * @page /events
+ * @entity EVENT
+ * @description The player's events surface — events they're subscribed to
+ *   (RSVP'd or invited) plus events made discoverable to everyone. This is the
+ *   EVENTS nav target, replacing the single active-instance event page so the
+ *   nav no longer hard-pushes one campaign (e.g. Bruised Banana).
+ * @permissions authenticated
+ * @relationships EVENT (EventArtifact), PLAYER (participant/invitee)
+ * @agentDiscoverable true
+ */
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Events',
+  description: 'Events you are subscribed to, plus events open to everyone.',
+}
+
+function formatWhen(ev: PlayerEventOverviewItem): string {
+  if (!ev.startTime) return 'Date TBD'
+  const opts: Intl.DateTimeFormatOptions = {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: ev.timezone ?? undefined,
+  }
+  try {
+    return new Intl.DateTimeFormat('en-US', opts).format(ev.startTime)
+  } catch {
+    return new Intl.DateTimeFormat('en-US', { ...opts, timeZone: undefined }).format(ev.startTime)
+  }
+}
+
+function formatWhere(ev: PlayerEventOverviewItem): string {
+  if (ev.locationDetails) return ev.locationDetails
+  if (ev.locationType === 'in_app' || ev.locationType === 'in-app') return 'In-app'
+  if (ev.locationType === 'virtual' || ev.locationType === 'online') return 'Online'
+  return ev.locationType || 'Location TBD'
+}
+
+function EventCard({ ev }: { ev: PlayerEventOverviewItem }) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-bold text-white leading-snug">{ev.title}</h3>
+        <div className="text-xs text-zinc-500 flex flex-wrap gap-x-3 gap-y-1">
+          <span>{formatWhen(ev)}</span>
+          <span aria-hidden>·</span>
+          <span>{formatWhere(ev)}</span>
+        </div>
+      </div>
+      {ev.description && (
+        <p className="text-sm text-zinc-400 leading-relaxed line-clamp-3">{ev.description}</p>
+      )}
+      <div className="flex flex-wrap gap-3 pt-1 text-xs font-semibold">
+        {ev.instanceId && (
+          <Link href="/event" className="text-green-400 hover:text-green-300">
+            View details →
+          </Link>
+        )}
+        {ev.startTime && (
+          <a
+            href={`/api/events/${ev.id}/ics`}
+            className="text-zinc-400 hover:text-zinc-200"
+          >
+            Add to calendar
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default async function EventsPage() {
+  const player = await getCurrentPlayer()
+  if (!player) redirect('/login')
+
+  const { subscribed, discoverable } = await getPlayerEventsOverview()
+  const hasAny = subscribed.length > 0 || discoverable.length > 0
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="mx-auto w-full max-w-2xl px-4 pt-20 pb-16 space-y-10">
+        <header className="space-y-2">
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-zinc-500">
+            Events
+          </p>
+          <h1 className="text-2xl font-bold tracking-tight">What you can show up for</h1>
+          <p className="text-sm text-zinc-400">
+            Events you&apos;re subscribed to, plus what&apos;s open to everyone.
+          </p>
+        </header>
+
+        {!hasAny && (
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-6 text-center space-y-3">
+            <p className="text-sm text-zinc-400">
+              Nothing on your calendar yet. When you RSVP to an event or get invited, it shows up
+              here — along with anything the campaign opens to all players.
+            </p>
+            <Link href="/" className="inline-block text-sm font-semibold text-green-400 hover:text-green-300">
+              Back to Now →
+            </Link>
+          </div>
+        )}
+
+        {subscribed.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+              Your events
+            </h2>
+            <div className="space-y-3">
+              {subscribed.map((ev) => (
+                <EventCard key={ev.id} ev={ev} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {discoverable.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+              Open to everyone
+            </h2>
+            <div className="space-y-3">
+              {discoverable.map((ev) => (
+                <EventCard key={ev.id} ev={ev} />
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,10 +2,8 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getCurrentPlayer } from '@/lib/auth'
-import {
-  getPlayerEventsOverview,
-  type PlayerEventOverviewItem,
-} from '@/actions/event-artifact'
+import { getPlayerEventsOverview } from '@/actions/event-artifact'
+import type { PlayerEventOverviewItem } from '@/lib/event-discoverability'
 
 /**
  * @page /events

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,6 +19,12 @@ export function NavBar({ isAdmin, isAuthenticated }: { isAdmin: boolean; isAuthe
                      pathname.startsWith('/wallet') ||
                      pathname.startsWith('/daemons') ||
                      pathname.startsWith('/capture')
+        } else if (path === '/events') {
+            // EVENTS: active on the events index and the single-instance event page
+            active = pathname === '/events' ||
+                     pathname.startsWith('/events/') ||
+                     pathname === '/event' ||
+                     pathname.startsWith('/event/')
         } else {
             active = pathname === path || pathname.startsWith(`${path}/`)
         }
@@ -27,57 +33,43 @@ export function NavBar({ isAdmin, isAuthenticated }: { isAdmin: boolean; isAuthe
 
     return (
         <nav className="fixed top-0 left-0 right-0 h-14 border-b border-zinc-900 bg-black/80 backdrop-blur z-50 flex items-center justify-between px-3 sm:px-8 font-mono text-xs">
-            <div className="flex items-center gap-1 sm:gap-4">
+            <div className="flex items-center gap-1 sm:gap-4 min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                 {isAuthenticated && (
                     <>
                         <Link
                             href="/"
-                            title="Orient your session: daily check-in, compass, and what to do next."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/')}`}
+                            title="Orient your session: daily check-in, compass, what to do next — and zoom through time in the Observatory."
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/')}`}
                         >
                             NOW
                         </Link>
                         <Link
-                            href="/observatory"
-                            title="The Observatory: zoom through time — orientation, vision, year, quarter, month, week, today."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/observatory')}`}
-                        >
-                            OBSERVATORY
-                        </Link>
-                        <Link
                             href="/vault"
                             title="Your private studio: charges, quests, drafts, invitations — metabolize what you are carrying."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/vault')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/vault')}`}
                         >
                             VAULT
                         </Link>
                         <Link
                             href="/garden"
                             title="Your Garden: the BARs you've planted, growing under your lenses."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/garden')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/garden')}`}
                         >
                             GARDEN
                         </Link>
                         <Link
-                            href="/event"
-                            title="Residency nights, donate, invite bingo — show up for the campaign."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/event')}`}
+                            href="/events"
+                            title="Events you're subscribed to, plus events open to all players."
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/events')}`}
                         >
                             EVENTS
                         </Link>
                         <Link
                             href="/adventures"
                             title="Active play: shadow work, journeys, daemons, campaigns, and published adventures."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/adventures')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/adventures')}`}
                         >
                             PLAY
-                        </Link>
-                        <Link
-                            href="/bars/capture"
-                            title="Forge a BAR: turn a charged moment into an artifact you can grow into a quest."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/bars/capture')}`}
-                        >
-                            + BAR
                         </Link>
                     </>
                 )}
@@ -86,28 +78,28 @@ export function NavBar({ isAdmin, isAuthenticated }: { isAdmin: boolean; isAuthe
                         <Link
                             href="/launch"
                             title="The book, the deck, and the game — start here."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/launch')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/launch')}`}
                         >
                             START
                         </Link>
                         <Link
                             href="/handbook"
                             title="Read the front of the book, phone-first. Free."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/handbook')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/handbook')}`}
                         >
                             BOOK
                         </Link>
                         <Link
                             href="/deck/sales"
                             title="The Allyship Deck — 120 cards. See what's inside."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/deck')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/deck')}`}
                         >
                             DECK
                         </Link>
                         <Link
                             href="/game/index.html"
                             title="Play Mastering the Game of Allyship in your browser. No account needed."
-                            className={`px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/game')}`}
+                            className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/game')}`}
                         >
                             PLAY
                         </Link>
@@ -120,7 +112,16 @@ export function NavBar({ isAdmin, isAuthenticated }: { isAdmin: boolean; isAuthe
                 )}
             </div>
 
-            <div className="flex items-center gap-2 sm:gap-3">
+            <div className="flex items-center gap-2 sm:gap-3 shrink-0">
+                {isAuthenticated && (
+                    <Link
+                        href="/bars/capture"
+                        title="Forge a BAR: turn a charged moment into an artifact you can grow into a quest."
+                        className={`shrink-0 px-3 sm:px-4 py-3 rounded transition-colors ${isActive('/bars/capture')}`}
+                    >
+                        + BAR
+                    </Link>
+                )}
                 {isAuthenticated ? <SiteSignalNavTrigger /> : null}
                 {isAuthenticated && (
                     <>

--- a/src/components/now/NowHome.tsx
+++ b/src/components/now/NowHome.tsx
@@ -120,6 +120,37 @@ export async function NowHome({ playerId, vibulons }: NowHomeProps) {
             gardenCount={barCounts.gardenCount}
           />
 
+          {/* Observatory — folded into Now: zoom through time across your lenses */}
+          <Link
+            href="/observatory"
+            style={{
+              textDecoration: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+              padding: '13px 16px',
+              borderRadius: 10,
+              background: '#1a1a18',
+              boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.08)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 11, minWidth: 0 }}>
+              <span style={{ fontSize: 16, color: '#7c3aed', textShadow: '0 0 12px #7c3aed', lineHeight: 1 }}>
+                ◎
+              </span>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+                <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 700, fontSize: 13, color: '#e8e6e0', lineHeight: 1 }}>
+                  Observatory
+                </span>
+                <span style={{ fontFamily: 'Space Mono, monospace', fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: '#6b6965', lineHeight: 1 }}>
+                  Zoom through time · your lenses
+                </span>
+              </div>
+            </div>
+            <span style={{ fontFamily: 'Space Mono, monospace', fontSize: 11, color: '#6b6965' }}>→</span>
+          </Link>
+
           {/* Tap the Vein — daily ritual (sibling of Daily Charge, above it) */}
           <TapTheVeinPanel summary={ttvPanel} />
 

--- a/src/lib/event-discoverability.ts
+++ b/src/lib/event-discoverability.ts
@@ -1,0 +1,18 @@
+/** Shared, non-server constants/types for the player events surface. */
+
+/** Visibility values that make an event discoverable to all logged-in players. */
+export const DISCOVERABLE_VISIBILITIES = ['public', 'discoverable'] as const
+
+export type PlayerEventOverviewItem = {
+  id: string
+  title: string
+  description: string
+  startTime: Date | null
+  endTime: Date | null
+  timezone: string | null
+  locationType: string
+  locationDetails: string | null
+  instanceId: string | null
+  visibility: string
+  status: string
+}


### PR DESCRIPTION
## Why

The logged-in nav had grown so crowded that the action controls (**log out**, **+ BAR**, **feedback**) were pushed off-screen on narrow viewports, and **EVENTS** always rendered the single active instance — hardcoded to the Bruised Banana residency.

## What changed

### Nav declutter (`src/components/NavBar.tsx`)
- **Removed OBSERVATORY** from the nav — it now lives inside the Now page.
- **Pinned the action cluster** (`+ BAR`, feedback, **Disconnect**) with `shrink-0` and moved `+ BAR` into it, so these are always reachable.
- Page links (NOW · VAULT · GARDEN · EVENTS · PLAY) now **scroll horizontally** on overflow instead of pushing the actions off-screen.
- **EVENTS** now points at the new `/events` index (still highlights on `/event` too).

### Observatory folded into Now (`src/components/now/NowHome.tsx`)
- Added an Observatory entry card linking to `/observatory` (route unchanged).

### Events surface — retarget + discoverable flag
- New **`/events`** page lists:
  - **Your events** — anything the player RSVP'd to or was invited to.
  - **Open to everyone** — events admins mark discoverable (e.g. the July Allyship Launch Party), upcoming/undated only.
- `getPlayerEventsOverview()` in `event-artifact.ts` gathers both groups.
- Added a `discoverable` visibility option in the admin event editor.
- Public/discoverable events are now calendar-accessible to any logged-in player (so "Add to calendar" doesn't 403).

## Notes
The "stop pushing Bruised Banana" outcome depends on data, not just code: discoverable events only appear once an admin sets an event's visibility to `public`/`discoverable`, and the July Launch Party events need to exist as `EventArtifact`s. The plumbing is in place.

## Verification
- `tsc --noEmit` — passes
- `eslint` — 0 errors (pre-existing warnings only)
- Prisma schema validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDmnfLmkjg1JHp1wNZTeRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDmnfLmkjg1JHp1wNZTeRn)_