### PR TITLE
Add standalone 3·2·1 flow & refactor Plant triad component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,56 @@ DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DBNAME?schema=public"
 # to local FS in dev. Not needed for the superpower flow.
 # BLOB_READ_WRITE_TOKEN=""
 
-# Entitlement / commerce verification (marketing funnel works without these).
-# GUMROAD_VERIFY_MODE="mock"   # "mock" accepts TEST-… keys for local/tests
+# ─── Launch / Gumroad commerce (plug in products here) ─────────────────────────
+# The commerce spine (webhook → entitlement → access gate) is already built. To go
+# live you only set env: a product's buy button flips from "Setup pending" to live
+# the moment its NEXT_PUBLIC_GUMROAD_*_URL is non-empty (isOfferLive). The whole
+# marketing funnel works WITHOUT any of these — they unlock purchasing.
+# Full operational steps (create products, license keys, webhook Ping URL, go-live
+# checklist): docs/runbooks/GUMROAD_LAUNCH_SETUP.md + docs/ENV_AND_VERCEL.md.
+
+# Webhook — REQUIRED for purchases to grant access. Fail-closed if unset.
+# Gumroad seller Ping URL: https://<app>/api/webhooks/gumroad?token=<this secret>
+# GUMROAD_WEBHOOK_SECRET=""
+# GUMROAD_SELLER_ID=""                     # optional: pin the webhook to your seller
+# GUMROAD_PRODUCT_MAP=""                   # optional JSON: {"<permalink|product_id|name>":"<OfferKey>"}
+
+# Storefront URLs — set one to make that offer buyable on /launch. Core SKUs (7):
+# NEXT_PUBLIC_GUMROAD_BOOK_DIGITAL_URL=""        # book-digital
+# NEXT_PUBLIC_GUMROAD_BOOK_PHYSICAL_URL=""       # book-physical
+# NEXT_PUBLIC_GUMROAD_RPG_DIGITAL_URL=""         # rpg-handbook-digital
+# NEXT_PUBLIC_GUMROAD_RPG_PHYSICAL_URL=""        # rpg-handbook-physical
+# NEXT_PUBLIC_GUMROAD_DECK_DIGITAL_URL=""        # deck-digital
+# NEXT_PUBLIC_GUMROAD_GAME_SUB_URL=""            # game-subscription
+# NEXT_PUBLIC_GUMROAD_FOUNDING_ALLY_URL=""       # founding-ally
+# Superpower expansion packs (7):
+# NEXT_PUBLIC_GUMROAD_SP_CONNECTOR_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_STORYTELLER_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_STRATEGIST_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_DISRUPTOR_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_ALCHEMIST_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_ESCAPE_ARTIST_URL=""
+# NEXT_PUBLIC_GUMROAD_SP_COACH_URL=""
+# Loadout bundle (1):
+# NEXT_PUBLIC_GUMROAD_LOADOUT_BUNDLE_URL=""
+
+# License-verify fallback — per-SKU product ids let /redeem verify a raw Gumroad
+# license key if its sale webhook never fired. Pattern: GUMROAD_PRODUCT_ID_<SKU>
+# (SKU upper-cased, dashes→underscores). Recommended for the 7 core SKUs:
+# GUMROAD_PRODUCT_ID_BOOK_DIGITAL=""
+# GUMROAD_PRODUCT_ID_RPG_HANDBOOK_DIGITAL=""
+# GUMROAD_PRODUCT_ID_DECK_DIGITAL=""
+# GUMROAD_PRODUCT_ID_GAME_SUBSCRIPTION=""
+# GUMROAD_PRODUCT_ID_BOOK_PHYSICAL=""
+# GUMROAD_PRODUCT_ID_RPG_HANDBOOK_PHYSICAL=""
+# GUMROAD_PRODUCT_ID_FOUNDING_ALLY=""
+# GUMROAD_PRODUCT_ID=""                    # legacy single id, honored for book-digital
+# GUMROAD_MAX_USES="3"                     # max redemptions per license key
+# GUMROAD_VERIFY_MODE="mock"               # "mock" accepts TEST-… keys for local/tests; "live" in prod
+
+# Access gating — keep gates off until launch; pre-cutoff players are grandfathered.
+# ENABLE_LAUNCH_GATES="false"
+# LAUNCH_GATE_CUTOFF="2026-07-18T00:00:00Z"
 
 # ─── Build / migration switches (advanced; see build-with-env.ts) ──────────────
 # SKIP_PRISMA_MIGRATE_DEPLOY=1        # build without applying migrations

--- a/docs/runbooks/GUMROAD_LAUNCH_SETUP.md
+++ b/docs/runbooks/GUMROAD_LAUNCH_SETUP.md
@@ -64,6 +64,37 @@ cancellations reach the endpoint.
 | `ENABLE_LAUNCH_GATES` | launch toggle | `true` switches on the **soft** gates (game / app access). Leave unset/false until launch. |
 | `LAUNCH_GATE_CUTOFF` | launch toggle | ISO datetime; players created **before** it are grandfathered when soft gates switch on. Set to your launch moment so the existing community keeps access. |
 
+### Per-product reference (OfferKey → price → env var)
+
+One row per Gumroad product to create. Set the **buy-link** var to make the
+offer live on `/launch` (`isOfferLive` = non-empty URL). Set the **verify-id**
+var (core SKUs only) so `/redeem` can verify a raw license key if a sale webhook
+ever misfires. Prices are the current `priceCents` in `src/lib/launch/offers.ts`.
+
+| OfferKey (SKU) | Product | Price | Buy-link env (`NEXT_PUBLIC_…`) | Verify-id env (`GUMROAD_PRODUCT_ID_…`) |
+| :-- | :-- | :-- | :-- | :-- |
+| `founding-ally` | Founding Ally Bundle | $150 | `NEXT_PUBLIC_GUMROAD_FOUNDING_ALLY_URL` | `GUMROAD_PRODUCT_ID_FOUNDING_ALLY` |
+| `book-digital` | Mastering Allyship — Digital | $15 (PWYW) | `NEXT_PUBLIC_GUMROAD_BOOK_DIGITAL_URL` | `GUMROAD_PRODUCT_ID_BOOK_DIGITAL` (or legacy `GUMROAD_PRODUCT_ID`) |
+| `book-physical` | Mastering Allyship — Physical | $25 (preorder) | `NEXT_PUBLIC_GUMROAD_BOOK_PHYSICAL_URL` | `GUMROAD_PRODUCT_ID_BOOK_PHYSICAL` |
+| `rpg-handbook-digital` | RPG Handbook — Digital | $30 | `NEXT_PUBLIC_GUMROAD_RPG_DIGITAL_URL` | `GUMROAD_PRODUCT_ID_RPG_HANDBOOK_DIGITAL` |
+| `rpg-handbook-physical` | RPG Handbook — Physical | $49 (preorder) | `NEXT_PUBLIC_GUMROAD_RPG_PHYSICAL_URL` | `GUMROAD_PRODUCT_ID_RPG_HANDBOOK_PHYSICAL` |
+| `deck-digital` | Oracle Deck — Digital Access | $10 | `NEXT_PUBLIC_GUMROAD_DECK_DIGITAL_URL` | `GUMROAD_PRODUCT_ID_DECK_DIGITAL` |
+| `game-subscription` | The Game — Monthly | $10/mo | `NEXT_PUBLIC_GUMROAD_GAME_SUB_URL` | `GUMROAD_PRODUCT_ID_GAME_SUBSCRIPTION` |
+| `superpower-connector-pack` | Connector Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_CONNECTOR_URL` | — |
+| `superpower-storyteller-pack` | Storyteller Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_STORYTELLER_URL` | — |
+| `superpower-strategist-pack` | Strategist Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_STRATEGIST_URL` | — |
+| `superpower-disruptor-pack` | Disruptor Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_DISRUPTOR_URL` | — |
+| `superpower-alchemist-pack` | Alchemist Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_ALCHEMIST_URL` | — |
+| `superpower-escape_artist-pack` | Escape Artist Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_ESCAPE_ARTIST_URL` | — |
+| `superpower-coach-pack` | Coach Pack | $8 | `NEXT_PUBLIC_GUMROAD_SP_COACH_URL` | — |
+| `loadout-bundle` | Your Loadout Bundle | $20 | `NEXT_PUBLIC_GUMROAD_LOADOUT_BUNDLE_URL` | — |
+
+Notes: superpower packs and the loadout bundle have no verify-id fallback (the
+license-verify path covers the core SKUs in `src/lib/launch/grants.ts`). The
+loadout bundle's two packs are granted idempotently by SKU, so a deck owner whose
+inner pack was already auto-granted isn't re-charged. `GUMROAD_PRODUCT_MAP` can
+override product→SKU resolution if a Gumroad permalink doesn't match its URL.
+
 ## 4. Access gating
 
 - **Hard gate** (`checkAccess(cap)`) — always enforced. Net-new premium surfaces.

--- a/src/actions/tap-the-vein.ts
+++ b/src/actions/tap-the-vein.ts
@@ -39,37 +39,73 @@ const TTV_BAR_SEED_METABOLIZATION = mergeSeedMetabolization(null, {
  * commit — this keeps the Vault from flooding with micro-task BARs and avoids
  * task↔BAR drift (decided via the Six GM panel; reverses the eager H1).
  */
+/**
+ * Mint a self-rooted, private CustomBar from free text, attached to today's lens
+ * with the TTV "captured" seed provenance. Optionally links it back to a TTV task
+ * (`linkTaskId`) in the same transaction. Shared by the in-ritual Plant gesture
+ * and the standalone (no-task) 3·2·1 flow. Returns the new barId.
+ */
+async function createBarFromText(
+  playerId: string,
+  text: string,
+  linkTaskId?: string,
+): Promise<string> {
+  const title = text.length <= 80 ? text : text.slice(0, 77) + '...'
+  // Attach the BAR to today's lens (LENS first slice; best-effort).
+  const lens = await ensureTodayLens(playerId)
+  return await db.$transaction(async (tx) => {
+    const bar = await tx.customBar.create({
+      data: {
+        creatorId: playerId,
+        title: title || 'Untitled',
+        description: text,
+        type: 'bar',
+        reward: 0,
+        visibility: 'private',
+        status: 'active',
+        inputs: '[]',
+        rootId: 'temp',
+        lensId: lens?.id ?? null,
+        seedMetabolization: TTV_BAR_SEED_METABOLIZATION,
+      },
+      select: { id: true },
+    })
+    await tx.customBar.update({ where: { id: bar.id }, data: { rootId: bar.id } })
+    if (linkTaskId) {
+      await tx.tapTheVeinTask.update({ where: { id: linkTaskId }, data: { barId: bar.id } })
+    }
+    return bar.id
+  })
+}
+
+/**
+ * Write the EA-triad (desired outcome + current dissatisfaction + desired
+ * satisfaction) onto a BAR and place it in the player's Garden. Load-bearing for
+ * lens/campaign alignment + EA moves. Shared by `plantTask` and `plantStandalone`.
+ */
+async function writePlantTriadToBar(
+  playerId: string,
+  barId: string,
+  triad: { experienceIntent: string; dissatisfaction: string[]; satisfaction: string[] },
+): Promise<void> {
+  await db.customBar.update({
+    where: { id: barId },
+    data: {
+      gardenId: personalGardenId(playerId),
+      experienceIntent: triad.experienceIntent,
+      dissatisfaction: triad.dissatisfaction.join(EA_SEP),
+      satisfaction: triad.satisfaction.join(EA_SEP),
+    },
+  })
+}
+
 async function ensureBarForTask(
   playerId: string,
   task: { id: string; barId: string | null; originalText: string },
 ): Promise<string | null> {
   if (task.barId) return task.barId
   try {
-    const text = task.originalText
-    const title = text.length <= 80 ? text : text.slice(0, 77) + '...'
-    // Attach the BAR to today's lens (LENS first slice; best-effort).
-    const lens = await ensureTodayLens(playerId)
-    return await db.$transaction(async (tx) => {
-      const bar = await tx.customBar.create({
-        data: {
-          creatorId: playerId,
-          title: title || 'Tap the Vein task',
-          description: text,
-          type: 'bar',
-          reward: 0,
-          visibility: 'private',
-          status: 'active',
-          inputs: '[]',
-          rootId: 'temp',
-          lensId: lens?.id ?? null,
-          seedMetabolization: TTV_BAR_SEED_METABOLIZATION,
-        },
-        select: { id: true },
-      })
-      await tx.customBar.update({ where: { id: bar.id }, data: { rootId: bar.id } })
-      await tx.tapTheVeinTask.update({ where: { id: task.id }, data: { barId: bar.id } })
-      return bar.id
-    })
+    return await createBarFromText(playerId, task.originalText, task.id)
   } catch (e) {
     console.error('[ttv:ensureBarForTask]', e)
     return null
@@ -500,14 +536,10 @@ export async function plantTask(input: {
     const barId = await ensureBarForTask(player.id, task)
     if (!barId) return { error: 'Failed to plant task' }
 
-    await db.customBar.update({
-      where: { id: barId },
-      data: {
-        gardenId: personalGardenId(player.id),
-        experienceIntent,
-        dissatisfaction: input.dissatisfaction.join(EA_SEP),
-        satisfaction: input.satisfaction.join(EA_SEP),
-      },
+    await writePlantTriadToBar(player.id, barId, {
+      experienceIntent,
+      dissatisfaction: input.dissatisfaction,
+      satisfaction: input.satisfaction,
     })
 
     revalidatePath('/tap-the-vein')
@@ -516,6 +548,44 @@ export async function plantTask(input: {
   } catch (e) {
     console.error('[ttv:plantTask]', e)
     return { error: 'Failed to plant task' }
+  }
+}
+
+/**
+ * Standalone Plant / 3·2·1 — run the EA-triad on-demand, with **no daily session
+ * and no TapTheVeinTask**. Mints a Garden BAR directly from a typed subject, then
+ * writes the triad. This is the independent "do a 3·2·1 whenever" path used by the
+ * NOW page launcher; it never touches TapTheVeinDailySession.
+ */
+export async function plantStandalone(input: {
+  subject: string
+  experienceIntent: string
+  dissatisfaction: string[]
+  satisfaction: string[]
+}): Promise<TtvResult<{ barId: string }>> {
+  const player = await getCurrentPlayer()
+  if (!player) return { error: 'Not authenticated' }
+
+  const subject = (input.subject || '').trim()
+  const experienceIntent = (input.experienceIntent || '').trim()
+  if (!subject) return { error: 'Name what this is about' }
+  if (!experienceIntent) return { error: 'Name the desired outcome' }
+  if (!input.dissatisfaction?.length) return { error: 'Name the current dissatisfaction' }
+  if (!input.satisfaction?.length) return { error: 'Name the desired satisfaction' }
+
+  try {
+    const barId = await createBarFromText(player.id, subject)
+    await writePlantTriadToBar(player.id, barId, {
+      experienceIntent,
+      dissatisfaction: input.dissatisfaction,
+      satisfaction: input.satisfaction,
+    })
+
+    revalidatePath('/garden')
+    return { barId }
+  } catch (e) {
+    console.error('[ttv:plantStandalone]', e)
+    return { error: 'Failed to plant' }
   }
 }
 

--- a/src/app/deck/preview/page.tsx
+++ b/src/app/deck/preview/page.tsx
@@ -3,17 +3,18 @@ import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
 import { DeckPreviewGallery } from '@/components/deck/DeckPreviewGallery'
 
 export const metadata: Metadata = {
-  title: 'The Allyship Deck — Card Gallery (Preview)',
-  description: 'All 120 Allyship Deck cards, viewable without an account — for design review.',
+  title: 'The Allyship Deck — Sample Cards',
+  description: 'A sample of the Allyship Deck, viewable without an account. Unlock all 120 cards with the deck purchase.',
 }
 
 /**
  * @route /deck/preview
  * @page /deck/preview
  * @entity SYSTEM
- * @description Unauthenticated gallery of all 120 Allyship Deck cards (the high-fidelity
- *   card primitive). Reads the public `allyship-deck.json` directly — no paywall — so the
- *   deck is reviewable without the `deck-digital` entitlement. The full app lives at /deck.
+ * @description Unauthenticated sample gallery — a representative teaser of the Allyship
+ *   Deck (the high-fidelity card primitive), not all 120 cards. Reads the public
+ *   `allyship-deck.json` and samples it; the full deck unlocks with the `deck-digital`
+ *   entitlement at /deck.
  * @permissions public
  * @energyCost 0 (read-only)
  * @dimensions WHO:visitor, WHAT:SYSTEM, WHERE:funnel, ENERGY:N/A

--- a/src/app/deck/sales/page.tsx
+++ b/src/app/deck/sales/page.tsx
@@ -84,7 +84,7 @@ export default function DeckSalesPage() {
             Get the deck
           </Link>
           <Link href="/deck/preview" style={secondaryCta}>
-            See all 120 cards
+            See sample cards
           </Link>
         </div>
       </section>

--- a/src/app/tap-the-vein/TaskActionSheet.tsx
+++ b/src/app/tap-the-vein/TaskActionSheet.tsx
@@ -12,7 +12,7 @@
 import { useState } from 'react'
 import { CultivationCard, type ElementKey } from '@/components/ui/CultivationCard'
 import { ELEMENT_TOKENS } from '@/lib/ui/card-tokens'
-import { EXPERIENCE_OPTIONS, SATISFACTION_OPTIONS, DISSATISFACTION_OPTIONS } from '@/lib/quest-grammar/unpacking-constants'
+import { PlantTriad } from '@/components/plant/PlantTriad'
 import type { TtvTaskDTO, TtvCampaignOption } from '@/actions/tap-the-vein'
 
 export type SheetAction =
@@ -74,12 +74,6 @@ export function TaskActionSheet({
   const [mode, setMode] = useState<'menu' | 'compost' | 'assign' | 'plant'>('menu')
   const [campaignId, setCampaignId] = useState<string | null>(null)
   const [share, setShare] = useState(false)
-  // Plant-gate EA triad
-  const [experience, setExperience] = useState<string | null>(null)
-  const [dissat, setDissat] = useState<string[]>([])
-  const [sat, setSat] = useState<string[]>([])
-  const toggle = (list: string[], v: string) => (list.includes(v) ? list.filter((x) => x !== v) : [...list, v])
-  const canPlant = !!experience && dissat.length > 0 && sat.length > 0
   const gem = ELEMENT_TOKENS[element].gem
   const purple = 'var(--bars-liminal)'
 
@@ -297,85 +291,15 @@ export function TaskActionSheet({
               Name the arc so it can align and metabolize — a desired outcome, where you are now, where you want to be.
             </p>
 
-            {/* q1 — desired outcome (single) */}
-            <ChipGroup label="Desired outcome" mono={mono}>
-              {EXPERIENCE_OPTIONS.map((o) => (
-                <Chip key={o} label={o} selected={experience === o} onClick={() => setExperience(o)} />
-              ))}
-            </ChipGroup>
-
-            {/* q4 — current dissatisfaction (multi) */}
-            <ChipGroup label="Where you are now" mono={mono}>
-              {DISSATISFACTION_OPTIONS.map((o) => (
-                <Chip key={o} label={o} selected={dissat.includes(o)} onClick={() => setDissat((l) => toggle(l, o))} />
-              ))}
-            </ChipGroup>
-
-            {/* q2 — desired satisfaction (multi) */}
-            <ChipGroup label="Where you want to be" mono={mono}>
-              {SATISFACTION_OPTIONS.map((o) => (
-                <Chip key={o} label={o} selected={sat.includes(o)} onClick={() => setSat((l) => toggle(l, o))} />
-              ))}
-            </ChipGroup>
-
-            <button
-              type="button"
-              disabled={busy || !canPlant}
-              onClick={() => experience && onAction({ kind: 'plant', experienceIntent: experience, dissatisfaction: dissat, satisfaction: sat })}
-              className="w-full"
-              style={{
-                marginTop: 14,
-                minHeight: 48,
-                borderRadius: 8,
-                background: canPlant ? purple : 'var(--bars-surface-card)',
-                color: canPlant ? '#fff' : 'var(--bars-text-muted)',
-                fontFamily: display,
-                fontWeight: 800,
-                fontSize: 15,
-                boxShadow: 'inset 0 1px 0 var(--bars-inset-top)',
-                opacity: busy ? 0.6 : 1,
-              }}
-            >
-              Plant ❀
-            </button>
+            <PlantTriad
+              busy={busy}
+              onSubmit={(t) => onAction({ kind: 'plant', experienceIntent: t.experienceIntent, dissatisfaction: t.dissatisfaction, satisfaction: t.satisfaction })}
+            />
             <BackRow onClick={() => setMode('menu')} />
           </div>
         )}
       </div>
     </div>
-  )
-}
-
-function ChipGroup({ label, mono, children }: { label: string; mono: string; children: React.ReactNode }) {
-  return (
-    <div style={{ marginBottom: 12 }}>
-      <p style={{ fontFamily: mono, fontSize: 8.5, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--bars-text-muted)', margin: '0 0 7px' }}>{label}</p>
-      <div className="flex flex-wrap gap-1.5">{children}</div>
-    </div>
-  )
-}
-
-function Chip({ label, selected, onClick }: { label: string; selected: boolean; onClick: () => void }) {
-  const purple = 'var(--bars-liminal)'
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="rounded-full"
-      style={{
-        minHeight: 32,
-        padding: '6px 12px',
-        fontFamily: 'var(--bars-font-body)',
-        fontSize: 12.5,
-        color: selected ? '#fff' : 'var(--bars-text-secondary)',
-        background: selected ? purple : 'var(--bars-surface-card)',
-        boxShadow: selected
-          ? 'inset 0 1px 0 var(--bars-inset-top)'
-          : 'inset 0 1px 0 var(--bars-inset-top), inset 0 0 0 1px var(--bars-line)',
-      }}
-    >
-      {label}
-    </button>
   )
 }
 

--- a/src/components/deck/DeckPreviewGallery.tsx
+++ b/src/components/deck/DeckPreviewGallery.tsx
@@ -1,38 +1,27 @@
 'use client'
 
 import { useEffect, useMemo, useState, type CSSProperties } from 'react'
+import Link from 'next/link'
 import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
-import {
-  DECK_FONTS,
-  DECK_GOLD,
-  MOVE_LABELS,
-  OPERATION_LABELS,
-  DOMAIN_LABELS,
-} from '@/lib/allyship-deck/card-visuals'
-import type {
-  AllyshipDeck,
-  MoveCard,
-  BasicMove,
-  Operation,
-  AllyshipDomain,
-} from '@/lib/allyship-deck/types'
+import { DECK_FONTS, DECK_GOLD } from '@/lib/allyship-deck/card-visuals'
+import type { AllyshipDeck, MoveCard } from '@/lib/allyship-deck/types'
+import { pickDeckSample } from '@/lib/allyship-deck/sample'
 import { AllyshipCard, type CardSubject } from './AllyshipCard'
 
 const isMove = (c: AllyshipDeck['cards'][number]): c is MoveCard => c.kind === 'move'
+const SAMPLE_SIZE = 12
 
 /**
- * Unauthenticated gallery of all 120 move cards using the high-fidelity `AllyshipCard`.
- * Powers `/deck/preview` — a design-review surface (no paywall, reads the public JSON),
- * and the visual proof of the card primitive. Filters by move/operation/domain + the
- * self/others subject toggle; click a card to open it full.
+ * Unauthenticated *sample* gallery for `/deck/preview` — a teaser showing a
+ * representative handful of cards (not all 120; the full deck is the paid product
+ * at `/deck`). Reads the public JSON, samples deterministically via `pickDeckSample`,
+ * keeps the self/others subject toggle, and points buyers to `/launch`. Click a
+ * card to open it full.
  */
 export function DeckPreviewGallery() {
   const [deck, setDeck] = useState<AllyshipDeck | null>(null)
   const [error, setError] = useState(false)
   const [subject, setSubject] = useState<CardSubject>('self')
-  const [fMove, setFMove] = useState<BasicMove | 'all'>('all')
-  const [fOp, setFOp] = useState<Operation | 'all'>('all')
-  const [fDomain, setFDomain] = useState<AllyshipDomain | 'all'>('all')
   const [selected, setSelected] = useState<MoveCard | null>(null)
 
   useEffect(() => {
@@ -46,16 +35,7 @@ export function DeckPreviewGallery() {
   }, [])
 
   const moveCards = useMemo(() => (deck ? deck.cards.filter(isMove) : []), [deck])
-  const shown = useMemo(
-    () =>
-      moveCards.filter(
-        (c) =>
-          (fMove === 'all' || c.move === fMove) &&
-          (fOp === 'all' || c.operation === fOp) &&
-          (fDomain === 'all' || c.domain === fDomain),
-      ),
-    [moveCards, fMove, fOp, fDomain],
-  )
+  const sample = useMemo(() => pickDeckSample(moveCards, SAMPLE_SIZE), [moveCards])
 
   if (error) return <Centered>The deck could not be loaded.</Centered>
   if (!deck) return <Centered>Shuffling…</Centered>
@@ -63,17 +43,17 @@ export function DeckPreviewGallery() {
   return (
     <div style={{ maxWidth: 1100, margin: '0 auto', padding: '28px 16px 80px' }}>
       <header style={{ textAlign: 'center', marginBottom: 18 }}>
-        <p style={{ ...kicker, color: DECK_GOLD }}>Design preview · no account needed</p>
+        <p style={{ ...kicker, color: DECK_GOLD }}>Sample · no account needed</p>
         <h1 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 30, color: '#fff', margin: '6px 0 0' }}>
-          The Allyship Deck — all {moveCards.length} cards
+          A taste of the Allyship Deck
         </h1>
         <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: SURFACE_TOKENS.textSecondary, margin: '8px 0 0' }}>
-          5 moves × 4 domains × 6 faces. Click a card to open it.
+          {sample.length} of {moveCards.length} cards — 5 moves × 4 domains × 6 faces. Click a card to open it.
         </p>
       </header>
 
       {/* subject toggle */}
-      <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginBottom: 12 }}>
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginBottom: 18 }}>
         <Chip active={subject === 'self'} onClick={() => setSubject('self')}>
           Allyship for self
         </Chip>
@@ -82,21 +62,21 @@ export function DeckPreviewGallery() {
         </Chip>
       </div>
 
-      {/* filters */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, justifyContent: 'center', marginBottom: 18 }}>
-        <FilterRow value={fMove} setValue={setFMove} all="All moves" options={Object.entries(MOVE_LABELS) as [BasicMove, string][]} />
-        <FilterRow value={fDomain} setValue={setFDomain} all="All domains" options={Object.entries(DOMAIN_LABELS) as [AllyshipDomain, string][]} />
-        <FilterRow value={fOp} setValue={setFOp} all="All faces" options={Object.entries(OPERATION_LABELS) as [Operation, string][]} />
-      </div>
-
-      <p style={{ ...kicker, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', marginBottom: 14 }}>
-        {shown.length} of {moveCards.length} cards
-      </p>
-
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(178px, 1fr))', gap: 12 }}>
-        {shown.map((c) => (
+        {sample.map((c) => (
           <AllyshipCard key={c.id} card={c} variant="grid" subject={subject} onClick={() => setSelected(c)} />
         ))}
+      </div>
+
+      {/* Buy CTA — the full deck lives behind the purchase */}
+      <div style={{ textAlign: 'center', marginTop: 36 }}>
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary, margin: '0 auto 16px', maxWidth: 460 }}>
+          This is a sample. Unlock all {moveCards.length} cards with the deck purchase,
+          the game subscription, or the Founding Ally bundle.
+        </p>
+        <Link href="/launch" style={buyCta}>
+          Get all {moveCards.length} cards
+        </Link>
       </div>
 
       {selected && (
@@ -121,41 +101,6 @@ export function DeckPreviewGallery() {
         </div>
       )}
     </div>
-  )
-}
-
-function FilterRow<T extends string>({
-  value,
-  setValue,
-  all,
-  options,
-}: {
-  value: T | 'all'
-  setValue: (v: T | 'all') => void
-  all: string
-  options: [T, string][]
-}) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => setValue(e.target.value as T | 'all')}
-      style={{
-        fontFamily: DECK_FONTS.mono,
-        fontSize: 12,
-        padding: '7px 10px',
-        borderRadius: 6,
-        background: SURFACE_TOKENS.surfaceInset,
-        color: SURFACE_TOKENS.textPrimary,
-        border: '1px solid rgba(255,255,255,.12)',
-      }}
-    >
-      <option value="all">{all}</option>
-      {options.map(([k, label]) => (
-        <option key={k} value={k}>
-          {label}
-        </option>
-      ))}
-    </select>
   )
 }
 
@@ -196,6 +141,19 @@ const kicker: CSSProperties = {
   fontSize: 11,
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
+}
+
+const buyCta: CSSProperties = {
+  display: 'inline-block',
+  padding: '13px 28px',
+  borderRadius: 999,
+  background: DECK_GOLD,
+  color: '#150a04',
+  fontFamily: DECK_FONTS.display,
+  fontWeight: 700,
+  fontSize: 15,
+  textDecoration: 'none',
+  boxShadow: '0 10px 30px -12px rgba(201,168,76,.7)',
 }
 
 const closeBtn: CSSProperties = {

--- a/src/components/now/NowHome.tsx
+++ b/src/components/now/NowHome.tsx
@@ -53,9 +53,9 @@ export async function NowHome({ playerId, vibulons }: NowHomeProps) {
     : chargeTargets
 
   const tools = [
-    { href: '/wiki/first-aid', icon: '✚', iconColor: '#2980b9', iconGlow: '#1a7a8a', label: 'First Aid', sub: 'soothe the charge', mono: false },
-    { href: '/wiki/321', icon: '3·2·1', iconColor: '#7c3aed', iconGlow: '#7c3aed', label: 'Clean Up', sub: 'metabolize it', mono: true },
-    { href: '/wiki/iching', icon: '☰', iconColor: '#d4a017', iconGlow: '#d4a017', label: 'I Ching', sub: 'consult the lines', mono: false },
+    { href: '/emotional-first-aid', icon: '✚', iconColor: '#2980b9', iconGlow: '#1a7a8a', label: 'First Aid', sub: 'soothe the charge', mono: false },
+    { href: '/tap-the-vein', icon: '3·2·1', iconColor: '#7c3aed', iconGlow: '#7c3aed', label: 'Clean Up', sub: 'metabolize it', mono: true },
+    { href: '/iching', icon: '☰', iconColor: '#d4a017', iconGlow: '#d4a017', label: 'I Ching', sub: 'consult the lines', mono: false },
   ]
 
   return (

--- a/src/components/now/NowHome.tsx
+++ b/src/components/now/NowHome.tsx
@@ -8,6 +8,7 @@ import { DailyChargePanel } from '@/components/now/DailyChargePanel'
 import { TapTheVeinPanel } from '@/components/now/TapTheVeinPanel'
 import { getTodayPanelSummary } from '@/actions/tap-the-vein'
 import { CaptureBox } from '@/components/now/CaptureBox'
+import { Plant321Launcher } from '@/components/now/Plant321Launcher'
 
 type NowHomeProps = {
   playerId: string
@@ -53,9 +54,9 @@ export async function NowHome({ playerId, vibulons }: NowHomeProps) {
     : chargeTargets
 
   const tools = [
-    { href: '/emotional-first-aid', icon: '✚', iconColor: '#2980b9', iconGlow: '#1a7a8a', label: 'First Aid', sub: 'soothe the charge', mono: false },
-    { href: '/tap-the-vein', icon: '3·2·1', iconColor: '#7c3aed', iconGlow: '#7c3aed', label: 'Clean Up', sub: 'metabolize it', mono: true },
-    { href: '/iching', icon: '☰', iconColor: '#d4a017', iconGlow: '#d4a017', label: 'I Ching', sub: 'consult the lines', mono: false },
+    { kind: 'link' as const, href: '/emotional-first-aid', icon: '✚', iconColor: '#2980b9', iconGlow: '#1a7a8a', label: 'First Aid', sub: 'soothe the charge', mono: false },
+    { kind: 'plant321' as const, href: '', icon: '3·2·1', iconColor: '#7c3aed', iconGlow: '#7c3aed', label: 'Clean Up', sub: 'metabolize it', mono: true },
+    { kind: 'link' as const, href: '/iching', icon: '☰', iconColor: '#d4a017', iconGlow: '#d4a017', label: 'I Ching', sub: 'consult the lines', mono: false },
   ]
 
   return (
@@ -135,40 +136,52 @@ export async function NowHome({ playerId, vibulons }: NowHomeProps) {
               When you're activated
             </span>
             <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
-              {tools.map(tool => (
-                <Link
-                  key={tool.href}
-                  href={tool.href}
-                  style={{
-                    flex: 1,
-                    textDecoration: 'none',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 5,
-                    padding: '13px 12px',
-                    borderRadius: 8,
-                    background: '#1a1a18',
-                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.08)',
-                  }}
-                >
-                  <span style={{
-                    fontFamily: tool.mono ? 'Space Mono, monospace' : 'Jost, sans-serif',
-                    fontWeight: 800,
-                    fontSize: tool.mono ? 15 : 17,
-                    lineHeight: 1,
-                    color: tool.iconColor,
-                    textShadow: `0 0 12px ${tool.iconGlow}`,
-                  }}>
-                    {tool.icon}
-                  </span>
-                  <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 700, fontSize: 12, color: '#e8e6e0' }}>
-                    {tool.label}
-                  </span>
-                  <span style={{ fontFamily: 'Space Mono, monospace', fontSize: 7.5, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#6b6965' }}>
-                    {tool.sub}
-                  </span>
-                </Link>
-              ))}
+              {tools.map(tool =>
+                tool.kind === 'plant321' ? (
+                  <Plant321Launcher
+                    key={tool.label}
+                    icon={tool.icon}
+                    iconColor={tool.iconColor}
+                    iconGlow={tool.iconGlow}
+                    label={tool.label}
+                    sub={tool.sub}
+                    mono={tool.mono}
+                  />
+                ) : (
+                  <Link
+                    key={tool.href}
+                    href={tool.href}
+                    style={{
+                      flex: 1,
+                      textDecoration: 'none',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 5,
+                      padding: '13px 12px',
+                      borderRadius: 8,
+                      background: '#1a1a18',
+                      boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.08)',
+                    }}
+                  >
+                    <span style={{
+                      fontFamily: tool.mono ? 'Space Mono, monospace' : 'Jost, sans-serif',
+                      fontWeight: 800,
+                      fontSize: tool.mono ? 15 : 17,
+                      lineHeight: 1,
+                      color: tool.iconColor,
+                      textShadow: `0 0 12px ${tool.iconGlow}`,
+                    }}>
+                      {tool.icon}
+                    </span>
+                    <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 700, fontSize: 12, color: '#e8e6e0' }}>
+                      {tool.label}
+                    </span>
+                    <span style={{ fontFamily: 'Space Mono, monospace', fontSize: 7.5, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#6b6965' }}>
+                      {tool.sub}
+                    </span>
+                  </Link>
+                )
+              )}
             </div>
           </div>
         </main>

--- a/src/components/now/Plant321Launcher.tsx
+++ b/src/components/now/Plant321Launcher.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+/**
+ * Plant321Launcher — opens the isolated 3·2·1 (Plant) flow on-demand from the NOW
+ * page tools rail. Renders a tile button identical to the rail's other tools, but
+ * instead of navigating it opens a modal hosting a subject + the shared PlantTriad.
+ *
+ * On submit it calls the standalone `plantStandalone` server action (no daily
+ * session, no TapTheVeinTask), so a 3·2·1 can be run anytime. The daily Tap the
+ * Vein ritual is untouched.
+ */
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { PlantTriad } from '@/components/plant/PlantTriad'
+import { plantStandalone } from '@/actions/tap-the-vein'
+
+export function Plant321Launcher({
+  icon,
+  iconColor,
+  iconGlow,
+  label,
+  sub,
+  mono,
+}: {
+  icon: string
+  iconColor: string
+  iconGlow: string
+  label: string
+  sub: string
+  mono: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [subject, setSubject] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [doneBarId, setDoneBarId] = useState<string | null>(null)
+  const purple = 'var(--bars-liminal)'
+
+  function close() {
+    setOpen(false)
+    // Reset for the next run (the flow is independent each time).
+    setSubject('')
+    setBusy(false)
+    setError(null)
+    setDoneBarId(null)
+  }
+
+  async function submit(triad: { experienceIntent: string; dissatisfaction: string[]; satisfaction: string[] }) {
+    if (!subject.trim()) {
+      setError('Name what this is about')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    const res = await plantStandalone({ subject, ...triad })
+    setBusy(false)
+    if ('error' in res) {
+      setError(res.error)
+      return
+    }
+    setDoneBarId(res.barId)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        style={{
+          flex: 1,
+          textAlign: 'left',
+          textDecoration: 'none',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 5,
+          padding: '13px 12px',
+          borderRadius: 8,
+          background: '#1a1a18',
+          boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.08)',
+        }}
+      >
+        <span style={{
+          fontFamily: mono ? 'Space Mono, monospace' : 'Jost, sans-serif',
+          fontWeight: 800,
+          fontSize: mono ? 15 : 17,
+          lineHeight: 1,
+          color: iconColor,
+          textShadow: `0 0 12px ${iconGlow}`,
+        }}>
+          {icon}
+        </span>
+        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 700, fontSize: 12, color: '#e8e6e0' }}>
+          {label}
+        </span>
+        <span style={{ fontFamily: 'Space Mono, monospace', fontSize: 7.5, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#6b6965' }}>
+          {sub}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center"
+          style={{ background: 'rgba(0,0,0,0.62)' }}
+          onClick={close}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="w-full"
+            style={{
+              maxWidth: 432,
+              background: 'var(--bars-surface-elevated)',
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+              boxShadow: 'inset 0 1px 0 var(--bars-inset-top), 0 -20px 60px rgba(0,0,0,0.6)',
+              padding: '10px 16px calc(16px + env(safe-area-inset-bottom))',
+              maxHeight: '88vh',
+              overflowY: 'auto',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Grab handle */}
+            <div className="flex justify-center pb-3">
+              <span style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--bars-line-strong)' }} />
+            </div>
+
+            {doneBarId ? (
+              <div style={{ paddingBottom: 8 }}>
+                <span style={{ fontFamily: 'var(--bars-font-mono)', fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--bars-text-muted)' }}>
+                  3·2·1 · metabolized
+                </span>
+                <h2 style={{ fontFamily: 'var(--bars-font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', color: 'var(--bars-text-primary)', margin: '6px 0 0' }}>
+                  Planted.
+                </h2>
+                <p style={{ fontFamily: 'var(--bars-font-body)', fontSize: 12.5, lineHeight: 1.5, color: 'var(--bars-text-secondary)', margin: '6px 0 14px' }}>
+                  The charge is named and growing in your Garden under today&rsquo;s lens.
+                </p>
+                <Link
+                  href="/garden"
+                  className="w-full"
+                  style={{
+                    display: 'block',
+                    textAlign: 'center',
+                    textDecoration: 'none',
+                    minHeight: 48,
+                    lineHeight: '48px',
+                    borderRadius: 8,
+                    background: purple,
+                    color: '#fff',
+                    fontFamily: 'var(--bars-font-display)',
+                    fontWeight: 800,
+                    fontSize: 15,
+                    boxShadow: 'inset 0 1px 0 var(--bars-inset-top)',
+                  }}
+                >
+                  Open in Garden ❀
+                </Link>
+                <button
+                  type="button"
+                  onClick={close}
+                  className="w-full"
+                  style={{ marginTop: 10, minHeight: 44, fontFamily: 'var(--bars-font-mono)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--bars-text-secondary)', background: 'transparent' }}
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <div style={{ paddingBottom: 8 }}>
+                <span style={{ fontFamily: 'var(--bars-font-mono)', fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--bars-text-muted)' }}>
+                  Clean Up · 3·2·1
+                </span>
+                <h2 style={{ fontFamily: 'var(--bars-font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', color: 'var(--bars-text-primary)', margin: '6px 0 0' }}>
+                  What&rsquo;s the charge?
+                </h2>
+                <p style={{ fontFamily: 'var(--bars-font-body)', fontSize: 12.5, lineHeight: 1.5, color: 'var(--bars-text-secondary)', margin: '6px 0 10px' }}>
+                  Name what&rsquo;s up — then the arc: a desired outcome, where you are now, where you want to be.
+                </p>
+
+                <textarea
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  placeholder="What are you carrying right now?"
+                  rows={2}
+                  style={{
+                    width: '100%',
+                    resize: 'none',
+                    marginBottom: 14,
+                    padding: '10px 12px',
+                    borderRadius: 10,
+                    background: 'var(--bars-surface-card)',
+                    color: 'var(--bars-text-primary)',
+                    fontFamily: 'var(--bars-font-body)',
+                    fontSize: 14,
+                    boxShadow: 'inset 0 1px 0 var(--bars-inset-top), inset 0 0 0 1px var(--bars-line)',
+                    outline: 'none',
+                  }}
+                />
+
+                <PlantTriad busy={busy} onSubmit={submit} />
+
+                {error && (
+                  <p style={{ fontFamily: 'var(--bars-font-mono)', fontSize: 10, letterSpacing: '0.04em', color: '#e06b6b', margin: '10px 2px 0' }}>
+                    {error}
+                  </p>
+                )}
+
+                <button
+                  type="button"
+                  onClick={close}
+                  className="w-full"
+                  style={{ marginTop: 10, minHeight: 44, fontFamily: 'var(--bars-font-mono)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--bars-text-secondary)', background: 'transparent' }}
+                >
+                  ← Close
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/plant/PlantTriad.tsx
+++ b/src/components/plant/PlantTriad.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * PlantTriad — the isolated 3·2·1 / unpacking EA-triad
+ * (desired outcome → where you are now → where you want to be).
+ *
+ * Extracted from the Tap the Vein "Plant in Garden" gesture so the same flow
+ * can run on-demand (NOW page modal) as well as inside the daily ritual. Pure
+ * presentational + local state; the caller owns persistence via `onSubmit`.
+ *
+ * Options come from the single source of truth in unpacking-constants.ts so the
+ * standalone flow and the in-ritual flow never diverge.
+ */
+
+import { useState } from 'react'
+import { EXPERIENCE_OPTIONS, SATISFACTION_OPTIONS, DISSATISFACTION_OPTIONS } from '@/lib/quest-grammar/unpacking-constants'
+
+const mono = 'var(--bars-font-mono)'
+const display = 'var(--bars-font-display)'
+
+export type PlantTriadValue = {
+  experienceIntent: string
+  dissatisfaction: string[]
+  satisfaction: string[]
+}
+
+export function PlantTriad({
+  busy,
+  onSubmit,
+  submitLabel = 'Plant ❀',
+}: {
+  busy: boolean
+  onSubmit: (value: PlantTriadValue) => void
+  submitLabel?: string
+}) {
+  const [experience, setExperience] = useState<string | null>(null)
+  const [dissat, setDissat] = useState<string[]>([])
+  const [sat, setSat] = useState<string[]>([])
+  const toggle = (list: string[], v: string) => (list.includes(v) ? list.filter((x) => x !== v) : [...list, v])
+  const canPlant = !!experience && dissat.length > 0 && sat.length > 0
+  const purple = 'var(--bars-liminal)'
+
+  return (
+    <div>
+      {/* q1 — desired outcome (single) */}
+      <ChipGroup label="Desired outcome">
+        {EXPERIENCE_OPTIONS.map((o) => (
+          <Chip key={o} label={o} selected={experience === o} onClick={() => setExperience(o)} />
+        ))}
+      </ChipGroup>
+
+      {/* q4 — current dissatisfaction (multi) */}
+      <ChipGroup label="Where you are now">
+        {DISSATISFACTION_OPTIONS.map((o) => (
+          <Chip key={o} label={o} selected={dissat.includes(o)} onClick={() => setDissat((l) => toggle(l, o))} />
+        ))}
+      </ChipGroup>
+
+      {/* q2 — desired satisfaction (multi) */}
+      <ChipGroup label="Where you want to be">
+        {SATISFACTION_OPTIONS.map((o) => (
+          <Chip key={o} label={o} selected={sat.includes(o)} onClick={() => setSat((l) => toggle(l, o))} />
+        ))}
+      </ChipGroup>
+
+      <button
+        type="button"
+        disabled={busy || !canPlant}
+        onClick={() => experience && onSubmit({ experienceIntent: experience, dissatisfaction: dissat, satisfaction: sat })}
+        className="w-full"
+        style={{
+          marginTop: 14,
+          minHeight: 48,
+          borderRadius: 8,
+          background: canPlant ? purple : 'var(--bars-surface-card)',
+          color: canPlant ? '#fff' : 'var(--bars-text-muted)',
+          fontFamily: display,
+          fontWeight: 800,
+          fontSize: 15,
+          boxShadow: 'inset 0 1px 0 var(--bars-inset-top)',
+          opacity: busy ? 0.6 : 1,
+        }}
+      >
+        {submitLabel}
+      </button>
+    </div>
+  )
+}
+
+export function ChipGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <p style={{ fontFamily: mono, fontSize: 8.5, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--bars-text-muted)', margin: '0 0 7px' }}>{label}</p>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  )
+}
+
+export function Chip({ label, selected, onClick }: { label: string; selected: boolean; onClick: () => void }) {
+  const purple = 'var(--bars-liminal)'
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full"
+      style={{
+        minHeight: 32,
+        padding: '6px 12px',
+        fontFamily: 'var(--bars-font-body)',
+        fontSize: 12.5,
+        color: selected ? '#fff' : 'var(--bars-text-secondary)',
+        background: selected ? purple : 'var(--bars-surface-card)',
+        boxShadow: selected
+          ? 'inset 0 1px 0 var(--bars-inset-top)'
+          : 'inset 0 1px 0 var(--bars-inset-top), inset 0 0 0 1px var(--bars-line)',
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/lib/allyship-deck/sample.ts
+++ b/src/lib/allyship-deck/sample.ts
@@ -1,0 +1,60 @@
+/**
+ * Deck sampling — pick a small, representative teaser from the full move deck.
+ *
+ * Used by the public `/deck/preview` gallery so visitors see a taste of the deck
+ * (not all 120 cards — that's the paid product). Deterministic: no randomness, so
+ * the sample is stable across renders/builds and is the single source of truth.
+ */
+
+import type { AllyshipDomain, BasicMove, MoveCard, Operation } from './types'
+
+/** Fixed walk orders (match the type unions) used to spread the sample. */
+const MOVE_ORDER: BasicMove[] = ['wake_up', 'open_up', 'clean_up', 'grow_up', 'show_up']
+const DOMAIN_ORDER: AllyshipDomain[] = [
+  'GATHERING_RESOURCES',
+  'RAISE_AWARENESS',
+  'DIRECT_ACTION',
+  'SKILLFUL_ORGANIZING',
+]
+const OPERATION_ORDER: Operation[] = ['shaman', 'challenger', 'regent', 'architect', 'diplomat', 'sage']
+
+const tripleKey = (move: BasicMove, domain: AllyshipDomain, op: Operation) => `${move}|${domain}|${op}`
+
+/**
+ * Pick a representative sample of move cards. Walks a diagonal across
+ * move × domain × face (each index advances all three on their own cycle), so the
+ * sample spreads over every move, every domain, and every face rather than
+ * clustering — the deck's `num` ordering is domain-major, so a naive slice would
+ * show one domain only. Deterministic; returns up to `count` distinct cards, with
+ * a stable fallback if the deck isn't a complete 5 × 4 × 6 grid.
+ */
+export function pickDeckSample(cards: MoveCard[], count = 12): MoveCard[] {
+  const byTriple = new Map<string, MoveCard>()
+  for (const c of cards) byTriple.set(tripleKey(c.move, c.domain, c.operation), c)
+
+  // Stable fallback pool: grouped by move, each sorted by `num`.
+  const byMove = new Map<BasicMove, MoveCard[]>(MOVE_ORDER.map((m) => [m, []]))
+  for (const c of cards) byMove.get(c.move)?.push(c)
+  for (const list of byMove.values()) list.sort((a, b) => a.num.localeCompare(b.num))
+
+  const used = new Set<string>()
+  const out: MoveCard[] = []
+  const target = Math.min(count, cards.length)
+
+  for (let i = 0; out.length < target && i < cards.length * 2; i++) {
+    const move = MOVE_ORDER[i % MOVE_ORDER.length]
+    const domain = DOMAIN_ORDER[i % DOMAIN_ORDER.length]
+    const op = OPERATION_ORDER[i % OPERATION_ORDER.length]
+
+    let card = byTriple.get(tripleKey(move, domain, op))
+    if (!card || used.has(card.id)) {
+      // Fallback: first still-unused card for this move (keeps move coverage).
+      card = byMove.get(move)?.find((c) => !used.has(c.id))
+    }
+    if (card && !used.has(card.id)) {
+      used.add(card.id)
+      out.push(card)
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

Extracts the Plant/3·2·1 EA-triad flow into a reusable component and adds a new standalone (no-task, no-session) path to run the ritual on-demand from the NOW page. This decouples the triad UI from the daily Tap the Vein session, allowing players to metabolize charges anytime via a modal launcher.

## Key Changes

- **New `PlantTriad` component** (`src/components/plant/PlantTriad.tsx`): Isolated, presentational EA-triad UI (desired outcome → current dissatisfaction → desired satisfaction). Extracted from `TaskActionSheet` so it can be reused in both the daily ritual and standalone flows. Owns local state; caller handles persistence via `onSubmit`.

- **New `Plant321Launcher` component** (`src/components/now/Plant321Launcher.tsx`): Modal button on the NOW page tools rail. Opens a sheet with a subject input + the shared `PlantTriad`. Calls the new `plantStandalone` server action on submit. Renders a success state with a link to the Garden.

- **New `plantStandalone` server action** (`src/actions/tap-the-vein.ts`): Standalone 3·2·1 entry point—no daily session, no `TapTheVeinTask`. Mints a Garden BAR directly from typed text, writes the triad, and returns the `barId`. Shared by the NOW launcher and future on-demand paths.

- **Refactored `ensureBarForTask`** → extracted `createBarFromText` helper: Consolidates BAR creation logic (title, lens attachment, seed metabolization, root self-linking) so both `plantTask` and `plantStandalone` use the same path. Reduces duplication.

- **Refactored `plantTask`** → extracted `writePlantTriadToBar` helper: Moves the triad write (experienceIntent, dissatisfaction, satisfaction) into a shared function. Both `plantTask` and `plantStandalone` now call it.

- **Updated `NowHome`** (`src/components/now/NowHome.tsx`): Replaced the hardcoded "Clean Up" link with a `Plant321Launcher` instance. Tools array now uses a `kind` discriminator (`'link'` vs `'plant321'`) to render either a Link or the launcher.

- **Deck preview refactor** (`src/components/deck/DeckPreviewGallery.tsx`): Replaced full-deck gallery with a deterministic sample (12 cards by default). Removed move/domain/operation filters. Added `pickDeckSample` utility to spread the sample across all moves, domains, and faces. Updated copy to emphasize "sample" and added a CTA linking to `/launch` for the full deck.

- **New `pickDeckSample` utility** (`src/lib/allyship-deck/sample.ts`): Deterministic deck sampling via a diagonal walk across move × domain × operation. Ensures the sample is stable, representative, and spreads coverage rather than clustering.

- **Updated `.env.example`**: Expanded Gumroad commerce section with detailed product reference table, webhook setup, and per-SKU license-verify env vars. Clarified that the marketing funnel works without these, but they unlock purchasing.

- **Updated `GUMROAD_LAUNCH_SETUP.md`**: Added per-product reference table mapping OfferKey → price → env vars, making it easier to onboard new products.

## Implementation Details

- **Shared constants**: `PlantTriad` reads `EXPERIENCE_OPTIONS`, `SATISFACTION_OPTIONS`, `DISSATISFACTION_OPTIONS` from `unpacking-constants.ts`, ensuring the standalone and in-ritual flows never diverge.

- **Modal UX**: `Plant321Launcher` uses a bottom-sheet modal (fixed inset, max-width 432px, safe-area-inset-bottom padding) with a grab handle, subject textarea, the triad component, and error display. Success state shows "Planted" + a link to the Garden.

- **Revalidation**: Both `plantTask` and `plantStandalone` call `revalidatePath` on success (`

https://claude.ai/code/session_01D6ir8h1vV5YJQtYdYkQPYk