### PR TITLE
Capture legibility & onboarding: English on every sigil, element↔emotion field guide, first-run walkthrough

### DIFF
--- a/src/app/bars/[id]/page.tsx
+++ b/src/app/bars/[id]/page.tsx
@@ -21,6 +21,16 @@ import { HandLocationToggle } from '@/components/hand/HandLocationToggle'
 import { readHandDb } from '@/lib/hand-service'
 import { effectiveMaturity, parseSeedMetabolization } from '@/lib/bar-seed-metabolization'
 import { isHandVaultMovable } from '@/lib/hand-movement'
+import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+
+// Charge level → human label (mirrors the Seed Capture Whiteboard).
+const CHARGE_LABELS: Record<number, string> = {
+    1: 'barely a flicker',
+    2: 'a low hum',
+    3: "it's sitting with me",
+    4: 'hard to shake',
+    5: "can't put it down",
+}
 
 /**
  * @page /bars/:id
@@ -152,6 +162,28 @@ export default async function BarDetailPage({
                         charge={charge}
                         title={bar.title}
                     />
+                )}
+
+                {/* Intent · charge line — context beneath the frozen polaroid (canvas BARs). */}
+                {canvasLayout && (
+                    <div className="flex items-baseline justify-between gap-3 px-1 font-mono text-[10px] uppercase tracking-[0.06em]">
+                        <span className="text-zinc-500 truncate">
+                            intent · {tags.length > 0 ? tags.join(' · ') : 'none'}
+                        </span>
+                        {charge && (
+                            <span
+                                className="flex-shrink-0"
+                                style={{
+                                    color:
+                                        element && element in ELEMENT_TOKENS
+                                            ? ELEMENT_TOKENS[element as ElementKey].gem
+                                            : '#a855f7',
+                                }}
+                            >
+                                charge {charge} · {CHARGE_LABELS[charge]}
+                            </span>
+                        )}
+                    </div>
                 )}
 
                 {/* Card: Face | Back */}

--- a/src/app/cyoa-intake/[id]/CyoaIntakeRunner.tsx
+++ b/src/app/cyoa-intake/[id]/CyoaIntakeRunner.tsx
@@ -19,12 +19,12 @@ import type { EmotionChannel, AlchemyAltitude } from '@/lib/alchemy/types'
 // Constants
 // ---------------------------------------------------------------------------
 
-const CHANNELS: Array<{ key: EmotionChannel; label: string; sigil: string; hint: string }> = [
-  { key: 'joy', label: 'Joy', sigil: '木', hint: 'Vitality, delight, love of the game' },
-  { key: 'anger', label: 'Anger', sigil: '火', hint: 'Obstacle present, boundary met' },
-  { key: 'neutrality', label: 'Neutral', sigil: '土', hint: 'Whole-system perspective' },
-  { key: 'fear', label: 'Fear', sigil: '金', hint: 'Risk detected, excitement as opportunity' },
-  { key: 'sadness', label: 'Sadness', sigil: '水', hint: 'Something I care about feels distant' },
+const CHANNELS: Array<{ key: EmotionChannel; label: string; element: string; sigil: string; hint: string }> = [
+  { key: 'joy', label: 'Joy', element: 'Wood', sigil: '木', hint: 'Vitality, delight, love of the game' },
+  { key: 'anger', label: 'Anger', element: 'Fire', sigil: '火', hint: 'Obstacle present, boundary met' },
+  { key: 'neutrality', label: 'Neutral', element: 'Earth', sigil: '土', hint: 'Whole-system perspective' },
+  { key: 'fear', label: 'Fear', element: 'Metal', sigil: '金', hint: 'Risk detected, excitement as opportunity' },
+  { key: 'sadness', label: 'Sadness', element: 'Water', sigil: '水', hint: 'Something I care about feels distant' },
 ]
 
 const ALTITUDES: Array<{ key: AlchemyAltitude; label: string; hint: string }> = [
@@ -806,8 +806,8 @@ function CheckInStep0Scene({
                     : 'border-stone-700 bg-stone-900 text-stone-400 hover:border-stone-500 hover:text-stone-300'
                 }`}
               >
-                <span className="font-mono text-amber-600 mr-2 text-sm">{c.sigil}</span>
-                <span className="font-medium text-stone-300 mr-2">{c.label}</span>
+                <span className="font-mono text-amber-600 mr-2 text-sm" role="img" aria-label={`${c.element} element`}>{c.sigil}</span>
+                <span className="font-medium text-stone-300 mr-2">{c.element} · {c.label}</span>
                 <span className="text-xs text-stone-500">— {c.hint}</span>
               </button>
             )

--- a/src/app/wiki/emotional-alchemy/page.tsx
+++ b/src/app/wiki/emotional-alchemy/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { ALL_CANONICAL_MOVES, getMoveFamily } from '@/lib/quest-grammar/move-engine'
 import { SHENG_CYCLE, KE_CYCLE } from '@/lib/alchemy/wuxing'
+import { ElementEmotionLegend } from '@/components/bars/ElementEmotionLegend'
 
 /**
  * @page /wiki/emotional-alchemy
@@ -62,6 +63,9 @@ export default function EmotionalAlchemyPage() {
           The 15 canonical moves unlock for cross-national collaboration when onboarding completes.
         </p>
       </header>
+
+      {/* Player-facing field guide — the same legend surfaced on the capture canvas. */}
+      <ElementEmotionLegend />
 
       <section className="bg-zinc-900/40 border border-zinc-800 rounded-xl p-4 space-y-4">
         <h2 id="elements" className="text-lg font-bold text-white">5 Elements + Channels</h2>

--- a/src/components/bars/BarCardFace.tsx
+++ b/src/components/bars/BarCardFace.tsx
@@ -102,6 +102,10 @@ export function BarCardFace({
         )}
       </div>
       <div className="p-4 relative z-10">
+        {/* Kicker — names the BAR's origin, like the prototype Face card. */}
+        <span className="block font-mono text-[7.5px] uppercase tracking-[0.1em] text-zinc-600 text-center mb-2">
+          {canvasLayout ? 'from the canvas' : 'note'}
+        </span>
         <p className="font-mono text-sm text-zinc-300 line-clamp-2 break-words text-center min-h-[40px] flex items-center justify-center">
           {teaser}
         </p>

--- a/src/components/bars/BarCardFace.tsx
+++ b/src/components/bars/BarCardFace.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { CultivationCard } from '@/components/ui/CultivationCard'
-import { ELEMENT_TOKENS, STAGE_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { ELEMENT_TOKENS, STAGE_TOKENS, elementLabel, type ElementKey } from '@/lib/ui/card-tokens'
 
 /**
  * Renders the Face of a BAR card — image + first line teaser.
@@ -66,6 +66,11 @@ export function BarCardFace({
       altitude="dissatisfied"
       element={el ? (element as ElementKey) : undefined}
       className={className}
+      aria-label={
+        el
+          ? `${elementLabel(element as ElementKey, { withEmotion: true })} seed — ${teaser}`
+          : teaser
+      }
     >
       <div className={`card-art-window ${st.artWindowHeight} overflow-hidden rounded-t-xl bg-black/20 relative`}>
         {imageUrl && (
@@ -76,14 +81,22 @@ export function BarCardFace({
             className={`w-full h-full object-cover object-center ${st.artOpacity}`}
           />
         )}
-        {/* Element sigil badge — only when the BAR carries an element */}
+        {/* Element sigil badge — only when the BAR carries an element.
+            Sigil is a watermark; pair it with the English name + emotion so the
+            Chinese character never stands alone. */}
         {el && !imageUrl && (
-          <div className="absolute inset-0 flex items-center justify-center">
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
             <span
               style={{ color: el.gem, textShadow: `0 0 12px ${el.glow}`, fontSize: 38, lineHeight: 1 }}
               aria-hidden
             >
               {el.sigil}
+            </span>
+            <span
+              className="font-mono text-[9px] uppercase tracking-[0.14em]"
+              style={{ color: el.gem, opacity: 0.85 }}
+            >
+              {elementLabel(element as ElementKey, { withEmotion: true })}
             </span>
           </div>
         )}

--- a/src/components/bars/CanvasPreview.tsx
+++ b/src/components/bars/CanvasPreview.tsx
@@ -85,7 +85,7 @@ export function CanvasPreview({
     // Field background — element-driven radial glow (top) + purple glow (bottom)
     // + two faint grids over #0c0d11. Mirrors FieldBackground in the composer.
     const topGlow = el
-        ? `radial-gradient(ellipse 130% 66% at 50% 6%, color-mix(in srgb, ${el.frame} 30%, transparent), transparent 56%),`
+        ? `radial-gradient(ellipse 130% 66% at 50% 6%, color-mix(in srgb, ${el.frame} 34%, transparent), transparent 56%),`
         : ''
     const fieldBg = [
         topGlow,
@@ -261,26 +261,25 @@ export function CanvasPreview({
                             style={{
                                 fontSize: cqw(22),
                                 color: el.gem,
-                                textShadow: `0 0 8px ${el.glow}`,
+                                textShadow: `0 0 12px ${el.glow}`,
                                 lineHeight: 1,
                             }}
                         >
                             {el.sigil}
                         </span>
-                        {/* English name + emotion — never let the sigil stand alone */}
+                        {/* English name on one line — keeps the sigil translated without
+                            crowding the frozen-polaroid caption (emotion lives in the legend). */}
                         <span
                             className="font-mono uppercase"
                             style={{
-                                fontSize: cqw(8.5),
+                                fontSize: cqw(9),
                                 letterSpacing: '0.12em',
                                 color: el.gem,
                                 opacity: 0.85,
-                                lineHeight: 1.15,
+                                lineHeight: 1,
                             }}
                         >
                             {el.label}
-                            <br />
-                            <span style={{ opacity: 0.75 }}>{el.emotion}</span>
                         </span>
                     </span>
                 )}

--- a/src/components/bars/CanvasPreview.tsx
+++ b/src/components/bars/CanvasPreview.tsx
@@ -256,15 +256,32 @@ export function CanvasPreview({
                 }}
             >
                 {el && (
-                    <span
-                        style={{
-                            fontSize: cqw(22),
-                            color: el.gem,
-                            textShadow: `0 0 8px ${el.glow}`,
-                            lineHeight: 1,
-                        }}
-                    >
-                        {el.sigil}
+                    <span className="flex items-center" style={{ gap: cqw(6) }}>
+                        <span
+                            style={{
+                                fontSize: cqw(22),
+                                color: el.gem,
+                                textShadow: `0 0 8px ${el.glow}`,
+                                lineHeight: 1,
+                            }}
+                        >
+                            {el.sigil}
+                        </span>
+                        {/* English name + emotion — never let the sigil stand alone */}
+                        <span
+                            className="font-mono uppercase"
+                            style={{
+                                fontSize: cqw(8.5),
+                                letterSpacing: '0.12em',
+                                color: el.gem,
+                                opacity: 0.85,
+                                lineHeight: 1.15,
+                            }}
+                        >
+                            {el.label}
+                            <br />
+                            <span style={{ opacity: 0.75 }}>{el.emotion}</span>
+                        </span>
                     </span>
                 )}
                 {title && (

--- a/src/components/bars/CaptureWalkthrough.tsx
+++ b/src/components/bars/CaptureWalkthrough.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+/**
+ * CaptureWalkthrough — first-run coach-marks for the seed-capture canvas.
+ *
+ * Players told us they didn't understand how to capture a seed. This walks the
+ * five-beat flow once on first visit (write → attune → charge → capture → Hand),
+ * is gated by localStorage so it only auto-shows once, and stays replayable from
+ * a quiet "How it works" pill. A video embed slot is left for a real screen
+ * recording (set WALKTHROUGH_VIDEO_URL).
+ *
+ * Mounted inside SeedCaptureWhiteboard's phone-frame container, so absolute
+ * positioning lands within the canvas.
+ */
+
+import { useEffect, useState } from 'react'
+
+const SEEN_KEY = 'bars:capture:walkthrough-seen'
+
+// Drop a real screen-recording URL here later (mp4 or embed) — the slot renders
+// automatically when set; until then players see a labelled placeholder.
+const WALKTHROUGH_VIDEO_URL = ''
+
+type Step = {
+  kicker: string
+  title: string
+  body: string
+  // Where the relevant control lives, as a hint arrow on the card.
+  point?: 'right' | 'down' | 'up'
+}
+
+const STEPS: Step[] = [
+  {
+    kicker: 'Step 1 · Write',
+    title: 'Write your spark',
+    body: 'Tap the board (or the “Aa” tool) and type what’s charged for you right now — a line, a scrap, whatever wants out.',
+    point: 'up',
+  },
+  {
+    kicker: 'Step 2 · Attune',
+    title: 'Give it an element',
+    body: 'Tap a colour on the right rail to tint your seed. Each colour is an element — and the emotion it carries.',
+    point: 'right',
+  },
+  {
+    kicker: 'Step 3 · Charge',
+    title: 'Set the charge',
+    body: 'Down below, say how charged it feels — from “barely a flicker” to “can’t put it down.”',
+    point: 'down',
+  },
+  {
+    kicker: 'Step 4 · Capture',
+    title: 'Capture the seed',
+    body: 'Hit “Capture this seed →” to plant it. That’s the whole move — no forms, no required fields.',
+    point: 'down',
+  },
+  {
+    kicker: 'Step 5 · Hand',
+    title: 'It lands in your Hand',
+    body: 'Your seed drops into your Hand — the cards you’re carrying. Tune it any time to grow it into a quest.',
+  },
+]
+
+function ArrowHint({ point }: { point: NonNullable<Step['point']> }) {
+  const glyph = point === 'right' ? '→' : point === 'down' ? '↓' : '↑'
+  const label =
+    point === 'right' ? 'the element rail →' : point === 'down' ? '↓ the bottom bar' : '↑ the board'
+  return (
+    <span
+      className="font-mono uppercase"
+      style={{ color: '#a855f7', fontSize: 10, letterSpacing: '0.12em' }}
+    >
+      <span style={{ fontSize: 13 }}>{glyph}</span> {label}
+    </span>
+  )
+}
+
+export function CaptureWalkthrough({ onOpenLegend }: { onOpenLegend?: () => void }) {
+  const [open, setOpen] = useState(false)
+  const [step, setStep] = useState(0)
+
+  // Auto-show once on first visit.
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(SEEN_KEY)) {
+        setStep(0)
+        setOpen(true)
+      }
+    } catch {
+      /* localStorage unavailable — skip auto-show */
+    }
+  }, [])
+
+  function dismiss() {
+    setOpen(false)
+    try {
+      localStorage.setItem(SEEN_KEY, '1')
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function replay() {
+    setStep(0)
+    setOpen(true)
+  }
+
+  // Quiet replay affordance when the walkthrough isn't showing.
+  if (!open) {
+    return (
+      <button
+        onClick={replay}
+        aria-label="Show me how to capture a seed"
+        className="absolute font-mono uppercase"
+        style={{
+          left: 14,
+          bottom: 14,
+          zIndex: 30,
+          fontSize: 9,
+          letterSpacing: '0.12em',
+          color: 'rgba(232,226,218,0.6)',
+          background: 'rgba(255,255,255,0.06)',
+          boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.1)',
+          backdropFilter: 'blur(5px)',
+          border: 'none',
+          borderRadius: 999,
+          padding: '6px 11px',
+          cursor: 'pointer',
+        }}
+      >
+        How it works
+      </button>
+    )
+  }
+
+  const s = STEPS[step]
+  const isLast = step === STEPS.length - 1
+
+  return (
+    <div
+      className="absolute inset-0 flex flex-col justify-end"
+      style={{ zIndex: 50, background: 'rgba(5,4,3,0.78)', backdropFilter: 'blur(3px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="How to capture a seed"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) dismiss()
+      }}
+    >
+      <div
+        style={{
+          margin: 14,
+          borderRadius: 18,
+          padding: '20px 20px 16px',
+          background: 'linear-gradient(180deg, #201d2b, #15131c)',
+          boxShadow:
+            'inset 0 1px 0 rgba(255,255,255,0.08), 0 0 0 1px rgba(124,58,237,0.5), 0 -10px 40px -12px rgba(124,58,237,0.4)',
+        }}
+      >
+        {/* Progress dots */}
+        <div className="flex items-center justify-between mb-3">
+          <span
+            className="font-mono uppercase"
+            style={{ color: '#a855f7', fontSize: 9.5, letterSpacing: '0.14em' }}
+          >
+            {s.kicker}
+          </span>
+          <div className="flex gap-1.5">
+            {STEPS.map((_, i) => (
+              <span
+                key={i}
+                style={{
+                  width: i === step ? 16 : 6,
+                  height: 6,
+                  borderRadius: 999,
+                  background: i === step ? '#a855f7' : 'rgba(232,226,218,0.22)',
+                  transition: 'all 0.2s ease',
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        <h3 className="font-bold" style={{ color: '#f4f1ec', fontSize: 19, letterSpacing: '-0.01em' }}>
+          {s.title}
+        </h3>
+        <p className="mt-1.5 leading-relaxed" style={{ color: '#c9c5be', fontSize: 13.5 }}>
+          {s.body}
+        </p>
+
+        {s.point && (
+          <div className="mt-2.5">
+            <ArrowHint point={s.point} />
+          </div>
+        )}
+
+        {step === 1 && onOpenLegend && (
+          <button
+            onClick={onOpenLegend}
+            className="mt-2"
+            style={{ color: '#a855f7', fontSize: 12, fontWeight: 600, background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          >
+            What do the elements mean? →
+          </button>
+        )}
+
+        {/* Final step: video slot for a real end-to-end recording. */}
+        {isLast && (
+          <div className="mt-3">
+            {WALKTHROUGH_VIDEO_URL ? (
+              <video
+                src={WALKTHROUGH_VIDEO_URL}
+                controls
+                playsInline
+                style={{ width: '100%', borderRadius: 12, display: 'block' }}
+              />
+            ) : (
+              <div
+                className="flex flex-col items-center justify-center text-center"
+                style={{
+                  aspectRatio: '16 / 9',
+                  borderRadius: 12,
+                  background: 'rgba(255,255,255,0.03)',
+                  boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.08)',
+                  color: 'rgba(232,226,218,0.45)',
+                  gap: 6,
+                  padding: 12,
+                }}
+              >
+                <span style={{ fontSize: 22 }}>▶</span>
+                <span className="font-mono uppercase" style={{ fontSize: 9.5, letterSpacing: '0.12em' }}>
+                  Full walkthrough video — coming soon
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Controls */}
+        <div className="flex items-center justify-between mt-4">
+          <button
+            onClick={dismiss}
+            className="font-mono uppercase"
+            style={{ color: 'rgba(232,226,218,0.5)', fontSize: 10, letterSpacing: '0.12em', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            Skip
+          </button>
+          <div className="flex items-center gap-2">
+            {step > 0 && (
+              <button
+                onClick={() => setStep((n) => Math.max(0, n - 1))}
+                style={{
+                  padding: '9px 14px',
+                  borderRadius: 999,
+                  background: 'rgba(255,255,255,0.06)',
+                  color: '#e8e6e0',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  border: 'none',
+                  cursor: 'pointer',
+                }}
+              >
+                Back
+              </button>
+            )}
+            <button
+              onClick={() => (isLast ? dismiss() : setStep((n) => Math.min(STEPS.length - 1, n + 1)))}
+              style={{
+                padding: '9px 18px',
+                borderRadius: 999,
+                background: '#7c3aed',
+                color: '#fff',
+                fontSize: 12,
+                fontWeight: 700,
+                border: 'none',
+                cursor: 'pointer',
+                boxShadow: '0 0 20px -6px rgba(168,85,247,0.6), inset 0 1px 0 rgba(255,255,255,0.2)',
+              }}
+            >
+              {isLast ? 'Start capturing' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/bars/ElementEmotionLegend.tsx
+++ b/src/components/bars/ElementEmotionLegend.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+/**
+ * ElementEmotionLegend — the shared "what do the elements mean?" explainer.
+ *
+ * Surfaces the connection players were missing: every Wuxing element is a
+ * channel for one emotion, and a captured charge is energy, not a verdict.
+ *
+ * Single source of truth:
+ *   - sigil / English name / emotion  → ELEMENT_TOKENS (src/lib/ui/card-tokens.ts)
+ *   - the lesson each charge points at → ELEMENTS (src/lib/quest-grammar/elements.ts)
+ *
+ * Used inline (e.g. the wiki field guide) and as a modal overlay on the capture
+ * canvas. Design ref: design_handoff_bars_v1_intake "Elements and Emotional Alchemy".
+ */
+
+import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { ELEMENTS } from '@/lib/quest-grammar/elements'
+
+// Read the elements in the order energy naturally flows (the generative cycle).
+const FLOW_ORDER: ElementKey[] = ['wood', 'fire', 'earth', 'metal', 'water']
+
+// Short, plain-language lesson per element (mirrors the field-guide copy; falls
+// back to the canonical ELEMENTS lesson).
+const SHORT_LESSON: Record<ElementKey, string> = {
+  wood: 'Vitality detected — something alive and worth growing.',
+  fire: 'An obstacle is present, or a boundary was crossed.',
+  earth: 'Whole-system perspective. Grounded detachment.',
+  metal: 'Risk — or opportunity — detected. Excitement is fear read as opportunity.',
+  water: 'Something you care about is distant or misaligned.',
+}
+
+function ElementCard({ el }: { el: ElementKey }) {
+  const t = ELEMENT_TOKENS[el]
+  const lesson = SHORT_LESSON[el] ?? ELEMENTS[el].lesson
+  return (
+    <div
+      className="flex flex-col gap-2.5 rounded-xl p-4"
+      style={{
+        background: `radial-gradient(ellipse 120% 80% at 50% 0%, color-mix(in srgb, ${t.frame} 12%, transparent), transparent 60%), #1a1a18`,
+        boxShadow: `inset 0 1px 0 rgba(255,255,255,0.06), 0 0 0 1px color-mix(in srgb, ${t.frame} 55%, transparent)`,
+      }}
+    >
+      <span
+        style={{ color: t.gem, textShadow: `0 0 14px ${t.glow}`, fontSize: 30, lineHeight: 1 }}
+        aria-hidden
+      >
+        {t.sigil}
+      </span>
+      <div>
+        <div className="font-semibold" style={{ color: '#e8e6e0', fontSize: 17 }}>
+          {t.label}
+        </div>
+        <div
+          className="font-mono uppercase mt-0.5"
+          style={{ color: '#6b6965', fontSize: 9.5, letterSpacing: '0.1em' }}
+        >
+          {t.sigil} · {t.label}
+        </div>
+      </div>
+      <span
+        className="self-start font-mono uppercase rounded"
+        style={{
+          color: t.gem,
+          fontSize: 10,
+          letterSpacing: '0.04em',
+          padding: '4px 9px',
+          background: `color-mix(in srgb, ${t.frame} 16%, transparent)`,
+          boxShadow: `inset 0 0 0 1px ${t.frame}`,
+        }}
+      >
+        {t.emotion}
+      </span>
+      <p className="leading-snug" style={{ color: '#a09e98', fontSize: 13, margin: 0 }}>
+        {lesson}
+      </p>
+    </div>
+  )
+}
+
+export function ElementEmotionLegend({ className = '' }: { className?: string }) {
+  return (
+    <div className={className}>
+      <div className="mb-4">
+        <h2 className="font-bold" style={{ color: '#e8e6e0', fontSize: 22, letterSpacing: '-0.02em' }}>
+          The five elements &amp; their emotions
+        </h2>
+        <p className="mt-2 leading-relaxed" style={{ color: '#a09e98', fontSize: 14 }}>
+          Every charge you capture is <em style={{ fontStyle: 'normal', color: '#e8e6e0' }}>energy</em>, not
+          a verdict. Each element is a channel for one emotion — the colour you attune a seed to says which
+          emotion it carries. It&apos;s an energy economy, not a morality wheel.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {['Charge = energy detected', 'Element = which channel', 'Alchemy = how it moves'].map((chip) => (
+            <span
+              key={chip}
+              className="font-mono rounded"
+              style={{
+                fontSize: 11,
+                color: '#a09e98',
+                padding: '6px 11px',
+                background: '#111110',
+                boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.07)',
+              }}
+            >
+              {chip}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}>
+        {FLOW_ORDER.map((el) => (
+          <ElementCard key={el} el={el} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Modal wrapper for surfacing the legend over the capture canvas. */
+export function ElementEmotionLegendModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col"
+      style={{ zIndex: 45, background: 'rgba(5,4,3,0.92)', backdropFilter: 'blur(9px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="What the elements mean"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="flex items-center justify-between" style={{ padding: '18px 18px 6px' }}>
+        <span
+          className="font-mono uppercase"
+          style={{ color: 'rgba(232,226,218,0.6)', fontSize: 9, letterSpacing: '0.14em' }}
+        >
+          火 水 木 金 土 · Field guide
+        </span>
+        <button
+          onClick={onClose}
+          style={{
+            padding: '8px 16px',
+            borderRadius: 999,
+            background: '#7c3aed',
+            color: '#fff',
+            fontFamily: 'Space Mono, monospace',
+            fontSize: 11,
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          Done
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto" style={{ padding: '8px 16px 24px' }}>
+        <ElementEmotionLegend />
+        <a
+          href="/wiki/emotional-alchemy"
+          className="mt-5 inline-flex items-center gap-2"
+          style={{ color: '#a855f7', fontSize: 13, fontWeight: 600, textDecoration: 'none' }}
+        >
+          Learn the full alchemy →
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/components/bars/MoveGenerator.tsx
+++ b/src/components/bars/MoveGenerator.tsx
@@ -269,7 +269,7 @@ function BoardView({ cards, works, campaign, readyCount, total, onOpen }: {
         {readyCount >= total && total > 0 ? 'Every card is a BAR.' : 'Build each card into a move.'}
       </h1>
       <p style={{ fontFamily:'Nunito, sans-serif', fontSize:12, lineHeight:1.45, color:'#a09e98', margin:'9px 0 0' }}>
-        Tap a card to name its charge, name the block, and run the basic move.
+        Tap a card to name its charge, name the block, and run the basic move. Each finished card becomes a playable BAR.
       </p>
 
       <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:11, marginTop:18 }}>
@@ -520,7 +520,7 @@ function BlockStep({ card, work, setWork }: { card: MoveCard; work: CardWork; se
           <p style={{ fontFamily:'Nunito, sans-serif', fontSize:12, lineHeight:1.5, color:'#a09e98', margin:'7px 0 0' }}>When feelings stack three deep, the work isn't this card — it's <strong style={{ color:'#e8e6e0', fontWeight:700 }}>emotional alchemy itself</strong>. A sign to slow down and bring in support.</p>
           <div style={{ display:'flex', gap:8, marginTop:12 }}>
             <a href="/wiki/321" style={{ flex:1, textAlign:'center', textDecoration:'none', padding:10, borderRadius:8, background:'#7c3aed', color:'#fff', fontFamily:'Jost, sans-serif', fontWeight:700, fontSize:12, boxShadow:'0 0 22px -7px #7c3aed88' }}>Reach out for support →</a>
-            <a href="/wiki/321" style={{ flex:'0 0 auto', textAlign:'center', textDecoration:'none', padding:'10px 13px', borderRadius:8, background:'#242420', boxShadow:'inset 0 0 0 1px rgba(255,255,255,0.14)', color:'#a09e98', fontFamily:'Jost, sans-serif', fontWeight:700, fontSize:12 }}>Learn alchemy</a>
+            <a href="/wiki/emotional-alchemy" style={{ flex:'0 0 auto', textAlign:'center', textDecoration:'none', padding:'10px 13px', borderRadius:8, background:'#242420', boxShadow:'inset 0 0 0 1px rgba(255,255,255,0.14)', color:'#a09e98', fontFamily:'Jost, sans-serif', fontWeight:700, fontSize:12 }}>Learn alchemy</a>
           </div>
         </div>
       )}

--- a/src/components/bars/MoveGenerator.tsx
+++ b/src/components/bars/MoveGenerator.tsx
@@ -13,7 +13,13 @@ type FaceKey  = 'challenger' | 'sage' | 'architect' | 'diplomat' | 'shaman' | 'r
 type DomainKey = 'gather_resources' | 'raise_awareness' | 'direct_action' | 'skillful_organizing'
 
 const SIGILS: Record<string, string> = { fire:'火', water:'水', wood:'木', metal:'金', earth:'土', liminal:'◇' }
+const EL_NAMES: Record<string, string> = { fire:'Fire', water:'Water', wood:'Wood', metal:'Metal', earth:'Earth', liminal:'Liminal' }
 const FEELINGS: Record<string, string> = { fire:'Anger', water:'Sadness', metal:'Fear', earth:'Apathy', wood:'Restlessness', liminal:'Charge' }
+/** Accessible name for a bare element sigil, e.g. "Fire · Anger". */
+function sigilAria(el: string | null | undefined): string {
+  const key = el ?? 'liminal'
+  return `${EL_NAMES[key] ?? key} · ${FEELINGS[key] ?? ''}`.replace(/ · $/, '')
+}
 const FACES: Record<FaceKey, string> = { challenger:'Challenger', sage:'Sage', architect:'Architect', diplomat:'Diplomat', shaman:'Shaman', regent:'Regent' }
 const CHARGE_WORDS = ['', 'A flicker', 'A pull', 'A weight', 'A surge', 'A storm']
 
@@ -299,12 +305,12 @@ function BoardCard({ card, work, onOpen }: { card: MoveCard; work: CardWork; onO
   return (
     <div onClick={onOpen} style={{ position:'relative', overflow:'hidden', borderRadius:13, minHeight:172, padding:'14px 14px 13px', background:`radial-gradient(ellipse 120% 80% at 50% 0%, color-mix(in srgb, ${p.frame} 13%, transparent), transparent 60%), linear-gradient(180deg, #1d1d1a 0%, #1a1a18 100%)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), 0 0 0 1.5px ${p.frame}, 0 0 16px -5px ${p.glow}, 0 22px 40px -28px rgba(0,0,0,0.85)`, cursor:'pointer', WebkitTapHighlightColor:'transparent', transition:'transform 0.16s ease' }}>
       {/* Watermark */}
-      <span style={{ position:'absolute', left:'50%', top:'48%', transform:'translate(-50%,-50%)', fontFamily:'Nunito, sans-serif', fontSize:84, lineHeight:1, opacity:0.12, color:p.gem, textShadow:`0 0 24px ${p.glow}`, pointerEvents:'none', userSelect:'none', zIndex:0 }}>{sigil}</span>
+      <span style={{ position:'absolute', left:'50%', top:'48%', transform:'translate(-50%,-50%)', fontFamily:'Nunito, sans-serif', fontSize:84, lineHeight:1, opacity:0.12, color:p.gem, textShadow:`0 0 24px ${p.glow}`, pointerEvents:'none', userSelect:'none', zIndex:0 }} aria-hidden>{sigil}</span>
 
       <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', height:'100%' }}>
         {/* Gem + charge label */}
         <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:6 }}>
-          <span style={{ flex:'0 0 auto', width:28, height:28, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:15, color:p.gem, background:`color-mix(in srgb, ${p.frame} 18%, #111110)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), inset 0 0 0 1.5px color-mix(in srgb, ${p.frame} 70%, transparent), 0 0 12px -2px ${p.glow}` }}>{sigil}</span>
+          <span style={{ flex:'0 0 auto', width:28, height:28, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:15, color:p.gem, background:`color-mix(in srgb, ${p.frame} 18%, #111110)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), inset 0 0 0 1.5px color-mix(in srgb, ${p.frame} 70%, transparent), 0 0 12px -2px ${p.glow}` }} role="img" aria-label={sigilAria(card.el)}>{sigil}</span>
           <span style={{ fontFamily:'Space Mono, monospace', fontSize:7.5, letterSpacing:'0.08em', textTransform:'uppercase' as const, color:p.gem }}>{card.chargeLabel}</span>
         </div>
 
@@ -346,7 +352,7 @@ function CardView({ card, work, step, howOpen, setHowOpen, domain, onBoard, setW
 
       {/* Compact card summary */}
       <div style={{ position:'relative', overflow:'hidden', display:'flex', alignItems:'center', gap:12, marginTop:14, borderRadius:12, padding:'13px 14px', background:`radial-gradient(ellipse 120% 80% at 50% 0%, color-mix(in srgb, ${p.frame} 13%, transparent), transparent 60%), linear-gradient(180deg, #1d1d1a, #1a1a18)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), 0 0 0 1.5px ${p.frame}, 0 0 18px -5px ${p.glow}` }}>
-        <span style={{ flex:'0 0 auto', position:'relative', zIndex:1, width:38, height:38, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:19, color:p.gem, background:`color-mix(in srgb, ${p.frame} 18%, #111110)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), inset 0 0 0 1.5px color-mix(in srgb, ${p.frame} 70%, transparent), 0 0 14px -2px ${p.glow}` }}>{sigil}</span>
+        <span style={{ flex:'0 0 auto', position:'relative', zIndex:1, width:38, height:38, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:19, color:p.gem, background:`color-mix(in srgb, ${p.frame} 18%, #111110)`, boxShadow:`inset 0 1px 0 rgba(255,255,255,0.06), inset 0 0 0 1.5px color-mix(in srgb, ${p.frame} 70%, transparent), 0 0 14px -2px ${p.glow}` }} role="img" aria-label={sigilAria(card.el)}>{sigil}</span>
         <div style={{ flex:1, minWidth:0, position:'relative', zIndex:1 }}>
           <p style={{ fontFamily:'Jost, sans-serif', fontWeight:700, fontSize:14.5, lineHeight:1.2, margin:0, color:'#e8e6e0' }}>{card.title}</p>
           <span style={{ fontFamily:'Space Mono, monospace', fontSize:8, letterSpacing:'0.06em', textTransform:'uppercase' as const, color:'#6b6965' }}>
@@ -469,7 +475,7 @@ function BlockStep({ card, work, setWork }: { card: MoveCard; work: CardWork; se
       <div style={{ display:'flex', flexDirection:'column', gap:5, marginTop:10 }}>
         {/* Base row */}
         <div style={{ display:'flex', alignItems:'center', gap:11, borderRadius:12, background:'#111110', boxShadow:`inset 0 0 0 1px ${cardPal.frame}`, padding:'10px 12px' }}>
-          <span style={{ flex:'0 0 auto', width:30, height:30, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:15, color:cardPal.gem, background:`color-mix(in srgb, ${cardPal.gem} 16%, transparent)` }}>{sigil}</span>
+          <span style={{ flex:'0 0 auto', width:30, height:30, borderRadius:'50%', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Nunito, sans-serif', fontSize:15, color:cardPal.gem, background:`color-mix(in srgb, ${cardPal.gem} 16%, transparent)` }} role="img" aria-label={sigilAria(card.el)}>{sigil}</span>
           <div style={{ flex:1, minWidth:0 }}>
             <span style={{ fontFamily:'Space Mono, monospace', fontSize:7.5, letterSpacing:'0.1em', textTransform:'uppercase' as const, color:'#6b6965' }}>The charge</span>
             <p style={{ fontFamily:'Jost, sans-serif', fontWeight:700, fontSize:13, margin:'2px 0 0', color:'#e8e6e0' }}>{card.chargeLabel}</p>

--- a/src/components/bars/SeedCaptureWhiteboard.tsx
+++ b/src/components/bars/SeedCaptureWhiteboard.tsx
@@ -616,7 +616,7 @@ function BottomChrome({ fieldTint, charge, onSetCharge, intent, onIntentChange, 
                   n <= charge && tok
                     ? `0 0 10px -2px ${tok.glow}`
                     : n <= charge
-                    ? '0 0 10px -2px rgba(168,85,247,0.6)'
+                    ? '0 0 10px -2px var(--bars-liminal-glow)'
                     : 'none',
               }}
             />
@@ -697,7 +697,7 @@ function BottomChrome({ fieldTint, charge, onSetCharge, intent, onIntentChange, 
           border: 'none',
           cursor: capturing ? 'default' : 'pointer',
           opacity: capturing ? 0.7 : 1,
-          boxShadow: '0 0 30px -6px rgba(168,85,247,0.6), inset 0 1px 0 rgba(255,255,255,0.18)',
+          boxShadow: '0 0 30px -6px var(--bars-liminal-glow), inset 0 1px 0 rgba(255,255,255,0.18)',
           transition: 'opacity 0.2s',
         }}
       >
@@ -787,7 +787,7 @@ function TextEditorOverlay({
             fontWeight: 700,
             border: 'none',
             cursor: 'pointer',
-            boxShadow: '0 0 20px -6px rgba(168,85,247,0.6), inset 0 1px 0 rgba(255,255,255,0.2)',
+            boxShadow: '0 0 20px -6px var(--bars-liminal-glow), inset 0 1px 0 rgba(255,255,255,0.2)',
           }}
         >
           Done
@@ -822,19 +822,35 @@ function TextEditorOverlay({
         />
       </div>
 
-      {/* Size slider */}
-      <div className="flex items-center gap-3 px-6" style={{ paddingBottom: 4 }}>
-        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 11, color: 'rgba(232,226,218,0.5)', flexShrink: 0 }}>A</span>
+      {/* Size slider — vertical, pinned to the left edge (matches prototype). */}
+      <style>{`
+        .bars-szrange { -webkit-appearance: none; appearance: none; width: 168px; height: 4px; border-radius: 3px; background: rgba(255,255,255,0.22); outline: none; }
+        .bars-szrange::-webkit-slider-thumb { -webkit-appearance: none; width: 22px; height: 22px; border-radius: 50%; background: #fff; box-shadow: 0 0 10px rgba(0,0,0,0.55); cursor: pointer; }
+        .bars-szrange::-moz-range-thumb { width: 22px; height: 22px; border: none; border-radius: 50%; background: #fff; box-shadow: 0 0 10px rgba(0,0,0,0.55); cursor: pointer; }
+      `}</style>
+      <div
+        style={{
+          position: 'absolute',
+          left: 6,
+          top: '50%',
+          transform: 'translateY(-50%) rotate(-90deg)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 11, color: 'rgba(232,226,218,0.7)', transform: 'rotate(90deg)' }}>A</span>
         <input
+          className="bars-szrange"
           type="range"
-          min={12}
-          max={80}
+          min={16}
+          max={54}
           step={1}
           value={draftSize}
           onChange={(e) => onDraftSizeChange(Number(e.target.value))}
-          style={{ flex: 1 }}
+          aria-label="Text size"
         />
-        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 22, color: 'rgba(232,226,218,0.5)', flexShrink: 0 }}>A</span>
+        <span style={{ fontFamily: 'Jost, sans-serif', fontWeight: 800, fontSize: 20, color: 'rgba(232,226,218,0.7)', transform: 'rotate(90deg)' }}>A</span>
       </div>
 
       {/* Element colour rail */}
@@ -992,7 +1008,7 @@ function CapturedOverlay({ title, placedIn, onTuneNow, onBackToBoard }: Captured
             fontSize: 15.5,
             border: 'none',
             cursor: 'pointer',
-            boxShadow: '0 0 30px -6px rgba(168,85,247,0.6), inset 0 1px 0 rgba(255,255,255,0.18)',
+            boxShadow: '0 0 30px -6px var(--bars-liminal-glow), inset 0 1px 0 rgba(255,255,255,0.18)',
           }}
         >
           Tune now →

--- a/src/components/bars/SeedCaptureWhiteboard.tsx
+++ b/src/components/bars/SeedCaptureWhiteboard.tsx
@@ -2,11 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { ELEMENT_TOKENS, elementLabel, type ElementKey } from '@/lib/ui/card-tokens'
 import {
   captureBarFromCanvas,
   type CanvasItem,
 } from '@/actions/bars'
+import { ElementEmotionLegendModal } from './ElementEmotionLegend'
+import { CaptureWalkthrough } from './CaptureWalkthrough'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -27,6 +29,11 @@ const CHARGE_LABELS: Record<number, string> = {
 }
 
 const ELEMENT_ORDER: ElementKey[] = ['fire', 'water', 'wood', 'metal', 'earth']
+
+// Shown on the empty starter sticker — an invitation to write your own spark,
+// not an example to delete. Rendered muted by TextSticker; never captured as text.
+const PLACEHOLDER_PROMPT = "What's charged for\nyou right now?"
+const PLACEHOLDER_HINT = 'Tap to write'
 
 function clamp(v: number, min: number, max: number) {
   return Math.max(min, Math.min(max, v))
@@ -53,14 +60,18 @@ function buildDefaultItems(defaultText?: string): CanvasItem[] {
       size: 27,
     }]
   }
+  // No prefill → start with an EMPTY placeholder sticker. It renders the muted
+  // prompt copy (see TextSticker) inviting the user's own words, instead of a
+  // canned example they have to notice-and-delete. Excluded from capture until
+  // the user actually types something.
   return [{
     id: 'seed-text-1',
     type: 'text',
-    x: 184,
-    y: 218,
-    rot: -2,
-    text: 'I went quiet in the\nmeeting again.',
-    tint: 'water',
+    x: 196,
+    y: 300,
+    rot: 0,
+    text: '',
+    tint: null,
     size: 27,
   }]
 }
@@ -183,9 +194,10 @@ interface ToolRailProps {
   onAddVoice: () => void
   onAddLink: () => void
   onSetElement: (el: ElementKey) => void
+  onShowLegend: () => void
 }
 
-function ToolRail({ fieldTint, onAddText, onAddPhoto, onAddVoice, onAddLink, onSetElement }: ToolRailProps) {
+function ToolRail({ fieldTint, onAddText, onAddPhoto, onAddVoice, onAddLink, onSetElement, onShowLegend }: ToolRailProps) {
   const btnBase: React.CSSProperties = {
     width: 40,
     height: 40,
@@ -238,6 +250,25 @@ function ToolRail({ fieldTint, onAddText, onAddPhoto, onAddVoice, onAddLink, onS
       {/* Divider */}
       <div style={{ width: 30, height: 1, background: 'rgba(255,255,255,0.14)', margin: '3px 5px' }} />
 
+      {/* "What do the elements mean?" — opens the element↔emotion field guide */}
+      <div className="flex items-center gap-[10px]">
+        <span
+          className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-right leading-tight"
+          style={{ color: 'rgba(232,226,218,0.45)' }}
+        >
+          what do
+          <br />
+          these mean?
+        </span>
+        <button
+          onClick={onShowLegend}
+          aria-label="What do the elements mean?"
+          style={{ ...btnBase, width: 34, height: 34, fontSize: 16, fontWeight: 700 }}
+        >
+          ?
+        </button>
+      </div>
+
       {/* Element rows */}
       {ELEMENT_ORDER.map((el) => {
         const tok = ELEMENT_TOKENS[el]
@@ -245,14 +276,16 @@ function ToolRail({ fieldTint, onAddText, onAddPhoto, onAddVoice, onAddLink, onS
         return (
           <div key={el} className="flex items-center gap-[10px]">
             <span
-              className="font-mono text-[8.5px] uppercase tracking-[0.14em]"
+              className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-right leading-tight"
               style={{ color: active ? tok.gem : 'rgba(232,226,218,0.55)' }}
             >
-              {el.toUpperCase()}
+              {tok.label}
+              <br />
+              <span style={{ opacity: 0.7 }}>{tok.emotion}</span>
             </span>
             <button
               onClick={() => onSetElement(el)}
-              aria-label={`Attune to ${el}`}
+              aria-label={`Attune to ${elementLabel(el, { withEmotion: true })}`}
               style={{
                 width: 34,
                 height: 34,
@@ -291,10 +324,12 @@ interface TextStickerProps {
 }
 
 function TextSticker({ item, isDragging, onPointerDown }: TextStickerProps) {
-  const color = textColor((item.tint as ElementKey | null) ?? null)
+  const isEmpty = !item.text || !item.text.trim()
+  const color = isEmpty ? 'rgba(232,226,218,0.42)' : textColor((item.tint as ElementKey | null) ?? null)
   return (
     <div
       onPointerDown={(e) => onPointerDown(e, item.id)}
+      aria-label={isEmpty ? 'Empty seed — tap to write' : undefined}
       style={{
         position: 'absolute',
         left: item.x,
@@ -307,14 +342,18 @@ function TextSticker({ item, isDragging, onPointerDown }: TextStickerProps) {
         textAlign: 'center',
         whiteSpace: 'pre-wrap',
         maxWidth: 300,
-        padding: '4px 8px',
-        borderRadius: 9,
+        padding: isEmpty ? '12px 18px' : '4px 8px',
+        borderRadius: 14,
         color,
-        textShadow: '0 2px 16px rgba(0,0,0,0.85), 0 0 1px rgba(0,0,0,0.6)',
-        cursor: 'grab',
+        textShadow: isEmpty ? 'none' : '0 2px 16px rgba(0,0,0,0.85), 0 0 1px rgba(0,0,0,0.6)',
+        cursor: isEmpty ? 'text' : 'grab',
         userSelect: 'none',
         touchAction: 'none',
         transition: isDragging ? 'none' : 'transform 0.16s cubic-bezier(0.16,1,0.3,1)',
+        // Empty placeholder gets a soft dashed frame so it reads as "tap here".
+        ...(isEmpty && !isDragging
+          ? { boxShadow: 'inset 0 0 0 1px rgba(232,226,218,0.18)', background: 'rgba(255,255,255,0.015)' }
+          : {}),
         ...(isDragging
           ? {
               filter: 'brightness(1.06) drop-shadow(0 18px 26px rgba(0,0,0,0.55))',
@@ -324,7 +363,27 @@ function TextSticker({ item, isDragging, onPointerDown }: TextStickerProps) {
           : {}),
       }}
     >
-      {item.text}
+      {isEmpty ? (
+        <>
+          {PLACEHOLDER_PROMPT}
+          <span
+            style={{
+              display: 'block',
+              marginTop: 10,
+              fontFamily: 'Space Mono, monospace',
+              fontWeight: 400,
+              fontSize: 10,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              opacity: 0.75,
+            }}
+          >
+            {PLACEHOLDER_HINT}
+          </span>
+        </>
+      ) : (
+        item.text
+      )}
     </div>
   )
 }
@@ -787,7 +846,9 @@ function TextEditorOverlay({
           className="font-mono text-[8.5px] uppercase tracking-[0.16em]"
           style={{ color: 'rgba(232,226,218,0.5)' }}
         >
-          Attune to an element
+          {draftTint === 'none'
+            ? 'Attune to an element'
+            : `${ELEMENT_TOKENS[draftTint as ElementKey].sigil} ${elementLabel(draftTint as ElementKey, { withEmotion: true })}`}
         </span>
         <div className="flex gap-[13px]">
           {/* None swatch */}
@@ -800,7 +861,7 @@ function TextEditorOverlay({
               <button
                 key={t}
                 onClick={() => onDraftTintChange(t as ElementKey | 'none')}
-                aria-label={t === 'none' ? 'No element' : t}
+                aria-label={t === 'none' ? 'No element' : elementLabel(t as ElementKey, { withEmotion: true })}
                 style={{
                   width: 34,
                   height: 34,
@@ -1247,6 +1308,7 @@ export function SeedCaptureWhiteboard({
   const [reducedMotion, setReducedMotion] = useState(false)
   const [intent, setIntent] = useState('')
   const [captured, setCaptured] = useState<{ barId: string; title: string; placedIn: 'hand' | 'vault' } | null>(null)
+  const [showLegend, setShowLegend] = useState(false)
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -1545,11 +1607,28 @@ export function SeedCaptureWhiteboard({
   // ─── Capture ───────────────────────────────────────────────────────────────
 
   const handleCapture = useCallback(async () => {
+    // Guard: a board showing only the empty placeholder sticker has no real
+    // content. Don't capture a blank seed — nudge the user to add something.
+    const hasRealContent = items.some(
+      (i) =>
+        (i.type === 'text' && !!i.text && i.text.trim().length > 0) ||
+        i.type === 'photo' ||
+        i.type === 'voice' ||
+        i.type === 'link',
+    )
+    if (!hasRealContent) {
+      setCaptureError('Write a line — or add a photo, voice note, or link — before capturing.')
+      return
+    }
     setCaptureError(null)
     setCapturing(true)
+    // Never persist an empty placeholder text sticker.
+    const captureItems = items.filter(
+      (i) => !(i.type === 'text' && (!i.text || !i.text.trim())),
+    )
     try {
       const result = await captureBarFromCanvas({
-        items,
+        items: captureItems,
         fieldTint,
         charge,
         storyContent: intent.trim() || undefined,
@@ -1788,6 +1867,7 @@ export function SeedCaptureWhiteboard({
           onAddVoice={handleAddVoice}
           onAddLink={handleAddLink}
           onSetElement={handleSetElement}
+          onShowLegend={() => setShowLegend(true)}
         />
 
         {/* Compost node (visible while dragging) */}
@@ -1836,6 +1916,12 @@ export function SeedCaptureWhiteboard({
             onBackToBoard={() => router.push('/hand')}
           />
         )}
+
+        {/* Element ↔ emotion field guide */}
+        {showLegend && <ElementEmotionLegendModal onClose={() => setShowLegend(false)} />}
+
+        {/* First-run coach-marks: write → attune → charge → capture → Hand */}
+        <CaptureWalkthrough onOpenLegend={() => setShowLegend(true)} />
       </div>
     </div>
   )

--- a/src/components/bars/SimpleCaptureForm.tsx
+++ b/src/components/bars/SimpleCaptureForm.tsx
@@ -114,7 +114,7 @@ export function SimpleCaptureForm({ defaultText = '', campaignRef }: SimpleCaptu
                                     key={key}
                                     onClick={() => setElement(active ? null : key)}
                                     className="flex flex-col items-center gap-1 flex-1 py-2 rounded-lg transition-all duration-150"
-                                    title={label}
+                                    title={`${label} · ${token.emotion}`}
                                     style={{
                                         background: active ? token.cssVarColor + '22' : 'rgba(255,255,255,0.04)',
                                         border: `1px solid ${active ? token.cssVarColor : 'rgba(255,255,255,0.08)'}`,
@@ -122,10 +122,12 @@ export function SimpleCaptureForm({ defaultText = '', campaignRef }: SimpleCaptu
                                 >
                                     <span className="text-lg">{sigil}</span>
                                     <span
-                                        className="text-[10px]"
-                                        style={{ color: active ? token.cssVarColor : '#6b6965' }}
+                                        className="text-[10px] leading-tight text-center"
+                                        style={{ color: active ? token.cssVarColor : '#a09e98' }}
                                     >
                                         {label}
+                                        <br />
+                                        <span style={{ opacity: 0.7 }}>{token.emotion}</span>
                                     </span>
                                 </button>
                             )

--- a/src/components/bars/TuneBarClient.tsx
+++ b/src/components/bars/TuneBarClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { CultivationCard } from '@/components/ui/CultivationCard'
-import { ELEMENT_TOKENS, type ElementKey, type CardAltitude } from '@/lib/ui/card-tokens'
+import { ELEMENT_TOKENS, elementLabel, type ElementKey, type CardAltitude } from '@/lib/ui/card-tokens'
 import type { AlchemyAltitude } from '@/lib/alchemy/types'
 import type { MaturityPhase } from '@/lib/bar-seed-metabolization/types'
 import { tuneBar } from '@/actions/bars'
@@ -25,13 +25,14 @@ interface TuneBarClientProps {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const ELEMENTS: Array<{ key: ElementKey; label: string }> = [
-    { key: 'fire',   label: '火 Fire' },
-    { key: 'water',  label: '水 Water' },
-    { key: 'wood',   label: '木 Wood' },
-    { key: 'metal',  label: '金 Metal' },
-    { key: 'earth',  label: '土 Earth' },
-]
+// sigil + English name + emotion, e.g. "火 Fire · Anger" — derived from the
+// single source of truth so the Chinese sigil always carries its translation.
+const ELEMENTS: Array<{ key: ElementKey; label: string }> = (
+    ['fire', 'water', 'wood', 'metal', 'earth'] as ElementKey[]
+).map((key) => ({
+    key,
+    label: `${ELEMENT_TOKENS[key].sigil} ${elementLabel(key, { withEmotion: true })}`,
+}))
 
 const ALTITUDES: Array<{ key: CardAltitude; label: string; hint: string }> = [
     { key: 'dissatisfied', label: 'Dissatisfied', hint: 'Something still wrong' },
@@ -233,12 +234,21 @@ export function TuneBarClient({
 
                 {/* Channel 1: Element */}
                 <section>
-                    <p
-                        className="text-xs uppercase tracking-widest mb-3"
-                        style={{ color: 'var(--bars-text-muted, #6b6965)' }}
-                    >
-                        Element
-                    </p>
+                    <div className="flex items-baseline justify-between mb-3">
+                        <p
+                            className="text-xs uppercase tracking-widest"
+                            style={{ color: 'var(--bars-text-muted, #6b6965)' }}
+                        >
+                            Element
+                        </p>
+                        <a
+                            href="/wiki/emotional-alchemy"
+                            className="text-xs"
+                            style={{ color: '#a855f7', textDecoration: 'none' }}
+                        >
+                            how they channel emotion →
+                        </a>
+                    </div>
                     <div className="flex flex-wrap gap-2">
                         {ELEMENTS.map(({ key, label }) => {
                             const token = ELEMENT_TOKENS[key]

--- a/src/components/bars/UnpackingQuiz.tsx
+++ b/src/components/bars/UnpackingQuiz.tsx
@@ -399,7 +399,7 @@ function StepTruths({ nowEls, truths, setTruths }: {
           What would have to be true?
         </h2>
         <p style={{ fontFamily: 'Nunito, sans-serif', fontSize: 12, lineHeight: 1.5, color: '#a09e98', margin: '6px 0 0' }}>
-          For you to feel this way. Write freely — these become the roots of your hand.
+          For you to feel this way. Reflection is optional — write what&apos;s true. These become the roots of your hand.
         </p>
       </div>
       {nowEls.map(el => {

--- a/src/components/campaign-hub/SeedGrowthCard.tsx
+++ b/src/components/campaign-hub/SeedGrowthCard.tsx
@@ -459,9 +459,9 @@ export function SeedGrowthCard({
             </span>
           </div>
           {/* Water level counter */}
-          <span className="text-[10px] font-mono text-zinc-500 tabular-nums">
+          <span className="text-[10px] font-mono text-zinc-500 tabular-nums" aria-label={`Water level ${Math.round(waterLevel)}`}>
             {Math.round(waterLevel)}
-            <span className="ml-0.5 text-zinc-600">水</span>
+            <span className="ml-0.5 text-zinc-600" title="Water (水)">水<span className="sr-only"> water</span></span>
           </span>
         </div>
 

--- a/src/components/handbook/HandbookReader.tsx
+++ b/src/components/handbook/HandbookReader.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { COLOR, FONT } from "@/lib/handbook/tokens";
-import { SEAL, SPREAD_ART } from "@/lib/handbook/assets";
+import { SEAL, SEAL_GLOSS, SPREAD_ART } from "@/lib/handbook/assets";
 import type { Block, Chapter } from "@/lib/handbook/content";
 import { createHandbookBar } from "@/actions/handbook-bar";
 import { addCampaignDomainPreference } from "@/actions/campaign-domain-preference";
@@ -389,7 +389,7 @@ export function HandbookReader({ chapterId }: { chapterId: string }) {
               <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginTop: 6 }}>
                 <div style={{ fontFamily: FONT.hand, fontWeight: 700, fontSize: 15, color: "#1d1a15", lineHeight: 0.9 }}>the Headmaster</div>
                 <div style={{ width: 26, height: 26, background: COLOR.cinnabar, borderRadius: 2, display: "grid", placeItems: "center" }}>
-                  <span style={{ fontFamily: FONT.seal, fontSize: 16, color: "#f6ece0" }}>{SEAL}</span>
+                  <span style={{ fontFamily: FONT.seal, fontSize: 16, color: "#f6ece0" }} role="img" aria-label={`Headmaster's seal — ${SEAL_GLOSS} (${SEAL})`} title={`${SEAL_GLOSS} (${SEAL})`}>{SEAL}</span>
                 </div>
               </div>
             </div>

--- a/src/components/handbook/blocks/BarPromptBlock.tsx
+++ b/src/components/handbook/blocks/BarPromptBlock.tsx
@@ -101,7 +101,7 @@ export function BarPromptBlock({
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
-            <span style={{ fontFamily: FONT.seal, fontSize: 18, color: COLOR.gold }}>種</span>
+            <span style={{ fontFamily: FONT.seal, fontSize: 18, color: COLOR.gold }} role="img" aria-label="Seed (種)" title="Seed (種)">種</span>
             <span style={{ fontFamily: FONT.mono, fontSize: 9.5, letterSpacing: "0.14em", color: COLOR.gold }}>
               SEED PLANTED · SAVED AS A BAR
             </span>

--- a/src/components/handbook/blocks/LetterBlock.tsx
+++ b/src/components/handbook/blocks/LetterBlock.tsx
@@ -70,7 +70,7 @@ export function LetterBlock({
           <div style={{ position: "absolute", inset: 0, background: COLOR.cinnabar, borderRadius: 4 }} />
           <div style={{ position: "absolute", inset: 5, border: "1.5px solid rgba(247,236,224,.78)", borderRadius: 2 }} />
           <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
-            <span style={{ fontFamily: FONT.seal, fontSize: 36, color: "#f6ece0" }}>{seal}</span>
+            <span style={{ fontFamily: FONT.seal, fontSize: 36, color: "#f6ece0" }} role="img" aria-label={`Headmaster's seal — Protection (${seal})`} title={`Protection (${seal})`}>{seal}</span>
           </div>
         </div>
       </div>

--- a/src/components/now/CaptureBox.tsx
+++ b/src/components/now/CaptureBox.tsx
@@ -42,7 +42,7 @@ export function CaptureBox() {
         return
       }
       setText('')
-      showFlash(destination === 'hand' ? 'Added to hand' : 'Saved to vault')
+      showFlash(destination === 'hand' ? 'Now in your hand' : 'Paved to the Vault')
       router.refresh()
     })
   }
@@ -53,14 +53,14 @@ export function CaptureBox() {
       await resolveOverflow({ newBarId: overflow.newBarId, depositBarId })
       setOverflow(null)
       setText('')
-      showFlash('Added to hand')
+      showFlash('Now in your hand')
       router.refresh()
     })
   }
 
   const handleKeepInVault = () => {
     setOverflow(null)
-    showFlash('Saved to vault')
+    showFlash('Paved to the Vault')
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -204,7 +204,7 @@ export function CaptureBox() {
             WebkitTapHighlightColor: 'transparent',
           }}
         >
-          {pending ? '…' : 'Keep'}
+          {pending ? 'Capturing' : 'Capture'}
           {!pending && <span style={{ fontSize: 13 }}>→</span>}
         </button>
       </div>

--- a/src/lib/handbook/assets.ts
+++ b/src/lib/handbook/assets.ts
@@ -16,6 +16,8 @@ export const MOVE_ICONS = {
 
 /** The Headmaster's chop glyph (rendered in the `Ma Shan Zheng` web font, no image). */
 export const SEAL = "護";
+/** English gloss for the seal glyph — pair it with 護 so the character never stands alone. */
+export const SEAL_GLOSS = "Protection";
 
 /** Print-preview spread art. */
 export const SPREAD_ART = "/oracle/images/wu-a.png";

--- a/src/lib/ui/card-tokens.ts
+++ b/src/lib/ui/card-tokens.ts
@@ -39,6 +39,8 @@ export type CardTier     = 1 | 2 | 3 | 4
 export const ELEMENT_TOKENS = {
   fire: {
     sigil:      '火',
+    label:      'Fire',      // English name — always render alongside the sigil
+    emotion:    'Anger',     // emotional channel this element carries
     frame:      '#c1392b',   // cinnabar
     glow:       '#e8671a',   // ember-ochre
     gem:        '#e74c3c',   // bright ember
@@ -54,6 +56,8 @@ export const ELEMENT_TOKENS = {
   },
   water: {
     sigil:      '水',
+    label:      'Water',
+    emotion:    'Sadness',
     frame:      '#1a3a5c',   // deep navy
     glow:       '#1a7a8a',   // deep teal
     gem:        '#2980b9',   // ocean blue
@@ -69,6 +73,8 @@ export const ELEMENT_TOKENS = {
   },
   wood: {
     sigil:      '木',
+    label:      'Wood',
+    emotion:    'Joy',
     frame:      '#4a7c59',   // muted sage / forest
     glow:       '#27ae60',   // jade
     gem:        '#2ecc71',   // emerald
@@ -84,6 +90,8 @@ export const ELEMENT_TOKENS = {
   },
   metal: {
     sigil:      '金',
+    label:      'Metal',
+    emotion:    'Fear',
     frame:      '#8e9aab',   // silver-slate (NOT purple — purple = primary action)
     glow:       '#bdc3c7',   // chrome
     gem:        '#bdc3c7',   // pale chrome
@@ -99,6 +107,8 @@ export const ELEMENT_TOKENS = {
   },
   earth: {
     sigil:      '土',
+    label:      'Earth',
+    emotion:    'Neutrality',
     frame:      '#b5651d',   // terracotta
     glow:       '#d4a017',   // ochre-amber
     gem:        '#d4a017',   // warm gold
@@ -114,6 +124,7 @@ export const ELEMENT_TOKENS = {
   },
 } as const satisfies Record<ElementKey, {
   sigil: string
+  label: string; emotion: string
   frame: string; glow: string; gem: string
   bg: string; border: string; borderHover: string
   textAccent: string; badgeBg: string
@@ -207,6 +218,19 @@ export const SURFACE_TOKENS = {
   tableSlateCenter: '#1d1f25', // lit center (top-left light source)
   tableSlateEdge:   '#0b0c0f', // vignette edge (darkened rim)
 } as const
+
+// ─── Helper: English label (+ optional emotion) for an element ───────────────
+// Single source of truth for rendering a sigil's English name everywhere in the
+// UI. Every place that shows a Wuxing sigil should pair it with this label so no
+// Chinese character ever appears without an English translation.
+
+export function elementLabel(
+  element: ElementKey,
+  opts: { withEmotion?: boolean } = {},
+): string {
+  const t = ELEMENT_TOKENS[element]
+  return opts.withEmotion ? `${t.label} · ${t.emotion}` : t.label
+}
 
 // ─── Helper: build CSS custom properties for a card element ──────────────────
 


### PR DESCRIPTION
## Why

Player feedback surfaced four friction points on the seed-capture experience:

1. Chinese sigils (火 水 木 金 土) appeared with no English translation.
2. Users didn't understand **how to capture a seed**.
3. The text feature was confusing, and its pre-filled example prompt "isn't what people want to do."
4. There was no explanation of how the **elements map to emotions**, and no end-to-end demo.

While addressing these, an audit against the uploaded redesign handoff confirmed most of the capture→build→display loop is **already implemented** — so this is a gap-closing + fidelity pass, not a rebuild. (The "Open Up" 5th move the handoff calls for already exists in the repo and is untouched.)

## What changed

### Phase 1 — the four feedback gaps
- **English (+ emotion) on every sigil.** Added `label` and `emotion` to `ELEMENT_TOKENS` as the single source of truth, plus an `elementLabel()` helper. Every render site now pairs the sigil with its English name and emotion (e.g. `火 Fire · Anger`): the capture rail + text-editor swatches, the Tune screen, Move Generator, card faces, canvas preview, CYOA intake, and the handbook 護/種 seal glyphs (accessible glosses).
- **Fixed the confusing default text.** The canvas no longer opens with the canned `"I went quiet in the meeting again."` — it starts with an empty placeholder sticker inviting the user's own words ("What's charged for you right now? Tap to write…"), and a placeholder-only board can't be captured as a blank seed.
- **Element↔emotion field guide.** New shared `ElementEmotionLegend` (element · emotion · lesson) surfaced from a "?" on the canvas, from the Tune screen's "how they channel emotion →" link, and on the wiki alchemy page.
- **First-run capture walkthrough.** New `CaptureWalkthrough` coach-marks (write → attune → charge → capture → "it lands in your Hand"), localStorage-gated and replayable, with an embed slot for a real walkthrough video later.

### Phase 2 — per-screen fidelity polish (against the handoff prototypes)
Every screen was already high-fidelity; only the meaningful, correct deltas were applied:
- **Seed Capture Whiteboard:** restored the vertical, left-pinned text-size slider (custom white thumb, 16–54 range); button glows now use the `--bars-liminal-glow` token.
- **CanvasPreview / BarCardFace / `/bars/[id]`:** single-line element name beside the sigil in the polaroid caption; "from the canvas" / "note" origin kicker; "intent · charge N · `<label>`" line under the canvas preview.
- **Move Generator:** board-help copy; "Learn alchemy" links to the field guide.
- **Now Home (CaptureBox):** "Keep →" → "Capture →"; thematic flash copy.
- **Unpacking Quiz:** restored the prototype's "reflection is optional" cue.

Deliberately **not** changed: mockup-only chrome (the fake "9:41" status time, the fixed phone-frame width), dev-scaffolding annotations the prototype shows (e.g. "→ emotionalAlchemyTag"), and a relabel that would misrepresent a button's actual behavior.

## Verification
- **ESLint: 0 errors** across all touched files (only pre-existing benign warnings).
- **Type-check:** clean for every changed file. The only `tsc` errors in this environment are the un-generated Prisma client (the engine binary download is blocked by the sandbox proxy) and a stale `design/` copy — neither from these changes. Recommend a clean CI run on a networked builder.
- Manual pass of `/bars/capture` recommended in a cleared browser profile to see the first-run walkthrough, empty placeholder, sigil+emotion labels, the field-guide modal, and capture→Hand.

## Out of scope / follow-ups
- Producing an actual tutorial video (embed slot is in place).
- The optional Stories composer / `captureDesign` migration (deferred Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk2W3KkfTpGHQYBUT68TAc)_