### PR TITLE
Unify the new-visitor journey: deck as engine, two-door homepage, one spine

### DIFF
--- a/src/app/awaken/AwakenFlow.tsx
+++ b/src/app/awaken/AwakenFlow.tsx
@@ -9,6 +9,7 @@ import {
   AWAKEN_NONPROFIT_HREF,
   AWAKEN_CHAPTER_FILE_HREF,
 } from '@/lib/awaken/content'
+import { NextMoveBlock } from '@/components/funnel/NextMoveBlock'
 
 type Status = 'idle' | 'loading' | 'done' | 'error'
 
@@ -137,6 +138,26 @@ function ShowUp({ onInView }: { onInView: () => void }) {
       </div>
 
       <SecondaryLinks />
+
+      <div className="mt-12 border-t border-zinc-900 pt-8">
+        <NextMoveBlock
+          heading="Or step into the game itself"
+          moves={[
+            {
+              href: '/deck/sales',
+              label: 'Discover the game',
+              sublabel: 'The 120-move Allyship Deck — see what it is.',
+              element: 'wood',
+            },
+            {
+              href: '/campaign/the-crossing',
+              label: 'Help right now · The Crossing',
+              sublabel: 'Pick a concrete move that fits what you can offer.',
+              element: 'earth',
+            },
+          ]}
+        />
+      </div>
     </section>
   )
 }
@@ -344,6 +365,15 @@ function SecondaryLinks() {
         Go deeper
       </p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/deck/preview"
+          className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 transition-colors hover:border-zinc-600"
+        >
+          <div className="font-bold text-white">See the 120 moves — free</div>
+          <div className="mt-1 text-xs text-zinc-400">
+            Browse the whole Allyship Deck, no account needed →
+          </div>
+        </Link>
         <Link
           href={AWAKEN_PRODUCTS_HREF}
           className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 transition-colors hover:border-zinc-600"

--- a/src/app/campaign/the-crossing/TheCrossingLanding.tsx
+++ b/src/app/campaign/the-crossing/TheCrossingLanding.tsx
@@ -12,6 +12,8 @@ import {
 } from '@/lib/the-crossing-support-moves'
 import { ELEMENT_TOKENS } from '@/lib/ui/card-tokens'
 import { DeckCardForRole } from '@/components/the-crossing/DeckCardForRole'
+import { DeckPurchaseCTA } from '@/components/launch/DeckPurchaseCTA'
+import { getMoveCardById } from '@/lib/allyship-deck/assemble'
 
 const PAGE_BG = 'radial-gradient(120% 50% at 50% -6%, #16121f 0%, #0a0908 46%)'
 const ACTION_PURPLE = '#7c3aed'
@@ -169,6 +171,11 @@ export function TheCrossingLanding() {
           </Link>
         </section>
 
+        {/* ── Buy the full deck ──────────────────────────────────────────── */}
+        <div className="mt-14">
+          <DeckPurchaseCTA blurb="Every path here is one move from the 120-move Allyship Deck. Get the whole deck and you carry a move for every moment — not just this campaign." />
+        </div>
+
         {/* ── /awaken cross-link (water) ─────────────────────────────────── */}
         <Link
           href="/awaken"
@@ -279,17 +286,20 @@ function RoleAccordion({
               </div>
             </dl>
 
-            {/* Deck-move chips */}
+            {/* Deck-move chips — real card titles, sourced from the canonical deck */}
             <div className="flex flex-wrap gap-2">
-              {role.starterCardIds.map((code) => (
-                <span
-                  key={code}
-                  className="rounded-md px-2 py-1 font-mono text-[10px] uppercase tracking-[0.1em]"
-                  style={{ background: `${tokens.gem}14`, color: tokens.gem }}
-                >
-                  {code}
-                </span>
-              ))}
+              {role.starterCardIds.map((code) => {
+                const card = getMoveCardById(code)
+                return (
+                  <span
+                    key={code}
+                    className="rounded-md px-2 py-1 text-[11px] font-medium"
+                    style={{ background: `${tokens.gem}14`, color: tokens.gem }}
+                  >
+                    {card?.title ?? code}
+                  </span>
+                )
+              })}
             </div>
 
             {/* Embedded starter deck card */}

--- a/src/app/campaign/the-crossing/TheCrossingLanding.tsx
+++ b/src/app/campaign/the-crossing/TheCrossingLanding.tsx
@@ -338,7 +338,7 @@ function RoleAccordion({
               className="inline-flex text-xs font-semibold"
               style={{ color: ACTION_PURPLE_LITE }}
             >
-              Save this as a BAR →
+              Save this move →
             </Link>
           </div>
         </div>

--- a/src/app/campaign/the-crossing/move/[roleId]/CaptureForm.tsx
+++ b/src/app/campaign/the-crossing/move/[roleId]/CaptureForm.tsx
@@ -144,7 +144,7 @@ export function CaptureForm({
       <p className="text-[11px] text-[#6b6965]">
         Goes to{' '}
         <span className="text-[#a09e98]">Wendell’s board</span> as a {domainLabel(role.primaryDomain)}{' '}
-        BAR. He follows up through the contact you leave — no account needed.
+        move. He follows up through the contact you leave — no account needed.
       </p>
 
       {/* Sticky submit */}

--- a/src/app/campaign/the-crossing/move/[roleId]/page.tsx
+++ b/src/app/campaign/the-crossing/move/[roleId]/page.tsx
@@ -53,7 +53,7 @@ export default async function TheCrossingMovePage(props: {
           </p>
           <h1 className="text-[34px] font-bold leading-[1.05] tracking-[-0.02em]">{role.label}</h1>
           <p className="text-[14px] leading-relaxed text-[#cfcdc6]">
-            This becomes a BAR on Wendell’s board. He’ll follow up through the contact you leave — no
+            This goes straight to Wendell’s board. He’ll follow up through the contact you leave — no
             account needed.
           </p>
         </header>

--- a/src/app/campaign/the-crossing/move/[roleId]/saved/page.tsx
+++ b/src/app/campaign/the-crossing/move/[roleId]/saved/page.tsx
@@ -13,7 +13,7 @@ const PAGE_BG = 'radial-gradient(120% 50% at 50% -6%, #16121f 0%, #0a0908 46%)'
 const ACTION_PURPLE = '#7c3aed'
 const ACTION_PURPLE_LITE = '#8b5cf6'
 
-export const metadata: Metadata = { title: 'Saved as a BAR | The Crossing' }
+export const metadata: Metadata = { title: 'Move saved | The Crossing' }
 
 export default async function TheCrossingSavedPage(props: {
   params: Promise<{ roleId: string }>
@@ -58,7 +58,7 @@ export default async function TheCrossingSavedPage(props: {
         </div>
 
         <h1 className="text-[28px] font-bold leading-tight tracking-[-0.02em]">
-          Your move is saved as a BAR.
+          Your move is saved.
         </h1>
 
         {/* Mini BAR card */}
@@ -78,7 +78,7 @@ export default async function TheCrossingSavedPage(props: {
               className="rounded-full px-2 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.12em]"
               style={{ background: 'rgba(212,160,23,.16)', color: '#e0a93b' }}
             >
-              New BAR
+              New move
             </span>
           </div>
           <p className="mt-3 text-[15px] font-semibold leading-snug text-[#f4f2ec]">{summary}</p>

--- a/src/app/campaign/the-crossing/role/[roleId]/page.tsx
+++ b/src/app/campaign/the-crossing/role/[roleId]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/the-crossing-support-moves'
 import { ELEMENT_TOKENS } from '@/lib/ui/card-tokens'
 import { DeckCardForRole } from '@/components/the-crossing/DeckCardForRole'
+import { DeckPurchaseCTA } from '@/components/launch/DeckPurchaseCTA'
 
 const PAGE_BG = 'radial-gradient(120% 50% at 50% -6%, #16121f 0%, #0a0908 46%)'
 const ACTION_PURPLE = '#7c3aed'
@@ -150,6 +151,12 @@ export default async function TheCrossingRolePage(props: {
           </div>
         </section>
 
+        {/* Buy the full deck — these two moves are a taste of all 120 */}
+        <DeckPurchaseCTA
+          element={role.element}
+          blurb="These two moves are from the 120-move Allyship Deck — the consultable heart of the whole game. Get the deck and you have a move for every moment."
+        />
+
         {/* Account upsell (purple — action/account channel) */}
         <section
           className="rounded-2xl border p-5"
@@ -157,8 +164,9 @@ export default async function TheCrossingRolePage(props: {
         >
           <p className="text-sm font-semibold text-white">Save this contribution</p>
           <p className="mt-1 text-[13px] leading-relaxed text-[#cfcdc6]">
-            Create your BARS Engine account to track what happens to your move — or just make it now,
-            no account needed.
+            This is the whole game in miniature: care becomes a move, a move becomes evidence you can
+            follow. Create your BARS Engine account to track what happens to your move — or just make
+            it now, no account needed.
           </p>
           <Link
             href={`/login?returnTo=${encodeURIComponent(moveHref)}`}

--- a/src/app/campaign/the-crossing/role/[roleId]/page.tsx
+++ b/src/app/campaign/the-crossing/role/[roleId]/page.tsx
@@ -111,7 +111,7 @@ export default async function TheCrossingRolePage(props: {
               href={moveHref}
               className="flex-1 rounded-[11px] border border-white/15 px-4 py-3 text-center text-sm font-semibold text-[#cfcdc6] transition-colors hover:text-white"
             >
-              Save this as a BAR →
+              Save this move →
             </Link>
           </div>
         </section>

--- a/src/app/deck/preview/page.tsx
+++ b/src/app/deck/preview/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
 import { DeckPreviewGallery } from '@/components/deck/DeckPreviewGallery'
+import { DeckPurchaseCTA } from '@/components/launch/DeckPurchaseCTA'
 
 export const metadata: Metadata = {
   title: 'The Allyship Deck — Card Gallery (Preview)',
@@ -24,6 +25,12 @@ export default function DeckPreviewPage() {
   return (
     <main style={{ minHeight: '100vh', background: SURFACE_TOKENS.bgBase }}>
       <DeckPreviewGallery />
+      <div className="mx-auto w-full max-w-[680px] px-5 py-10 sm:px-8">
+        <DeckPurchaseCTA
+          variant="card"
+          blurb="You just browsed all 120 cards. Get the full deck to draw, track, and turn any move into real action — for yourself or a campaign."
+        />
+      </div>
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,6 @@ export default async function Home(props: { searchParams: Promise<{ ritualComple
 
   // ── Unauthenticated landing ───────────────────────────────────────────────
   if (!playerId) {
-    const venmoUrl = 'https://venmo.com/u/Wendell-Britt'
     return (
       <div className="flex min-h-screen w-full items-center justify-center bg-black text-white font-mono flex-col gap-8 p-8">
         <div className="text-center space-y-4 max-w-2xl">
@@ -57,39 +56,64 @@ export default async function Home(props: { searchParams: Promise<{ ritualComple
             Mastering the Game of Allyship
           </h1>
           <p className="text-zinc-400 text-base sm:text-lg">
-            Allyship is hard, lonely work that rarely comes with a map. This turns it into a game you
-            can actually play — a book, a deck, and a living practice for showing up, together.
+            Allyship is hard, lonely work that rarely comes with a map. A book, a 120-move deck, and a
+            living practice that turn showing up — together — into a game you can actually play.
           </p>
+          <p className="text-zinc-500 text-sm">Two ways in. Pick the one that fits you right now.</p>
         </div>
 
-        {/* ── Priority: The Crossing car fundraiser ─────────────────────────── */}
-        <div className="w-full max-w-md rounded-2xl border border-amber-500/40 bg-gradient-to-b from-amber-950/40 to-zinc-950 p-6 shadow-lg shadow-amber-900/20">
-          <div className="text-[10px] uppercase tracking-widest text-amber-400/80 mb-2">
-            Help me get a car · The Crossing
+        {/* ── Two clear doors ───────────────────────────────────────────────── */}
+        <div className="grid w-full max-w-2xl gap-4 sm:grid-cols-2">
+          {/* Door A — Discover the game */}
+          <div className="flex flex-col rounded-2xl border border-emerald-600/40 bg-gradient-to-b from-emerald-950/40 to-zinc-950 p-6">
+            <div className="text-[10px] uppercase tracking-widest text-emerald-400/80 mb-2">
+              Curious? Start here
+            </div>
+            <h2 className="text-xl font-bold text-white leading-snug">Discover the game</h2>
+            <p className="mt-2 flex-1 text-sm text-zinc-300 leading-relaxed">
+              See what the deck and the game actually are — 120 allyship moves you can draw, play, and
+              turn into real action. Most of it is free, no account needed.
+            </p>
+            <div className="mt-5 flex flex-col gap-2">
+              <Link
+                href="/deck/sales"
+                className="w-full py-3 px-6 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 text-white font-bold rounded-lg text-center transition-all shadow-lg shadow-green-900/30"
+              >
+                Explore the deck &amp; game →
+              </Link>
+              <Link
+                href="/deck/preview"
+                className="w-full py-2 px-4 text-emerald-200/90 hover:text-white font-semibold rounded-lg text-center transition-all text-xs"
+              >
+                Browse all 120 cards free →
+              </Link>
+            </div>
           </div>
-          <h2 className="text-xl font-bold text-white leading-snug">
-            The car died. The work didn&apos;t.
-          </h2>
-          <p className="mt-2 text-sm text-zinc-300 leading-relaxed">
-            A reliable car is the next practical bridge — getting me back on the road while the
-            Mastering the Game of Allyship launch keeps moving. Money helps, and so do car leads,
-            intros, and signal boosts.
-          </p>
-          <div className="mt-5 flex flex-col gap-3">
-            <a
-              href={venmoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-full py-3 px-6 bg-gradient-to-r from-amber-500 to-yellow-500 hover:from-amber-400 hover:to-yellow-400 text-black font-bold rounded-lg text-center transition-all shadow-lg shadow-amber-900/30"
-            >
-              Donate now via Venmo
-            </a>
-            <Link
-              href="/campaign/the-crossing"
-              className="w-full py-3 px-6 bg-zinc-900 border border-amber-600/50 hover:border-amber-500 hover:bg-zinc-800 text-amber-100 font-bold rounded-lg text-center transition-all text-sm"
-            >
-              See the campaign &amp; other ways to help →
-            </Link>
+
+          {/* Door B — Help right now (The Crossing) */}
+          <div className="flex flex-col rounded-2xl border border-amber-500/40 bg-gradient-to-b from-amber-950/40 to-zinc-950 p-6">
+            <div className="text-[10px] uppercase tracking-widest text-amber-400/80 mb-2">
+              Ready to help · The Crossing
+            </div>
+            <h2 className="text-xl font-bold text-white leading-snug">Help right now</h2>
+            <p className="mt-2 flex-1 text-sm text-zinc-300 leading-relaxed">
+              The work is in motion and needs a reliable car to keep moving. Money helps — and so do
+              car leads, intros, and signal boosts. Pick the move that fits what you can offer.
+            </p>
+            <div className="mt-5 flex flex-col gap-2">
+              <Link
+                href="/campaign/the-crossing"
+                className="w-full py-3 px-6 bg-gradient-to-r from-amber-500 to-yellow-500 hover:from-amber-400 hover:to-yellow-400 text-black font-bold rounded-lg text-center transition-all shadow-lg shadow-amber-900/30"
+              >
+                Find your move →
+              </Link>
+              <Link
+                href="/awaken"
+                className="w-full py-2 px-4 text-amber-100/90 hover:text-white font-semibold rounded-lg text-center transition-all text-xs"
+              >
+                Or join the July 17–19 launch weekend →
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -120,33 +144,18 @@ export default async function Home(props: { searchParams: Promise<{ ritualComple
           </Link>
         )}
 
-        {/* ── Explore the work ──────────────────────────────────────────────── */}
-        <div className="flex flex-col gap-4 w-full max-w-xs">
-          <Link
-            href="/launch"
-            className="w-full py-3 px-6 bg-zinc-900 border border-zinc-700 hover:border-zinc-500 hover:bg-zinc-800 text-zinc-200 font-bold rounded-lg text-center transition-all"
-          >
-            Explore the book &amp; deck
+        {/* ── Secondary row ─────────────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm">
+          <Link href="/launch" className="text-zinc-300 hover:text-white font-semibold transition-colors">
+            See all the ways to support →
           </Link>
-
-          <Link
-            href="/awaken"
-            className="w-full py-3 px-6 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 text-white font-bold rounded-lg text-center transition-all shadow-lg shadow-green-900/30"
-          >
-            Start here — wake up &amp; show up
-          </Link>
-
-          <Link
-            href="/login"
-            className="w-full py-3 px-4 bg-zinc-900 border border-zinc-700 hover:border-zinc-500 hover:bg-zinc-800 text-zinc-200 font-bold rounded-lg text-center transition-all text-sm"
-          >
-            Log In
+          <Link href="/login" className="text-zinc-400 hover:text-white font-semibold transition-colors">
+            Log in
           </Link>
         </div>
 
-        <div className="text-xs text-zinc-600 mt-4 text-center max-w-md">
-          New here? Start with the book and deck — most of it is free, no account needed. Existing
-          players can log in to continue.
+        <div className="text-xs text-zinc-600 mt-2 text-center max-w-md">
+          New here? Most of it is free, no account needed. Existing players can log in to continue.
         </div>
       </div>
     )

--- a/src/components/funnel/NextMoveBlock.tsx
+++ b/src/components/funnel/NextMoveBlock.tsx
@@ -1,0 +1,70 @@
+/**
+ * NextMoveBlock — a small "pick your next move" footer that keeps the three
+ * new-visitor funnels (deck ↔ roles ↔ awaken ↔ launch) connected so no page
+ * dead-ends. Each row is element-tinted and answers "what do I do next, and why".
+ *
+ * Server component (plain Link). UI_COVENANT: color via card-tokens, layout via Tailwind.
+ */
+
+import Link from 'next/link'
+import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+
+export type NextMove = {
+  href: string
+  label: string
+  sublabel: string
+  element?: ElementKey
+}
+
+export function NextMoveBlock({
+  heading = 'Your next move',
+  moves,
+}: {
+  heading?: string
+  moves: NextMove[]
+}) {
+  return (
+    <section className="space-y-3">
+      <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#6b6965]">{heading}</p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {moves.map((move) => {
+          const tokens = ELEMENT_TOKENS[move.element ?? 'earth']
+          const external = move.href.startsWith('http')
+          const inner = (
+            <>
+              <span aria-hidden className="text-[18px] leading-none" style={{ color: tokens.gem }}>
+                {tokens.sigil}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[14px] font-semibold text-[#f4f2ec]">{move.label}</span>
+                <span className="block text-[12px] leading-snug text-[#a09e98]">{move.sublabel}</span>
+              </span>
+              <span className="flex-none text-sm" style={{ color: tokens.gem }}>
+                →
+              </span>
+            </>
+          )
+          const className =
+            'flex items-center gap-3 rounded-2xl border p-4 transition-colors hover:border-white/25'
+          const style = { borderColor: tokens.frame, background: '#121210' }
+          return external ? (
+            <a
+              key={move.href}
+              href={move.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={className}
+              style={style}
+            >
+              {inner}
+            </a>
+          ) : (
+            <Link key={move.href} href={move.href} className={className} style={style}>
+              {inner}
+            </Link>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/launch/DeckPurchaseCTA.tsx
+++ b/src/components/launch/DeckPurchaseCTA.tsx
@@ -1,0 +1,71 @@
+/**
+ * DeckPurchaseCTA — the single canonical "get the full deck" block.
+ *
+ * Reuses the launch offer registry (src/lib/launch/offers.ts) so the SKU, price,
+ * and destination are never re-invented: `offerByKey('deck-digital')` for name +
+ * price, `offerHref('deck-digital')` for the link (live Gumroad URL when wired,
+ * else the honest `/launch#deck-digital` fallback — never a dead link).
+ *
+ * Server component (plain Link). UI_COVENANT: color via card-tokens, layout via Tailwind.
+ */
+
+import Link from 'next/link'
+import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { offerByKey, offerHref, formatPrice } from '@/lib/launch/offers'
+
+export function DeckPurchaseCTA({
+  element = 'earth',
+  variant = 'inline',
+  /** Override the lead-in line; defaults to the role-page framing. */
+  blurb = 'Every role here is one move from the 120-move Allyship Deck.',
+}: {
+  element?: ElementKey
+  variant?: 'inline' | 'card'
+  blurb?: string
+}) {
+  const tokens = ELEMENT_TOKENS[element]
+  const deck = offerByKey('deck-digital')
+  const price = deck ? formatPrice(deck.priceCents) : '$10'
+  const href = offerHref('deck-digital')
+
+  return (
+    <section
+      className={`rounded-2xl border p-5 ${variant === 'card' ? 'text-center' : ''}`}
+      style={{
+        borderColor: tokens.frame,
+        background: `radial-gradient(135% 130% at 90% -14%, ${tokens.gradFrom}, ${tokens.gradTo} 72%)`,
+      }}
+    >
+      <p
+        className="font-mono text-[10px] uppercase tracking-[0.16em]"
+        style={{ color: tokens.gem }}
+      >
+        The Allyship Deck
+      </p>
+      <p className="mt-2 text-[15px] leading-snug text-[#e8e6e0]">{blurb}</p>
+      <div
+        className={`mt-4 flex flex-col gap-2 sm:flex-row ${variant === 'card' ? 'sm:justify-center' : ''}`}
+      >
+        <Link
+          href={href}
+          className="rounded-[11px] px-5 py-3 text-center text-sm font-semibold text-white transition-transform active:scale-[0.97]"
+          style={{ background: `linear-gradient(135deg, ${tokens.glow}, ${tokens.frame})` }}
+        >
+          Get the full deck — {price} →
+        </Link>
+        <Link
+          href="/deck/sales"
+          className="rounded-[11px] border border-white/15 px-5 py-3 text-center text-sm font-semibold text-[#cfcdc6] transition-colors hover:text-white"
+        >
+          See what&apos;s inside
+        </Link>
+      </div>
+      <Link
+        href={offerHref('founding-ally')}
+        className="mt-3 inline-flex text-[12px] font-semibold text-[#a09e98] transition-colors hover:text-white"
+      >
+        Or go all-in — become a Founding Ally →
+      </Link>
+    </section>
+  )
+}

--- a/src/components/the-crossing/DeckCardForRole.tsx
+++ b/src/components/the-crossing/DeckCardForRole.tsx
@@ -2,77 +2,22 @@
  * DeckCardForRole — renders one Allyship Deck starter move for a Crossing role,
  * built on the real CultivationCard primitive (not the prototype's AllyshipCard).
  *
- * A move code is `MOVE-DOMAIN-FACE` (e.g. `WAKE-GR-DIPLOMAT`). We parse it for
- * the move / domain / face labels and a contemplative question, tint the card to
- * the role's element (element tint follows the role everywhere it appears), and
- * show a signed-out "Sign in to claim" action bar on public pages.
+ * A move code is the canonical card id (`MOVE-DOMAIN-FACE`, e.g. `WAKE-GR-DIPLOMAT`).
+ * We read the real card from the canonical deck library — title, question, and the
+ * practice all come from `move-library.ts` via `getMoveCardById`, so this surface can
+ * never drift from the deck. We tint to the role's element (element tint follows the
+ * role everywhere it appears) and show a signed-out "Sign in to claim" action bar on
+ * public pages.
  *
- * No deck-move registry is required: labels + question derive from the code.
  * UI_COVENANT: color via card-tokens; layout via Tailwind.
  */
 
 import Link from 'next/link'
 import { CultivationCard } from '@/components/ui/CultivationCard'
 import { ELEMENT_TOKENS, type ElementKey } from '@/lib/ui/card-tokens'
+import { getMoveCardById } from '@/lib/allyship-deck/assemble'
+import { MOVE_LABELS, OPERATION_LABELS, DOMAIN_LABELS } from '@/lib/allyship-deck/card-visuals'
 import type { TheCrossingSupportRole } from '@/lib/the-crossing-support-moves'
-
-const MOVE_LABELS: Record<string, string> = {
-  WAKE: 'Wake Up',
-  OPEN: 'Open Up',
-  CLEAN: 'Clean Up',
-  GROW: 'Grow Up',
-  SHOW: 'Show Up',
-}
-
-const DOMAIN_LABELS: Record<string, string> = {
-  GR: 'Gather Resources',
-  SO: 'Skillful Organizing',
-  RA: 'Raise Awareness',
-  DA: 'Direct Action',
-}
-
-const FACE_LABELS: Record<string, string> = {
-  ARCHITECT: 'Architect',
-  DIPLOMAT: 'Diplomat',
-  REGENT: 'Regent',
-  CHALLENGER: 'Challenger',
-  SAGE: 'Sage',
-  SHAMAN: 'Shaman',
-}
-
-const QUESTION_BY_MOVE: Record<string, string> = {
-  WAKE: 'What is here that you have not let yourself see yet?',
-  OPEN: 'What becomes possible if you receive instead of grip?',
-  CLEAN: 'What charge is asking to be metabolized before you move?',
-  GROW: 'Which capacity wants to stretch one notch further?',
-  SHOW: 'What is the smallest move that makes this real?',
-}
-
-export type ParsedDeckCode = {
-  code: string
-  move: string
-  moveLabel: string
-  domain: string
-  domainLabel: string
-  face: string
-  faceLabel: string
-  question: string
-}
-
-/** Parse a `MOVE-DOMAIN-FACE` deck code into display parts. */
-export function parseDeckCode(code: string): ParsedDeckCode {
-  const [move = '', domain = '', face = ''] = code.toUpperCase().split('-')
-  return {
-    code,
-    move,
-    moveLabel: MOVE_LABELS[move] ?? move,
-    domain,
-    domainLabel: DOMAIN_LABELS[domain] ?? domain,
-    face,
-    faceLabel: FACE_LABELS[face] ?? face,
-    question: QUESTION_BY_MOVE[move] ?? 'What wants to happen next?',
-  }
-}
 
 export function DeckCardForRole({
   code,
@@ -86,8 +31,18 @@ export function DeckCardForRole({
   /** Render the signed-out claim bar (public deck preview). */
   showActionBar?: boolean
 }) {
-  const parsed = parseDeckCode(code)
   const tokens = ELEMENT_TOKENS[element]
+  const card = getMoveCardById(code)
+
+  // Canonical card data when resolvable; graceful degrade so a bad id never
+  // crashes a statically-generated role page.
+  const moveFace = card
+    ? `${MOVE_LABELS[card.move]} · ${OPERATION_LABELS[card.operation]}`
+    : code
+  const title = card?.title ?? code
+  const question = card?.primaryQuestion ?? 'What is the smallest move that makes this real?'
+  const practice = card?.remediation ?? card?.optimizesFor ?? null
+  const domainText = card ? DOMAIN_LABELS[card.domain] : ''
 
   return (
     <CultivationCard
@@ -95,7 +50,7 @@ export function DeckCardForRole({
       altitude="neutral"
       stage="growing"
       className="rounded-2xl p-4"
-      aria-label={`${parsed.moveLabel} · ${parsed.faceLabel} — ${role.label} starter card`}
+      aria-label={`${moveFace} — ${role.label} starter card`}
     >
       {/* Move + face row */}
       <div className="flex items-center justify-between gap-2">
@@ -103,20 +58,30 @@ export function DeckCardForRole({
           className="font-mono text-[10px] uppercase tracking-[0.14em]"
           style={{ color: tokens.gem }}
         >
-          {parsed.moveLabel} · {parsed.faceLabel}
+          {moveFace}
         </span>
         <span aria-hidden className="text-base leading-none" style={{ color: tokens.gem }}>
           {tokens.sigil}
         </span>
       </div>
 
-      {/* Title = the code */}
+      {/* Title = the real card title */}
       <h4 className="mt-2 font-semibold tracking-tight text-[var(--cs-card-title,#f4f2ec)]">
-        {parsed.code}
+        {title}
       </h4>
 
       {/* Contemplative question */}
-      <p className="mt-1 text-[13px] italic leading-snug text-[#cfcdc6]">{parsed.question}</p>
+      <p className="mt-1 text-[13px] italic leading-snug text-[#cfcdc6]">{question}</p>
+
+      {/* The practice the card asks of you */}
+      {practice ? (
+        <p className="mt-2 text-[12px] leading-snug text-[#a09e98]">
+          <span className="font-mono text-[9px] uppercase tracking-[0.16em]" style={{ color: tokens.gem }}>
+            Practice ·{' '}
+          </span>
+          {practice}
+        </p>
+      ) : null}
 
       {/* Modifier box: the role's contribution + the artifact it makes */}
       <div
@@ -132,9 +97,9 @@ export function DeckCardForRole({
         <p className="mt-0.5 text-[11px] text-[#a09e98]">Make: {role.artifact}</p>
       </div>
 
-      {/* Footer: domain · collector number placeholder */}
+      {/* Footer: domain · collector mark */}
       <div className="mt-3 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.12em] text-[#6b6965]">
-        <span>{parsed.domainLabel}</span>
+        <span>{domainText}</span>
         <span aria-hidden style={{ color: tokens.gem }}>
           ♦
         </span>

--- a/src/lib/allyship-deck/assemble.ts
+++ b/src/lib/allyship-deck/assemble.ts
@@ -138,3 +138,28 @@ export function assembleDeck(generatedAt = new Date().toISOString()): AllyshipDe
 
 /** Capabilities available (for UI). */
 export const CAPABILITY_KEYS: Capability[] = CAPABILITIES.map((c) => c.capability)
+
+// ── Canonical card lookup ───────────────────────────────────────────────────
+// Single source of truth for callers that need one card by id (role pages, the
+// Crossing deck cards). Lives here — not in deck-bar.ts — because this module is
+// client-safe (no next/headers, db, or fs), so client components can import it.
+
+let _cardIndex: Map<string, AllyshipCard> | null = null
+
+function cardIndex(): Map<string, AllyshipCard> {
+  if (!_cardIndex) {
+    _cardIndex = new Map(assembleDeck().cards.map((c) => [c.id, c]))
+  }
+  return _cardIndex
+}
+
+/** Look up any card (move or instruction) by its canonical id, e.g. "OPEN-GR-SHAMAN". */
+export function getCardById(id: string): AllyshipCard | undefined {
+  return cardIndex().get(id)
+}
+
+/** Look up a move card by id, narrowing out instruction cards. */
+export function getMoveCardById(id: string): MoveCard | undefined {
+  const card = cardIndex().get(id)
+  return card?.kind === 'move' ? card : undefined
+}

--- a/src/lib/launch/offers.ts
+++ b/src/lib/launch/offers.ts
@@ -162,7 +162,7 @@ const CORE_LAUNCH_OFFERS: readonly LaunchOffer[] = [
   {
     key: 'deck-digital',
     name: 'Oracle Deck — Digital Access',
-    blurb: 'The 52-card Oracle at the Edge of the Known World. (Also included with The Game.)',
+    blurb: 'The 120-move Oracle at the Edge of the Known World. (Also included with The Game.)',
     group: 'digital',
     priceCents: 1000,
     gumroadUrl: GUMROAD.deckDigital,


### PR DESCRIPTION
## Why

A cold visitor arriving from social media hit **three disconnected funnels** with inconsistent language, and had to guess their next move and why:

1. **The Crossing** — a personal car-fund fundraiser that *dominated the homepage hero*, plus a no-account "roles" contribution flow.
2. **Awaken** — donate / free-chapter email capture / event RSVP that **never created an account and dead-ended**.
3. **Deck + commerce** — the actual product/game, gated behind a paywall + jargon. The free 120-card preview had **no purchase CTA**; the buy path was buried at `/launch`.

The Allyship Deck is the engine of the whole thing, yet it was the most buried — its purchase path never appeared on role pages or the free preview, and role pages rendered raw codes like `WAKE-SO-ARCHITECT` from hardcoded tables that silently drift from the canonical deck.

**Goal:** one coherent spine — *Discover → understand why → pick your next move* — so a new visitor moves from curious/confused → excited and ready to donate time or money.

## What changed

**Homepage → two clear doors** (`src/app/page.tsx`)
The personal fundraiser no longer hijacks the hero. The visitor self-selects: **Discover the game** (deck sales + "browse all 120 cards free") vs **Help right now · The Crossing**. The deck and its purchase path now sit at the top of the funnel.

**Deck as single source of truth** (`src/lib/allyship-deck/assemble.ts`, `src/components/the-crossing/DeckCardForRole.tsx`)
Added client-safe `getCardById` / `getMoveCardById`. `DeckCardForRole` now renders the **real** card title, question, and practice from the canonical library, and the duplicated label/question lookup tables (which had to be hand-synced) are deleted.

**Surface buy-the-full-deck** (new `src/components/launch/DeckPurchaseCTA.tsx`)
One canonical CTA reusing the launch offers registry (`deck-digital` $10, `founding-ally`) — now on role pages, the Crossing landing, and the free `/deck/preview` gallery (which previously had no way to buy).

**Connect the funnels** (new `src/components/funnel/NextMoveBlock.tsx`)
`/awaken` no longer dead-ends — it links into the deck and roles, and the free deck preview is added to its "go deeper" links. Raw deck codes on the landing are replaced with real card titles.

**Copy fixes**
- `offers.ts`: `deck-digital` blurb said "52-card" but the deck is 120 moves — corrected.
- Softened "BAR" jargon on the no-account Crossing surfaces (role page, landing, capture form/page, saved confirmation) to plain language: "Save this move", "your move is saved", "New move".

## Verification

- ESLint: **0 errors** on all touched files.
- `tsc`: **0 errors in touched files** (the project-wide errors are an environment-only missing-Prisma-client cascade).
- ⚠️ Full `npm run build` / `npm run check` could **not** be run green in the remote environment because the egress policy blocks Prisma's engine-binary download. Changes are isolated and don't touch Prisma — **please run `npm run check && npm run build` locally before merge** to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AskuV8nvDAbUhTge6diwM8)_