### PR TITLE
feat(deck): Allyship Deck Literacy — "Your move", real-life applications, orientation

### DIFF
--- a/.specify/specs/allyship-deck-literacy/tasks.md
+++ b/.specify/specs/allyship-deck-literacy/tasks.md
@@ -15,11 +15,11 @@
 - [x] **T2.5** Gate: `npm run deck:assemble` → committed JSON → eslint clean + tsc baseline + node tests pass (full build/check runs in CI — Prisma engine blocked offline).
 
 ## Phase 3 — Applications (authored baseline)
-- [ ] **T3.1** `types.ts`: add `applications?: { context: string; example: string }[]`.
-- [ ] **T3.2** `move-library.ts`: add `applications` to selected `AUTHORED` entries (`OPEN-GR-*`, `WAKE-GR-*` first).
-- [ ] **T3.3** New `src/components/deck/CardApplications.tsx`: collapsible + deterministic fallback.
-- [ ] **T3.4** `AllyshipCard.tsx`: render `<CardApplications card subject />` in full view.
-- [ ] **T3.5** Gate: `npm run deck:assemble` → **commit JSON** → build → check.
+- [x] **T3.1** `types.ts`: add `applications?: { context: string; example: string }[]`.
+- [x] **T3.2** `move-library.ts`: added `applications` to 4 authored entries (`OPEN-GR-SHAMAN`, `OPEN-GR-CHALLENGER`, `WAKE-GR-SHAMAN`, `SHOW-RA-CHALLENGER`); more to follow.
+- [x] **T3.3** New `src/components/deck/CardApplications.tsx`: collapsible "How this shows up in real life" + deterministic fallback (domain framing + other reading).
+- [x] **T3.4** `AllyshipCard.tsx`: render `<CardApplications card subject />` in full view (after flavor).
+- [x] **T3.5** Gate: `npm run deck:assemble` → committed JSON (4 cards carry applications) → eslint clean + tsc baseline + node tests pass.
 
 ## Phase 4 — Applications (optional AI)
 - [ ] **T4.1** New `src/actions/deck-applications.ts`: `applyCardToSituation` (cached, flagged, degrades).

--- a/.specify/specs/allyship-deck-literacy/tasks.md
+++ b/.specify/specs/allyship-deck-literacy/tasks.md
@@ -28,9 +28,9 @@
 - [ ] **T4.4** Gate: build → check.
 
 ## Phase 5 — Orientation
-- [ ] **T5.1** New `src/components/deck/DeckOrientation.tsx`: four-use modal routing via `switchView`.
-- [ ] **T5.2** `AllyshipDeckReader.tsx`: open once via `deck-orientation-seen`; top-bar "How to use" re-open button.
-- [ ] **T5.3** Gate: build → check.
+- [x] **T5.1** New `src/components/deck/DeckOrientation.tsx`: four-use modal (daily / situation / browse / collection) routing via `switchView`.
+- [x] **T5.2** `AllyshipDeckReader.tsx`: open once via `deck-orientation-seen` (post-mount effect); top-bar "?" re-open button.
+- [x] **T5.3** Gate: eslint clean + tsc baseline (build/check in CI). _(No `deck:assemble` — no data change.)_
 
 ## Cross-cutting
 - [ ] **TX.1** `scripts/seed-cert-allyship-deck-literacy.ts` + `npm run seed:cert:allyship-deck-literacy` (grow one step per phase).

--- a/.specify/specs/allyship-deck-literacy/tasks.md
+++ b/.specify/specs/allyship-deck-literacy/tasks.md
@@ -8,11 +8,11 @@
 - [x] **T1.5** Gate: `npm run build` + `npm run check` (lint + tsc verified for P1 files in offline env).
 
 ## Phase 2 — "Your move" surfacing
-- [ ] **T2.1** `types.ts`: add `action?: string` to `MoveCard`.
-- [ ] **T2.2** `assemble.ts`: set `action: sub.action` in `buildMoveCards()` generated object.
-- [ ] **T2.3** `AllyshipCard.tsx`: distinct "Your move · Do this" element (full view).
-- [ ] **T2.4** `seed.ts`: fold `card.action` into BAR description (guarded), both branches; update seed tests.
-- [ ] **T2.5** Gate: `npm run deck:assemble` → **commit `public/allyship-deck/allyship-deck.json`** → build → check.
+- [x] **T2.1** `types.ts`: add `action?: string` to `MoveCard`.
+- [x] **T2.2** `assemble.ts`: set `action: sub.action` in `buildMoveCards()` generated object.
+- [x] **T2.3** `AllyshipCard.tsx`: distinct "Your move" inset (full view).
+- [x] **T2.4** `seed.ts`: lead BAR description with `card.action` (guarded), both branches; updated seed.test.ts (translate.test.ts fixture has no action — unaffected).
+- [x] **T2.5** Gate: `npm run deck:assemble` → committed JSON → eslint clean + tsc baseline + node tests pass (full build/check runs in CI — Prisma engine blocked offline).
 
 ## Phase 3 — Applications (authored baseline)
 - [ ] **T3.1** `types.ts`: add `applications?: { context: string; example: string }[]`.

--- a/public/allyship-deck/allyship-deck.json
+++ b/public/allyship-deck/allyship-deck.json
@@ -158,7 +158,17 @@
         "rest"
       ],
       "status": "authored",
-      "flavor": "Not every empty cup is the same cup."
+      "flavor": "Not every empty cup is the same cup.",
+      "applications": [
+        {
+          "context": "Burnout",
+          "example": "You feel \"broke,\" but a closer look shows the real scarcity is time and rest, not money. Name the one resource that would change everything."
+        },
+        {
+          "context": "An organization",
+          "example": "A team says it needs funding; on inspection it needs decisions. Distinguish what is depleted from what only feels depleted."
+        }
+      ]
     },
     {
       "id": "WAKE-GR-CHALLENGER",
@@ -893,7 +903,21 @@
         "rest"
       ],
       "status": "authored",
-      "flavor": "The child holding the empty cup is not a problem to solve yet. First, let yourself see the cup."
+      "flavor": "The child holding the empty cup is not a problem to solve yet. First, let yourself see the cup.",
+      "applications": [
+        {
+          "context": "Money",
+          "example": "Before drafting a fundraiser, sit with what the shortfall actually feels like — fear, shame, grief — and name it out loud before you name a number."
+        },
+        {
+          "context": "Asking for help",
+          "example": "You need a ride to an appointment. Instead of over-explaining, notice the discomfort of needing, then make the plain ask."
+        },
+        {
+          "context": "A stalled campaign",
+          "example": "A mutual-aid drive stalls. Rather than adding tactics, let the group feel what is missing — often it is rest or trust, not resources."
+        }
+      ]
     },
     {
       "id": "OPEN-GR-CHALLENGER",
@@ -926,7 +950,17 @@
         "connection"
       ],
       "status": "authored",
-      "flavor": "It never worked because the asking was fake. It was asking for rescue, not asking to be changed."
+      "flavor": "It never worked because the asking was fake. It was asking for rescue, not asking to be changed.",
+      "applications": [
+        {
+          "context": "At work",
+          "example": "You keep working weekends to avoid asking for headcount. Name the fear of looking incapable, then request the help you actually need."
+        },
+        {
+          "context": "In a friendship",
+          "example": "You want deeper support but keep things light to avoid being a burden. Make the real ask instead of the safe one."
+        }
+      ]
     },
     {
       "id": "OPEN-GR-REGENT",
@@ -3292,7 +3326,17 @@
         "agency"
       ],
       "status": "authored",
-      "flavor": "The naming is the first move."
+      "flavor": "The naming is the first move.",
+      "applications": [
+        {
+          "context": "A meeting",
+          "example": "A colleague is talked over repeatedly. Instead of a vague follow-up, say it in the room: “I want to hear the rest of what she was saying.”"
+        },
+        {
+          "context": "Online",
+          "example": "You have drafted the post three times. Publish the specific truth today, addressed to the people who need to hear it."
+        }
+      ]
     },
     {
       "id": "SHOW-RA-REGENT",

--- a/public/allyship-deck/allyship-deck.json
+++ b/public/allyship-deck/allyship-deck.json
@@ -152,6 +152,7 @@
         "Resource tunnel-vision"
       ],
       "remediation": "Name the one resource that, if present, would change everything.",
+      "action": "Notice the signal",
       "capabilities": [
         "exploration",
         "rest"
@@ -183,6 +184,7 @@
         "Budgets that omit the scary line"
       ],
       "remediation": "Write the exact amount needed. Look at it for ten seconds.",
+      "action": "Notice resistance",
       "capabilities": [
         "exploration",
         "agency"
@@ -213,6 +215,7 @@
         "Everything is \"priority\""
       ],
       "remediation": "Rank the top three needs. Fund the first before the rest.",
+      "action": "Notice stewardship",
       "capabilities": [
         "rest",
         "agency"
@@ -243,6 +246,7 @@
         "Under-leveraging a strength"
       ],
       "remediation": "Name one resource you already have that could double.",
+      "action": "Notice potential",
       "capabilities": [
         "exploration",
         "participation"
@@ -273,6 +277,7 @@
         "Stepping on a key relationship"
       ],
       "remediation": "List who must say yes for resources to move. Start there.",
+      "action": "Notice relationships",
       "capabilities": [
         "connection",
         "participation"
@@ -302,6 +307,7 @@
         "Spiritualizing systemic lack"
       ],
       "remediation": "Ask whether this lack has happened before. Name the pattern.",
+      "action": "Notice meaning",
       "capabilities": [
         "exploration",
         "connection"
@@ -332,6 +338,7 @@
         "Seeing only what confirms you"
       ],
       "remediation": "Name one thing present in the room that no one is naming.",
+      "action": "Notice the signal",
       "capabilities": [
         "exploration",
         "connection"
@@ -363,6 +370,7 @@
         "Comfort chosen over truth"
       ],
       "remediation": "Name the thing the room is working hard not to see.",
+      "action": "Notice resistance",
       "capabilities": [
         "exploration",
         "agency"
@@ -393,6 +401,7 @@
         "Spotlight on the trivial"
       ],
       "remediation": "Choose the one truth worth the room's full attention.",
+      "action": "Notice stewardship",
       "capabilities": [
         "rest",
         "connection"
@@ -423,6 +432,7 @@
         "Truth that doesn't travel"
       ],
       "remediation": "Name the one fact that, if everyone saw it, would change things.",
+      "action": "Notice potential",
       "capabilities": [
         "exploration",
         "participation"
@@ -453,6 +463,7 @@
         "Missing the silenced"
       ],
       "remediation": "Name who isn't in the conversation. Bring their voice, or make room for it.",
+      "action": "Notice relationships",
       "capabilities": [
         "connection",
         "participation"
@@ -483,6 +494,7 @@
         "Framing a pattern as a one-off"
       ],
       "remediation": "Connect this incident to the pattern it belongs to.",
+      "action": "Notice meaning",
       "capabilities": [
         "exploration",
         "connection"
@@ -512,6 +524,7 @@
         "Intervening where it's safe, not where harm is"
       ],
       "remediation": "Name the specific harm, in specific terms.",
+      "action": "Notice the signal",
       "capabilities": [
         "exploration",
         "agency"
@@ -541,6 +554,7 @@
         "Politeness as complicity"
       ],
       "remediation": "Name the line that needs drawing — the one you've been avoiding.",
+      "action": "Notice resistance",
       "capabilities": [
         "agency",
         "exploration"
@@ -571,6 +585,7 @@
         "Taking on the fight that isn't yours"
       ],
       "remediation": "Name the one harm you're actually positioned to confront.",
+      "action": "Notice stewardship",
       "capabilities": [
         "rest",
         "agency"
@@ -600,6 +615,7 @@
         "Effort that doesn't move the harm"
       ],
       "remediation": "Name the point where pressure actually shifts the outcome.",
+      "action": "Notice potential",
       "capabilities": [
         "agency",
         "exploration"
@@ -629,6 +645,7 @@
         "Action that endangers those it claims to protect"
       ],
       "remediation": "Name who bears the risk. Don't spend others' safety.",
+      "action": "Notice relationships",
       "capabilities": [
         "connection",
         "participation"
@@ -658,6 +675,7 @@
         "Addressing the instance, missing the cycle"
       ],
       "remediation": "Connect this harm to the cycle it repeats, and aim there.",
+      "action": "Notice meaning",
       "capabilities": [
         "exploration",
         "agency"
@@ -687,6 +705,7 @@
         "Missing the informal one that runs things"
       ],
       "remediation": "Name how the work actually flows right now, not how it's supposed to.",
+      "action": "Notice the signal",
       "capabilities": [
         "exploration",
         "rest"
@@ -716,6 +735,7 @@
         "The workaround becoming permanent"
       ],
       "remediation": "Name the structural problem people keep absorbing personally.",
+      "action": "Notice resistance",
       "capabilities": [
         "exploration",
         "agency"
@@ -744,6 +764,7 @@
         "Polishing the front while the foundation cracks"
       ],
       "remediation": "Name the load-bearing part that needs care first.",
+      "action": "Notice stewardship",
       "capabilities": [
         "rest",
         "participation"
@@ -774,6 +795,7 @@
         "Missing the one that would help"
       ],
       "remediation": "Name the structure that would remove the most friction.",
+      "action": "Notice potential",
       "capabilities": [
         "participation",
         "exploration"
@@ -804,6 +826,7 @@
         "Stepping on relationships"
       ],
       "remediation": "Name who actually holds decision power and trust.",
+      "action": "Notice relationships",
       "capabilities": [
         "connection",
         "participation"
@@ -832,6 +855,7 @@
         "Fixing the instance while the pattern recurs"
       ],
       "remediation": "Connect this breakdown to the pattern it repeats.",
+      "action": "Notice meaning",
       "capabilities": [
         "exploration",
         "connection"
@@ -863,6 +887,7 @@
         "Talking about \"the money\" with no body in it"
       ],
       "remediation": "Name the sensation of lack out loud — where it sits in the body — before you make a single ask.",
+      "action": "Allow experience",
       "capabilities": [
         "connection",
         "rest"
@@ -895,6 +920,7 @@
         "Saying \"no\" for people before they can answer"
       ],
       "remediation": "Feel the \"no\" you're bracing against. Make the real ask anyway — for the thing you actually need.",
+      "action": "Allow discomfort",
       "capabilities": [
         "agency",
         "connection"
@@ -927,6 +953,7 @@
         "White-knuckling it alone"
       ],
       "remediation": "Hold the need for sixty seconds without solving it. Then choose one stewarding act you can own.",
+      "action": "Hold responsibility",
       "capabilities": [
         "agency",
         "rest"
@@ -958,6 +985,7 @@
         "Over-counting the future while starving the present"
       ],
       "remediation": "List three resources already within reach. Receive one of them today.",
+      "action": "Receive the resource",
       "capabilities": [
         "exploration",
         "participation"
@@ -989,6 +1017,7 @@
         "Resentment-laden giving"
       ],
       "remediation": "Offer or receive one resource with no strings — and say \"no strings\" out loud.",
+      "action": "Care for experience",
       "capabilities": [
         "connection",
         "participation"
@@ -1020,6 +1049,7 @@
         "Analysis standing in for witness"
       ],
       "remediation": "Watch the lack for three breaths without fixing it. Write the one true sentence that surfaces.",
+      "action": "Witness experience",
       "capabilities": [
         "exploration",
         "connection"
@@ -1050,6 +1080,7 @@
         "Abstraction as armor"
       ],
       "remediation": "Let the truth land for one breath before you respond.",
+      "action": "Allow experience",
       "capabilities": [
         "connection"
       ],
@@ -1079,6 +1110,7 @@
         "Outrage with no real contact"
       ],
       "remediation": "Feel the thing you've gone numb to. Then decide from there.",
+      "action": "Allow discomfort",
       "capabilities": [
         "connection",
         "agency"
@@ -1109,6 +1141,7 @@
         "Attention with no staying power"
       ],
       "remediation": "Choose one truth you'll keep in view past the news cycle.",
+      "action": "Hold responsibility",
       "capabilities": [
         "rest",
         "connection"
@@ -1138,6 +1171,7 @@
         "Awareness that deadens instead of activates"
       ],
       "remediation": "Name the energy this truth gives you. Aim it.",
+      "action": "Receive the resource",
       "capabilities": [
         "participation",
         "exploration"
@@ -1168,6 +1202,7 @@
         "Performing care"
       ],
       "remediation": "Relate to one person's reality with care, not as a case.",
+      "action": "Care for experience",
       "capabilities": [
         "connection"
       ],
@@ -1197,6 +1232,7 @@
         "Arguing reality away"
       ],
       "remediation": "Witness the truth for three breaths without rebutting it.",
+      "action": "Witness experience",
       "capabilities": [
         "exploration",
         "connection"
@@ -1226,6 +1262,7 @@
         "Reckless action driven by unfelt fear"
       ],
       "remediation": "Feel the fear before you move. Then move anyway.",
+      "action": "Allow experience",
       "capabilities": [
         "connection",
         "agency"
@@ -1256,6 +1293,7 @@
         "The moment passed"
       ],
       "remediation": "Feel what acting would cost. Weigh it against the cost of not acting.",
+      "action": "Allow discomfort",
       "capabilities": [
         "agency"
       ],
@@ -1285,6 +1323,7 @@
         "Flaring out"
       ],
       "remediation": "Stay one beat longer in the discomfort than feels possible.",
+      "action": "Hold responsibility",
       "capabilities": [
         "rest",
         "agency"
@@ -1314,6 +1353,7 @@
         "Anger that burns the actor, not the harm"
       ],
       "remediation": "Name the agency this anger gives you. Point it at the harm.",
+      "action": "Receive the resource",
       "capabilities": [
         "agency",
         "participation"
@@ -1344,6 +1384,7 @@
         "Care abandoned in the fight"
       ],
       "remediation": "Name the boundary fiercely; keep one thread of care for the human.",
+      "action": "Care for experience",
       "capabilities": [
         "connection",
         "agency"
@@ -1374,6 +1415,7 @@
         "Endless \"seeing\" as avoidance"
       ],
       "remediation": "Witness the whole field for three breaths, then act with aim.",
+      "action": "Witness experience",
       "capabilities": [
         "exploration",
         "agency"
@@ -1403,6 +1445,7 @@
         "Process fixes that ignore how it feels to live in them"
       ],
       "remediation": "Name what the current structure feels like to be inside.",
+      "action": "Allow experience",
       "capabilities": [
         "connection",
         "rest"
@@ -1432,6 +1475,7 @@
         "Everyone quietly overworked"
       ],
       "remediation": "Name the role or decision you're avoiding.",
+      "action": "Allow discomfort",
       "capabilities": [
         "agency",
         "connection"
@@ -1461,6 +1505,7 @@
         "The structure depending on one exhausted person"
       ],
       "remediation": "Hold the whole for a beat; then hand one piece to someone you trust.",
+      "action": "Hold responsibility",
       "capabilities": [
         "rest",
         "participation"
@@ -1490,6 +1535,7 @@
         "Scarcity of help while help stands unused"
       ],
       "remediation": "Name three people's capacities you haven't drawn on. Invite one.",
+      "action": "Receive the resource",
       "capabilities": [
         "participation",
         "exploration"
@@ -1520,6 +1566,7 @@
         "Extraction by spreadsheet"
       ],
       "remediation": "Design one part of the structure around how it cares for people.",
+      "action": "Care for experience",
       "capabilities": [
         "connection",
         "participation"
@@ -1549,6 +1596,7 @@
         "Rigid structure fighting the actual work"
       ],
       "remediation": "Watch how the work actually wants to move for three breaths. Organize with that.",
+      "action": "Witness experience",
       "capabilities": [
         "exploration",
         "rest"
@@ -1578,6 +1626,7 @@
         "Anger budgeting"
       ],
       "remediation": "Name the channel out loud: \"This is fear / anger / sadness about money.\"",
+      "action": "Identify channel",
       "capabilities": [
         "exploration"
       ],
@@ -1607,6 +1656,7 @@
         "Inherited shame as realism"
       ],
       "remediation": "Write the story as a sentence. Then write the version that isn't certain.",
+      "action": "Challenge interpretation",
       "capabilities": [
         "agency",
         "exploration"
@@ -1637,6 +1687,7 @@
         "Capability-blind planning"
       ],
       "remediation": "Match the block to a capability. That's the move to grow next.",
+      "action": "Identify missing move",
       "capabilities": [
         "agency",
         "rest"
@@ -1667,6 +1718,7 @@
         "Dumping anger on donors"
       ],
       "remediation": "Pick one: transcend (let it ripen), translate (e.g. fear → agency), or neutralize. Then do it.",
+      "action": "Select transformation",
       "capabilities": [
         "agency",
         "connection"
@@ -1697,6 +1749,7 @@
         "Manipulation dressed as warmth"
       ],
       "remediation": "Re-aim the ask from Connection: invite people into something good.",
+      "action": "Choose destination",
       "capabilities": [
         "connection"
       ],
@@ -1726,6 +1779,7 @@
         "Hollow takeaways"
       ],
       "remediation": "Write one sentence you'll carry into the next ask.",
+      "action": "Extract insight",
       "capabilities": [
         "exploration",
         "connection"
@@ -1755,6 +1809,7 @@
         "Grief dumped as advocacy"
       ],
       "remediation": "Name the channel before you publish a single word.",
+      "action": "Identify channel",
       "capabilities": [
         "exploration"
       ],
@@ -1784,6 +1839,7 @@
         "Truth bent to fit the story"
       ],
       "remediation": "Write the version of events that complicates your story.",
+      "action": "Challenge interpretation",
       "capabilities": [
         "exploration",
         "agency"
@@ -1813,6 +1869,7 @@
         "The knowing-doing gap left unaddressed"
       ],
       "remediation": "Name the capability awareness needs next — to act, connect, or organize.",
+      "action": "Identify missing move",
       "capabilities": [
         "agency",
         "rest"
@@ -1843,6 +1900,7 @@
         "Sanitized into meaninglessness"
       ],
       "remediation": "Pick transcend / translate / neutralize, then craft the message.",
+      "action": "Select transformation",
       "capabilities": [
         "agency",
         "connection"
@@ -1873,6 +1931,7 @@
         "Preaching only to the choir"
       ],
       "remediation": "Re-aim the message from a channel that opens people, not closes them.",
+      "action": "Choose destination",
       "capabilities": [
         "connection"
       ],
@@ -1902,6 +1961,7 @@
         "Shallow takes"
       ],
       "remediation": "Write the one insight you'll keep, beyond this moment.",
+      "action": "Extract insight",
       "capabilities": [
         "exploration",
         "connection"
@@ -1931,6 +1991,7 @@
         "Grief acted out as attack"
       ],
       "remediation": "Name the channel honestly before you intervene.",
+      "action": "Identify channel",
       "capabilities": [
         "exploration",
         "agency"
@@ -1961,6 +2022,7 @@
         "Collateral injustice"
       ],
       "remediation": "Write the version where the \"enemy\" is more complicated. Then aim true.",
+      "action": "Challenge interpretation",
       "capabilities": [
         "exploration",
         "agency"
@@ -1990,6 +2052,7 @@
         "Burnout"
       ],
       "remediation": "Name the capability the action needs next, and grow it.",
+      "action": "Identify missing move",
       "capabilities": [
         "agency",
         "rest"
@@ -2020,6 +2083,7 @@
         "Force that scatters"
       ],
       "remediation": "Pick transcend / translate / neutralize, then act from the forged state.",
+      "action": "Select transformation",
       "capabilities": [
         "agency"
       ],
@@ -2050,6 +2114,7 @@
         "Numbness that under-acts"
       ],
       "remediation": "Re-aim from resolve — an earned boundary, not blind heat.",
+      "action": "Choose destination",
       "capabilities": [
         "agency",
         "connection"
@@ -2079,6 +2144,7 @@
         "The same fight again, unlearned"
       ],
       "remediation": "Write the one lesson this confrontation taught you.",
+      "action": "Extract insight",
       "capabilities": [
         "exploration",
         "agency"
@@ -2108,6 +2174,7 @@
         "Resentment baked into the structure"
       ],
       "remediation": "Name the channel before you redesign anything.",
+      "action": "Identify channel",
       "capabilities": [
         "exploration"
       ],
@@ -2137,6 +2204,7 @@
         "Everything routed through one person"
       ],
       "remediation": "Write the story that keeps you the bottleneck. Then test it: hand one thing off.",
+      "action": "Challenge interpretation",
       "capabilities": [
         "agency",
         "participation"
@@ -2165,6 +2233,7 @@
         "More procedure, same dysfunction"
       ],
       "remediation": "Name the capability the structure needs — not another rule.",
+      "action": "Identify missing move",
       "capabilities": [
         "participation",
         "rest"
@@ -2195,6 +2264,7 @@
         "Reorg as discharge"
       ],
       "remediation": "Clear the charge first; then design from steadiness.",
+      "action": "Select transformation",
       "capabilities": [
         "rest",
         "participation"
@@ -2225,6 +2295,7 @@
         "Disengagement"
       ],
       "remediation": "Re-aim one structure from trust — give real ownership, not just tasks.",
+      "action": "Choose destination",
       "capabilities": [
         "connection",
         "participation"
@@ -2254,6 +2325,7 @@
         "Rebuilding the same flawed system"
       ],
       "remediation": "Write the one design principle this breakdown taught you.",
+      "action": "Extract insight",
       "capabilities": [
         "exploration",
         "participation"
@@ -2283,6 +2355,7 @@
         "Naming a capacity you wish for over the one actually emerging"
       ],
       "remediation": "Name the capacity one size bigger than today. Practice it once.",
+      "action": "Identify emerging capacity",
       "capabilities": [
         "participation",
         "exploration"
@@ -2312,6 +2385,7 @@
         "Pseudo-growth"
       ],
       "remediation": "Name the thing that scares you slightly. That's the edge — step to it.",
+      "action": "Identify developmental edge",
       "capabilities": [
         "agency"
       ],
@@ -2341,6 +2415,7 @@
         "Stewarding everything so nothing deepens"
       ],
       "remediation": "Choose one rep (\"make one real ask weekly\"). Schedule it.",
+      "action": "Steward growth",
       "capabilities": [
         "rest",
         "agency"
@@ -2371,6 +2446,7 @@
         "Polishing a capability you don't need"
       ],
       "remediation": "Pick the capability with the highest leverage. Train it deliberately.",
+      "action": "Amplify capacity",
       "capabilities": [
         "participation",
         "exploration"
@@ -2401,6 +2477,7 @@
         "Isolating success"
       ],
       "remediation": "Name one person your growth affects. Bring them with you.",
+      "action": "Relate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2431,6 +2508,7 @@
         "Growth that doesn't stick"
       ],
       "remediation": "Finish the sentence: \"I am becoming someone who ______.\"",
+      "action": "Integrate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2460,6 +2538,7 @@
         "Naming the capacity you wish for over the one emerging"
       ],
       "remediation": "Name the seeing or speaking capacity one size bigger than today.",
+      "action": "Identify emerging capacity",
       "capabilities": [
         "participation",
         "exploration"
@@ -2488,6 +2567,7 @@
         "Training comfortable speech, avoiding the edge"
       ],
       "remediation": "Name the sentence you're scared to say. That's the edge.",
+      "action": "Identify developmental edge",
       "capabilities": [
         "agency"
       ],
@@ -2516,6 +2596,7 @@
         "Practicing the wrong thing"
       ],
       "remediation": "Pick one rep — a weekly hard conversation. Schedule it.",
+      "action": "Steward growth",
       "capabilities": [
         "rest",
         "agency"
@@ -2545,6 +2626,7 @@
         "Growth without leverage"
       ],
       "remediation": "Pick the highest-leverage skill — clarity, story, or listening. Train it.",
+      "action": "Amplify capacity",
       "capabilities": [
         "participation",
         "exploration"
@@ -2574,6 +2656,7 @@
         "Collateral harm"
       ],
       "remediation": "Name one relationship your bolder voice affects. Tend it.",
+      "action": "Relate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2602,6 +2685,7 @@
         "Capacity gained, self un-integrated"
       ],
       "remediation": "Finish the sentence: \"I am becoming someone who can see and say ______.\"",
+      "action": "Integrate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2631,6 +2715,7 @@
         "Naming the courage you wish for over the one emerging"
       ],
       "remediation": "Name the boundary or action one size bigger than today. Take it once.",
+      "action": "Identify emerging capacity",
       "capabilities": [
         "agency",
         "participation"
@@ -2659,6 +2744,7 @@
         "Training comfort, avoiding the real confrontation"
       ],
       "remediation": "Name the confrontation that scares you slightly. Step to it.",
+      "action": "Identify developmental edge",
       "capabilities": [
         "agency"
       ],
@@ -2687,6 +2773,7 @@
         "Drilling the wrong skill"
       ],
       "remediation": "Pick one rep — a small \"no\" daily. Practice it.",
+      "action": "Steward growth",
       "capabilities": [
         "rest",
         "agency"
@@ -2716,6 +2803,7 @@
         "Growth without leverage"
       ],
       "remediation": "Pick the highest-leverage action capability. Train it.",
+      "action": "Amplify capacity",
       "capabilities": [
         "agency",
         "participation"
@@ -2744,6 +2832,7 @@
         "Bold action that isolates or endangers"
       ],
       "remediation": "Name who your bolder action affects. Move with them, not past them.",
+      "action": "Relate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2774,6 +2863,7 @@
         "Becoming what you fought"
       ],
       "remediation": "Finish the sentence: \"I am becoming someone who can act and still ______.\"",
+      "action": "Integrate growth",
       "capabilities": [
         "connection",
         "agency"
@@ -2803,6 +2893,7 @@
         "Naming the capacity you wish for over the one emerging"
       ],
       "remediation": "Name the organizing capacity one size bigger than today. Practice it once.",
+      "action": "Identify emerging capacity",
       "capabilities": [
         "participation",
         "exploration"
@@ -2832,6 +2923,7 @@
         "Clinging to doing it yourself"
       ],
       "remediation": "Name the thing you must stop doing yourself. Hand it off.",
+      "action": "Identify developmental edge",
       "capabilities": [
         "agency",
         "participation"
@@ -2861,6 +2953,7 @@
         "Practicing the wrong skill"
       ],
       "remediation": "Pick one rep — delegate one real thing weekly. Practice it.",
+      "action": "Steward growth",
       "capabilities": [
         "rest",
         "participation"
@@ -2890,6 +2983,7 @@
         "Growth without leverage"
       ],
       "remediation": "Pick the highest-leverage capability — clarity, trust, or follow-through. Build it.",
+      "action": "Amplify capacity",
       "capabilities": [
         "participation",
         "agency"
@@ -2919,6 +3013,7 @@
         "One strong organizer, a dependent group"
       ],
       "remediation": "Name one person whose capacity your growth could grow. Invest in them.",
+      "action": "Relate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2948,6 +3043,7 @@
         "Becoming the bottleneck you feared"
       ],
       "remediation": "Finish the sentence: \"I am becoming someone who can build and still ______.\"",
+      "action": "Integrate growth",
       "capabilities": [
         "connection",
         "participation"
@@ -2978,6 +3074,7 @@
         "Paralysis by optimization"
       ],
       "remediation": "Name the first concrete place the resources go this week.",
+      "action": "Choose domain",
       "capabilities": [
         "agency"
       ],
@@ -3007,6 +3104,7 @@
         "The ask that never posts"
       ],
       "remediation": "Post the ask today. Make it real and specific.",
+      "action": "Create intervention",
       "capabilities": [
         "agency"
       ],
@@ -3037,6 +3135,7 @@
         "Funds without follow-through"
       ],
       "remediation": "Set one transparency practice (a public update, a ledger). Keep it.",
+      "action": "Create stewardship",
       "capabilities": [
         "rest",
         "connection"
@@ -3067,6 +3166,7 @@
         "Scaffolding nobody uses"
       ],
       "remediation": "Add one structural lever: a milestone ladder ($200 / $400 / $800) or a match.",
+      "action": "Create structure",
       "capabilities": [
         "participation",
         "agency"
@@ -3097,6 +3197,7 @@
         "Transactional asks that sour"
       ],
       "remediation": "Invite one person with full consent and no strings. Name the dynamic aloud.",
+      "action": "Create relationship",
       "capabilities": [
         "connection",
         "participation"
@@ -3127,6 +3228,7 @@
         "Goodwill spent and not renewed"
       ],
       "remediation": "Name the artifact that outlives the campaign. Tell its story to one giver.",
+      "action": "Create legacy",
       "capabilities": [
         "connection",
         "participation"
@@ -3156,6 +3258,7 @@
         "A message to no one"
       ],
       "remediation": "Name the one audience and channel this truth goes to first.",
+      "action": "Choose domain",
       "capabilities": [
         "agency"
       ],
@@ -3184,6 +3287,7 @@
         "The truth that never gets said"
       ],
       "remediation": "Say the thing today — specifically, to the people who need to hear it.",
+      "action": "Create intervention",
       "capabilities": [
         "agency"
       ],
@@ -3213,6 +3317,7 @@
         "Awareness that spikes and dies"
       ],
       "remediation": "Set one recurring act that keeps the truth present.",
+      "action": "Create stewardship",
       "capabilities": [
         "rest",
         "connection"
@@ -3241,6 +3346,7 @@
         "A message that can't scale or repeat"
       ],
       "remediation": "Add one structural lever: a series, a shareable artifact, or a coalition list.",
+      "action": "Create structure",
       "capabilities": [
         "participation",
         "agency"
@@ -3271,6 +3377,7 @@
         "Extraction of testimony"
       ],
       "remediation": "Amplify one affected voice with consent; name your own role honestly.",
+      "action": "Create relationship",
       "capabilities": [
         "connection",
         "participation"
@@ -3300,6 +3407,7 @@
         "Attention spent, nothing retained"
       ],
       "remediation": "Name the artifact — the documented account, the changed mind — that outlives the post.",
+      "action": "Create legacy",
       "capabilities": [
         "connection",
         "participation"
@@ -3330,6 +3438,7 @@
         "Energy scattered"
       ],
       "remediation": "Name the one place this action lands first.",
+      "action": "Choose domain",
       "capabilities": [
         "agency"
       ],
@@ -3358,6 +3467,7 @@
         "The action that never happens"
       ],
       "remediation": "Take the action today — specific, real, visible.",
+      "action": "Create intervention",
       "capabilities": [
         "agency"
       ],
@@ -3388,6 +3498,7 @@
         "Unsustained campaigns"
       ],
       "remediation": "Set one sustainable recurring commitment to keep the pressure on.",
+      "action": "Create stewardship",
       "capabilities": [
         "rest",
         "agency"
@@ -3417,6 +3528,7 @@
         "Action that can't escalate or repeat"
       ],
       "remediation": "Add one structural lever — an escalation step or a clear next demand.",
+      "action": "Create structure",
       "capabilities": [
         "agency",
         "participation"
@@ -3447,6 +3559,7 @@
         "Action that speaks over"
       ],
       "remediation": "Act with the affected, by their lead; name and protect who's at risk.",
+      "action": "Create relationship",
       "capabilities": [
         "connection",
         "participation"
@@ -3477,6 +3590,7 @@
         "The harm returns"
       ],
       "remediation": "Name the change that must outlast the action; secure it.",
+      "action": "Create legacy",
       "capabilities": [
         "agency",
         "participation"
@@ -3506,6 +3620,7 @@
         "Systems built for nothing in particular"
       ],
       "remediation": "Name the one process this structure serves first.",
+      "action": "Choose domain",
       "capabilities": [
         "agency",
         "participation"
@@ -3535,6 +3650,7 @@
         "The reorg that never happens"
       ],
       "remediation": "Make the structural change today — define one role, fix one process.",
+      "action": "Create intervention",
       "capabilities": [
         "agency",
         "participation"
@@ -3565,6 +3681,7 @@
         "Nobody tending it"
       ],
       "remediation": "Assign one owner and one review rhythm to the structure.",
+      "action": "Create stewardship",
       "capabilities": [
         "rest",
         "participation"
@@ -3594,6 +3711,7 @@
         "A structure that can't scale or survive a departure"
       ],
       "remediation": "Add one durable lever — a documented process, a clear role, a handoff.",
+      "action": "Create structure",
       "capabilities": [
         "participation",
         "agency"
@@ -3625,6 +3743,7 @@
         "Tokens without power"
       ],
       "remediation": "Distribute one piece of real ownership; name the power dynamic openly.",
+      "action": "Create relationship",
       "capabilities": [
         "connection",
         "participation"
@@ -3654,6 +3773,7 @@
         "The work collapses when you leave"
       ],
       "remediation": "Name the structure or trained people that outlast you; secure them.",
+      "action": "Create legacy",
       "capabilities": [
         "participation",
         "connection"

--- a/src/app/wiki/iching/page.tsx
+++ b/src/app/wiki/iching/page.tsx
@@ -2,6 +2,12 @@ import Link from 'next/link'
 import { db } from '@/lib/db'
 import { getHexagramStructure } from '@/lib/iching-struct'
 
+// Render at request time, not at build. This page queries Prisma (bars +
+// archetypes); a static prerender runs that query during the build, which fails
+// when the build has no reachable database/Data Proxy (P5000). Matches the
+// sibling wiki pages (nations, archetypes) which already defer this way.
+export const dynamic = 'force-dynamic'
+
 /**
  * @page /wiki/iching
  * @entity WIKI

--- a/src/components/deck/AllyshipCard.tsx
+++ b/src/components/deck/AllyshipCard.tsx
@@ -22,6 +22,7 @@ import {
 import type { MoveCard } from '@/lib/allyship-deck/types'
 import { MovePip } from './MovePip'
 import { FaceBadge } from './FaceBadge'
+import { CardApplications } from './CardApplications'
 
 /** Which reading of the card to show: introspective (self) or for-others (campaign). */
 export type CardSubject = 'self' | 'campaign'
@@ -223,6 +224,9 @@ export function AllyshipCard({
           {card.flavor}
         </p>
       )}
+
+      {/* how this shows up in real life — authored applications or deterministic fallback */}
+      <CardApplications card={card} subject={subject} />
 
       {/* foot */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 16 }}>

--- a/src/components/deck/AllyshipCard.tsx
+++ b/src/components/deck/AllyshipCard.tsx
@@ -176,6 +176,24 @@ export function AllyshipCard({
         {question}
       </p>
 
+      {/* your move — the one concrete next step (distinct from the ongoing practice) */}
+      {card.action && (
+        <div
+          style={{
+            marginTop: 16,
+            padding: '12px 15px',
+            borderRadius: 8,
+            background: `color-mix(in srgb, ${DECK_GOLD} 9%, ${SURFACE_TOKENS.surfaceInset})`,
+            boxShadow: `inset 0 1px 0 rgba(255,255,255,.06), 0 0 0 1px color-mix(in srgb, ${DECK_GOLD} 34%, transparent)`,
+          }}
+        >
+          <div style={{ ...labelStyle, color: DECK_GOLD }}>Your move</div>
+          <div style={{ fontFamily: DECK_FONTS.body, fontSize: 14.5, color: '#fff', marginTop: 3, lineHeight: 1.5 }}>
+            {card.action}
+          </div>
+        </div>
+      )}
+
       {/* the practice well */}
       <div
         style={{

--- a/src/components/deck/AllyshipDeckReader.tsx
+++ b/src/components/deck/AllyshipDeckReader.tsx
@@ -25,6 +25,7 @@ import { GoDeeper } from './GoDeeper'
 import { FindYourPath } from './FindYourPath'
 import { recordDraw, type DeckStats } from '@/actions/deck-journal'
 import { HandModal } from '@/components/world/HandModal'
+import { DeckOrientation, type OrientationDest } from './DeckOrientation'
 
 type AppView = 'draw' | 'browse' | 'path' | 'collection'
 type DrawMode = 'single' | 'spread'
@@ -44,6 +45,8 @@ export function AllyshipDeckReader({ initialStats, authed = false }: { initialSt
   const [deck, setDeck] = useState<AllyshipDeck | null>(null)
   // Hand modal — keep the deck connected to the player's active inventory (FR12).
   const [handOpen, setHandOpen] = useState(false)
+  // First-run orientation — teaches the four ways to use the deck (shown once).
+  const [orientationOpen, setOrientationOpen] = useState(false)
   const [error, setError] = useState(false)
   const [view, setView] = useState<AppView>('draw')
   const [subject, setSubject] = useState<CardSubject>('self')
@@ -72,6 +75,15 @@ export function AllyshipDeckReader({ initialStats, authed = false }: { initialSt
       })
       .then(setDeck)
       .catch(() => setError(true))
+  }, [])
+
+  // Open the orientation once for first-time visitors (localStorage-gated).
+  // Done post-mount (not a lazy initializer) so server + first client render
+  // agree — the modal is opened after hydration, avoiding a mismatch.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional client-only first-run gate
+    if (window.localStorage.getItem('deck-orientation-seen') !== 'true') setOrientationOpen(true)
   }, [])
 
   const moveCards = useMemo(() => (deck ? deck.cards.filter(isMove) : []), [deck])
@@ -111,6 +123,25 @@ export function AllyshipDeckReader({ initialStats, authed = false }: { initialSt
     setView(v)
     setSelected(null)
     window.scrollTo(0, 0)
+  }
+
+  const dismissOrientation = () => {
+    setOrientationOpen(false)
+    if (typeof window !== 'undefined') window.localStorage.setItem('deck-orientation-seen', 'true')
+  }
+
+  const goFromOrientation = (dest: OrientationDest) => {
+    if (dest === 'daily') {
+      setDrawMode('single')
+      switchView('draw')
+    } else if (dest === 'situation') {
+      switchView('path')
+    } else if (dest === 'browse') {
+      switchView('browse')
+    } else {
+      switchView('collection')
+    }
+    dismissOrientation()
   }
 
   if (error) return <Centered>The deck could not be loaded.</Centered>
@@ -168,6 +199,20 @@ export function AllyshipDeckReader({ initialStats, authed = false }: { initialSt
 
           {/* Streak + balance + Hand / NOW (FR12) */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 'none' }}>
+            <button
+              type="button"
+              onClick={() => setOrientationOpen(true)}
+              title="How to use this deck"
+              aria-label="How to use this deck"
+              style={{
+                fontFamily: DECK_FONTS.mono, fontSize: 12, fontWeight: 700, lineHeight: 1,
+                width: 26, height: 26, borderRadius: '50%', cursor: 'pointer', flex: 'none',
+                color: SURFACE_TOKENS.textSecondary, background: 'transparent',
+                border: '1px solid rgba(255,255,255,.16)',
+              }}
+            >
+              ?
+            </button>
             {stats && (
               <>
                 <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontFamily: DECK_FONTS.mono, fontSize: 11, color: SURFACE_TOKENS.textSecondary }}>
@@ -210,6 +255,8 @@ export function AllyshipDeckReader({ initialStats, authed = false }: { initialSt
       </header>
 
       {handOpen && <HandModal onClose={() => setHandOpen(false)} carryingBarId={null} />}
+
+      {orientationOpen && <DeckOrientation onClose={dismissOrientation} onSelect={goFromOrientation} />}
 
       {/* ── Subject toggle ── */}
       <div style={{ display: 'flex', justifyContent: 'center', gap: 8, padding: '12px 16px 0' }}>

--- a/src/components/deck/CardApplications.tsx
+++ b/src/components/deck/CardApplications.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState, type CSSProperties } from 'react'
+import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
+import { DECK_FONTS, DOMAIN_LABELS } from '@/lib/allyship-deck/card-visuals'
+import type { MoveCard } from '@/lib/allyship-deck/types'
+import type { CardSubject } from './AllyshipCard'
+
+/**
+ * "How this shows up in real life" — the applications disclosure on a card.
+ *
+ * Deterministic and always non-empty (honoring the AI-allergic community):
+ * authored `card.applications` when present, otherwise a fallback derived from
+ * the card's own canonical data (domain framing + the other reading). The
+ * optional AI "apply to my situation" step (Phase 4) layers on top of this
+ * baseline — it never replaces it.
+ *
+ * @see .specify/specs/allyship-deck-literacy/spec.md (Phase 3)
+ */
+export function CardApplications({ card, subject }: { card: MoveCard; subject: CardSubject }) {
+  const [open, setOpen] = useState(false)
+  const items = card.applications?.length ? card.applications : fallbackApplications(card, subject)
+
+  return (
+    <div style={{ marginTop: 14 }}>
+      <button type="button" onClick={() => setOpen((v) => !v)} style={toggle} aria-expanded={open}>
+        {open ? '▾' : '▸'} How this shows up in real life
+      </button>
+      {open && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+          {items.map((it, i) => (
+            <div key={i} style={item}>
+              <div style={label}>{it.context}</div>
+              <div style={{ fontFamily: DECK_FONTS.body, fontSize: 13.5, color: '#fff', marginTop: 2, lineHeight: 1.45 }}>
+                {it.example}
+              </div>
+            </div>
+          ))}
+          {!card.applications?.length && (
+            <p style={{ fontFamily: DECK_FONTS.body, fontSize: 11.5, fontStyle: 'italic', color: SURFACE_TOKENS.textMuted, margin: '2px 0 0' }}>
+              Drawn from this card — worked examples for this move are still being written.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Deterministic fallback so the section is never empty and never needs AI. */
+function fallbackApplications(card: MoveCard, subject: CardSubject): { context: string; example: string }[] {
+  const otherReading =
+    subject === 'campaign'
+      ? { context: 'In your own practice', example: card.primaryQuestion }
+      : { context: 'For a campaign or someone else', example: card.campaignQuestion }
+  return [
+    { context: `In ${DOMAIN_LABELS[card.domain]}`, example: card.optimizesFor },
+    otherReading,
+  ]
+}
+
+const toggle: CSSProperties = {
+  fontFamily: DECK_FONTS.mono,
+  fontSize: 11,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: SURFACE_TOKENS.textSecondary,
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+}
+
+const item: CSSProperties = {
+  padding: '10px 12px',
+  borderRadius: 8,
+  background: SURFACE_TOKENS.surfaceInset,
+  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.04), 0 0 0 1px rgba(255,255,255,.08)',
+}
+
+const label: CSSProperties = {
+  fontFamily: DECK_FONTS.mono,
+  fontSize: 10,
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: '#e7c98a',
+}

--- a/src/components/deck/DeckOrientation.tsx
+++ b/src/components/deck/DeckOrientation.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
+import { DECK_FONTS, DECK_GOLD, LIMINAL } from '@/lib/allyship-deck/card-visuals'
+
+/** Where an orientation option sends the player — mapped to views/modes by the reader. */
+export type OrientationDest = 'daily' | 'situation' | 'browse' | 'collection'
+
+const OPTIONS: { key: OrientationDest; title: string; when: string; cta: string }[] = [
+  {
+    key: 'daily',
+    title: 'Pull a daily card',
+    when: 'For a daily centering practice. One card, one concrete move to carry into the day.',
+    cta: 'Draw a card',
+  },
+  {
+    key: 'situation',
+    title: 'Read your situation',
+    when: "Facing something specific? A short guided reading lays a 3-card spread for the moment you're in.",
+    cta: 'Find your path',
+  },
+  {
+    key: 'browse',
+    title: 'Browse the deck',
+    when: 'Looking for a particular move? Filter all 120 cards by move, face, or domain.',
+    cta: 'Open the deck',
+  },
+  {
+    key: 'collection',
+    title: 'Your collection',
+    when: "Revisit the cards you've drawn and keep your streak going.",
+    cta: 'View collection',
+  },
+]
+
+/**
+ * First-run orientation for /deck — teaches the four ways to use the deck and
+ * routes the player straight into the one they pick. Deck-aesthetic modal
+ * (reuses the detail-overlay pattern; not CultivationCard per UI_COVENANT).
+ * Shown once (localStorage in the reader) and re-openable from the top bar.
+ *
+ * @see .specify/specs/allyship-deck-literacy/spec.md (Phase 5)
+ */
+export function DeckOrientation({
+  onClose,
+  onSelect,
+}: {
+  onClose: () => void
+  onSelect: (dest: OrientationDest) => void
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 60,
+        background: 'rgba(5,4,3,.78)',
+        backdropFilter: 'blur(6px)',
+        WebkitBackdropFilter: 'blur(6px)',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 16,
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 'min(460px, 100%)',
+          background: SURFACE_TOKENS.surfaceElevated,
+          borderRadius: 18,
+          padding: 22,
+          boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06), 0 24px 48px -16px rgba(0,0,0,.9)',
+        }}
+      >
+        <p style={kicker}>New here?</p>
+        <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 22, color: '#fff', margin: '4px 0 4px' }}>
+          How to use the deck
+        </h2>
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 13.5, color: SURFACE_TOKENS.textSecondary, margin: '0 0 18px', lineHeight: 1.5 }}>
+          Four ways in — pick what fits the moment. You can always reopen this from the “?” in the top bar.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {OPTIONS.map((o) => (
+            <button key={o.key} type="button" onClick={() => onSelect(o.key)} style={optionBtn}>
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 10 }}>
+                <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 15, color: '#fff' }}>{o.title}</span>
+                <span style={{ fontFamily: DECK_FONTS.mono, fontSize: 10, letterSpacing: '0.04em', color: DECK_GOLD, whiteSpace: 'nowrap' }}>
+                  {o.cta} →
+                </span>
+              </div>
+              <p style={{ fontFamily: DECK_FONTS.body, fontSize: 12.5, color: SURFACE_TOKENS.textSecondary, margin: '5px 0 0', lineHeight: 1.45 }}>
+                {o.when}
+              </p>
+            </button>
+          ))}
+        </div>
+
+        <button type="button" onClick={onClose} style={laterBtn}>
+          Maybe later
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const kicker: CSSProperties = {
+  fontFamily: DECK_FONTS.mono,
+  fontSize: 10,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: SURFACE_TOKENS.textMuted,
+  margin: 0,
+}
+
+const optionBtn: CSSProperties = {
+  textAlign: 'left',
+  cursor: 'pointer',
+  padding: '13px 15px',
+  borderRadius: 12,
+  background: SURFACE_TOKENS.surfaceInset,
+  border: '1px solid rgba(255,255,255,.12)',
+  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.04)',
+}
+
+const laterBtn: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  marginTop: 16,
+  padding: '11px',
+  borderRadius: 10,
+  border: `1px solid ${LIMINAL.frame}`,
+  background: 'transparent',
+  color: SURFACE_TOKENS.textSecondary,
+  fontFamily: DECK_FONTS.display,
+  fontWeight: 600,
+  fontSize: 14,
+  cursor: 'pointer',
+}

--- a/src/lib/allyship-deck/__tests__/seed.test.ts
+++ b/src/lib/allyship-deck/__tests__/seed.test.ts
@@ -7,10 +7,12 @@ const deck = assembleDeck()
 const card = deck.cards.find((c): c is MoveCard => c.kind === 'move' && c.id === 'OPEN-GR-SHAMAN')
 assert.ok(card, 'fixture card OPEN-GR-SHAMAN exists')
 
-// self reading uses the introspective question; description leads with the practice.
+// self reading uses the introspective question; description leads with "Your move".
 const self = buildDeckSeed(card, 'self')
 assert.strictEqual(self.title, card.title)
-assert.ok(self.description.startsWith('The practice:'), 'description leads with the practice')
+assert.ok(self.description.startsWith('Your move:'), 'description leads with the concrete move')
+assert.ok(card.action && self.description.includes(card.action), 'includes the action')
+assert.ok(self.description.includes('The practice:'), 'still carries the practice')
 assert.ok(self.description.includes(card.remediation), 'includes remediation')
 assert.ok(self.description.includes(card.primaryQuestion), 'self → primaryQuestion')
 assert.strictEqual(self.rootId, 'deck_OPEN-GR-SHAMAN')

--- a/src/lib/allyship-deck/assemble.ts
+++ b/src/lib/allyship-deck/assemble.ts
@@ -53,6 +53,8 @@ function buildMoveCards(): MoveCard[] {
           forbiddenMoves: ['— author —'],
           failureModes: ['— author —'],
           remediation: `${sub.action} — in the context of ${d.lens}.`,
+          // "Your move" — the one concrete step, from the canonical submove. AUTHORED may override via the spread below.
+          action: sub.action,
           capabilities: [],
           status: 'generated',
         }

--- a/src/lib/allyship-deck/move-library.ts
+++ b/src/lib/allyship-deck/move-library.ts
@@ -142,6 +142,11 @@ export const AUTHORED: Record<string, Partial<MoveCard>> = {
     remediation: 'Name the sensation of lack out loud — where it sits in the body — before you make a single ask.',
     flavor: 'The child holding the empty cup is not a problem to solve yet. First, let yourself see the cup.',
     capabilities: ['connection', 'rest'],
+    applications: [
+      { context: 'Money', example: 'Before drafting a fundraiser, sit with what the shortfall actually feels like — fear, shame, grief — and name it out loud before you name a number.' },
+      { context: 'Asking for help', example: 'You need a ride to an appointment. Instead of over-explaining, notice the discomfort of needing, then make the plain ask.' },
+      { context: 'A stalled campaign', example: 'A mutual-aid drive stalls. Rather than adding tactics, let the group feel what is missing — often it is rest or trust, not resources.' },
+    ],
   },
   'OPEN-GR-CHALLENGER': {
     title: "The Ask You're Avoiding",
@@ -153,6 +158,10 @@ export const AUTHORED: Record<string, Partial<MoveCard>> = {
     remediation: 'Feel the "no" you\'re bracing against. Make the real ask anyway — for the thing you actually need.',
     flavor: 'It never worked because the asking was fake. It was asking for rescue, not asking to be changed.',
     capabilities: ['agency', 'connection'],
+    applications: [
+      { context: 'At work', example: 'You keep working weekends to avoid asking for headcount. Name the fear of looking incapable, then request the help you actually need.' },
+      { context: 'In a friendship', example: 'You want deeper support but keep things light to avoid being a burden. Make the real ask instead of the safe one.' },
+    ],
   },
   'OPEN-GR-REGENT': {
     title: 'Stay With the Need',
@@ -206,6 +215,10 @@ export const AUTHORED: Record<string, Partial<MoveCard>> = {
     remediation: 'Name the one resource that, if present, would change everything.',
     flavor: 'Not every empty cup is the same cup.',
     capabilities: ['exploration', 'rest'],
+    applications: [
+      { context: 'Burnout', example: 'You feel "broke," but a closer look shows the real scarcity is time and rest, not money. Name the one resource that would change everything.' },
+      { context: 'An organization', example: 'A team says it needs funding; on inspection it needs decisions. Distinguish what is depleted from what only feels depleted.' },
+    ],
   },
   'WAKE-GR-CHALLENGER': {
     title: "The Number You Won't Look At",
@@ -716,6 +729,10 @@ export const AUTHORED: Record<string, Partial<MoveCard>> = {
     remediation: "Say the thing today — specifically, to the people who need to hear it.",
     flavor: "The naming is the first move.",
     capabilities: ["agency"],
+    applications: [
+      { context: "A meeting", example: "A colleague is talked over repeatedly. Instead of a vague follow-up, say it in the room: “I want to hear the rest of what she was saying.”" },
+      { context: "Online", example: "You have drafted the post three times. Publish the specific truth today, addressed to the people who need to hear it." },
+    ],
   },
   'SHOW-RA-REGENT': {
     title: "Keep the Truth Alive",

--- a/src/lib/allyship-deck/seed.ts
+++ b/src/lib/allyship-deck/seed.ts
@@ -56,11 +56,14 @@ export function buildDeckSeed(
   const question = subject === 'campaign' ? card.campaignQuestion : card.primaryQuestion
   const { superpower, orientation } = opts
 
+  // "Your move" — the one concrete step leads the BAR when present.
+  const move = card.action ? `Your move: ${card.action}\n\n` : ''
+
   // Backward-compatible: no lens → original behavior unchanged.
   if (!superpower || !orientation) {
     return {
       title: card.title,
-      description: `The practice: ${card.remediation}\n\n${question}`,
+      description: `${move}The practice: ${card.remediation}\n\n${question}`,
       rootId: `deck_${card.id}`,
       provenance: {
         sourceType: 'deck_card',
@@ -79,7 +82,7 @@ export function buildDeckSeed(
   return {
     title: card.title,
     description:
-      `The practice: ${card.remediation}\n\n${question}\n\n` +
+      `${move}The practice: ${card.remediation}\n\n${question}\n\n` +
       `Through your ${superpower} (${orientation}) lens: ${t.prompt}\n` +
       `Artifact: ${t.suggestedArtifact}`,
     rootId: `deck_${card.id}_${superpower}_${orientation}`,

--- a/src/lib/allyship-deck/types.ts
+++ b/src/lib/allyship-deck/types.ts
@@ -59,6 +59,8 @@ export interface MoveCard {
   forbiddenMoves: string[]
   failureModes: string[]
   remediation: string
+  /** The one concrete next step ("Your move"). Defaults from the submove action; AUTHORED may override. */
+  action?: string
 
   flavor?: string
   capabilities: Capability[] // latent; selected at consult time (faces are channel-agnostic)

--- a/src/lib/allyship-deck/types.ts
+++ b/src/lib/allyship-deck/types.ts
@@ -61,6 +61,8 @@ export interface MoveCard {
   remediation: string
   /** The one concrete next step ("Your move"). Defaults from the submove action; AUTHORED may override. */
   action?: string
+  /** Authored real-life applications — how this move shows up in concrete situations. AUTHORED-only. */
+  applications?: { context: string; example: string }[]
 
   flavor?: string
   capabilities: Capability[] // latent; selected at consult time (faces are channel-agnostic)


### PR DESCRIPTION
Continues the **Allyship Deck Literacy** spec kit (`.specify/specs/allyship-deck-literacy/`). Phase 1 (glossary + inline deep links) already landed via #154; this PR delivers **P2, P3, and P5**. P4 (optional AI "apply to my situation") is intentionally deferred and will ship flagged-off later.

Goal: make the deck legible and actionable without a guidebook — deterministic-first, with any future AI strictly additive (honoring the AI-allergic community).

## P2 — "Your move" (the one concrete action)
- `MoveCard.action?` (optional), populated in `assemble.ts` from the canonical `SUBMOVES[move][operation].action` for all 120 cards (AUTHORED may override). No new hand-authored content — it surfaces what the grammar already encodes.
- `AllyshipCard` (full view): a distinct gold-accented **"Your move"** inset between the question and the existing "The practice" well (the one step now vs. the ongoing discipline).
- `buildDeckSeed`: the seeded BAR description now leads with `Your move: <action>` when present (both the plain and superpower-lens branches); provenance unchanged.

## P3 — Applications ("How this shows up in real life")
- `MoveCard.applications?: { context, example }[]` (AUTHORED-only), authored on four representative cards; more can be added with no code change.
- New `CardApplications` component: a collapsible disclosure showing authored examples, with a **deterministic fallback** derived from the card's own data (domain framing + the card's other reading) so it's never empty and never needs AI. This is the baseline the deferred P4 AI step will layer on top of.

## P5 — First-run orientation
- New `DeckOrientation` modal teaching the four ways to use the deck (daily card / read your situation / browse / collection), each routing straight into that view.
- `AllyshipDeckReader`: opens once via `localStorage['deck-orientation-seen']` (post-mount effect so SSR + hydration agree); a **"?"** button in the top bar re-opens it any time.

## Data regeneration
`public/allyship-deck/allyship-deck.json` regenerated via `npm run deck:assemble` — `action` on all 120 cards; `applications` on 4.

## Verification
This environment can't run the app or the full `npm run check` (Prisma's engine host is blocked by egress policy), so verification here is static + unit:
- `npm run deck:assemble` succeeds; `action`/`applications` confirmed present in the committed JSON.
- Node tests pass: `src/lib/allyship-deck/__tests__/seed.test.ts` (updated for the "Your move" lead) and `src/lib/superpowers/__tests__/translate.test.ts`.
- ESLint clean on all changed files; `tsc --noEmit` unchanged at the pre-existing baseline (zero new type errors).
- Full `build`/`check` run in CI.

Manual smoke (for a reviewer with the app running): draw a card → see "Your move" + expand "How this shows up in real life"; tap a term → `/deck/glossary#<id>`; first visit → orientation opens once, "?" re-opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaZKXKQFfqxfU5p9K8RZzb)_