### PR TITLE
Redesign SuperpowerReveal with dark OS aesthetic and Aligned Action bridge

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
 @import "../styles/cultivation-cards.css";
 @import "../styles/event-page.css";
 @import "../styles/promise-forge.css";
+@import "../styles/superpower-quiz.css";
 
 :root {
   --background: #ffffff;

--- a/src/app/superpower/page.tsx
+++ b/src/app/superpower/page.tsx
@@ -24,17 +24,54 @@ export default async function SuperpowerPage({
   const { ref } = await searchParams
 
   return (
-    <main className="mx-auto max-w-2xl px-4 py-10">
-      <header className="mx-auto mb-8 max-w-xl space-y-2">
-        <h1 className="text-2xl font-bold tracking-tight">Discover Your Allyship Superpower</h1>
-        <p className="text-sm opacity-80">
-          Twelve quick choices reveal how you ally — with yourself and with the world. There are
-          seven superpowers; you carry more than one. This is a lens for your next move, not a box.
-          No sign-up, no email — your result shows the moment you finish.
-        </p>
-      </header>
+    <main
+      className="flex min-h-screen justify-center"
+      style={{
+        background:
+          'radial-gradient(125% 85% at 50% -10%, #15110c 0%, var(--bars-bg-base) 60%)',
+        fontFamily: 'var(--bars-font-display)',
+      }}
+    >
+      <div className="flex w-full max-w-[460px] flex-col px-5 pb-14">
+        <header className="flex flex-col gap-[11px] pb-2 pt-[30px]">
+          <span
+            className="text-[10px] uppercase"
+            style={{
+              fontFamily: 'var(--bars-font-mono)',
+              letterSpacing: '.28em',
+              color: 'var(--bars-gold)',
+            }}
+          >
+            Superpower · Discovery Intake
+          </span>
+          <h1
+            className="text-[30px] font-bold"
+            style={{
+              fontFamily: 'var(--bars-font-display)',
+              letterSpacing: '-.02em',
+              lineHeight: 1.04,
+              color: 'var(--bars-text-primary)',
+              textWrap: 'balance',
+            }}
+          >
+            Discover Your Allyship Superpower
+          </h1>
+          <p
+            className="max-w-[380px] text-[13.5px]"
+            style={{
+              fontFamily: 'var(--bars-font-body)',
+              lineHeight: 1.55,
+              color: 'var(--bars-text-secondary)',
+            }}
+          >
+            Twelve quick choices reveal how you ally — with yourself and with the world. There are
+            seven superpowers; you carry more than one. A lens for your next move, not a box. No
+            sign-up, no email — your result shows the moment you finish.
+          </p>
+        </header>
 
-      <SuperpowerQuiz campaignRef={ref} />
+        <SuperpowerQuiz campaignRef={ref} />
+      </div>
     </main>
   )
 }

--- a/src/components/superpowers/SuperpowerQuiz.tsx
+++ b/src/components/superpowers/SuperpowerQuiz.tsx
@@ -7,9 +7,12 @@
  * items + the orientation question, then calls submitSuperpowerIntake (stateless
  * scoring — NO database, NO AI) and renders SuperpowerReveal. NO email gate.
  * Accessible: real <button>s, keyboard-operable, a labeled progress indicator.
- * UI_COVENANT: Tailwind for layout only.
+ *
+ * Styling: the dark "OS that contains cards" language (superpower-route handoff).
+ * All color flows through --bars-* tokens; motion via superpower-quiz.css.
+ * UI_COVENANT: Tailwind/inline for layout only — no hardcoded element hues.
  */
-import { useMemo, useState, useTransition } from 'react'
+import { useMemo, useState, useTransition, type CSSProperties } from 'react'
 import { QUIZ_ITEMS, ORIENTATION_ITEM } from '@/lib/superpowers/quiz/items'
 import { submitSuperpowerIntake } from '@/actions/superpower-intake'
 import type { QuizAnswer } from '@/lib/superpowers/quiz/types'
@@ -23,6 +26,10 @@ export interface SuperpowerQuizProps {
 }
 
 const TOTAL_STEPS = QUIZ_ITEMS.length + 1 // items + orientation
+
+const MONO: CSSProperties = { fontFamily: 'var(--bars-font-mono)' }
+const DISPLAY: CSSProperties = { fontFamily: 'var(--bars-font-display)' }
+const BODY: CSSProperties = { fontFamily: 'var(--bars-font-body)' }
 
 export function SuperpowerQuiz({ campaignRef }: SuperpowerQuizProps) {
   const [step, setStep] = useState(0)
@@ -71,99 +78,133 @@ export function SuperpowerQuiz({ campaignRef }: SuperpowerQuizProps) {
 
   if (outcome) {
     return (
-      <div className="space-y-4">
+      <div className="mt-6 flex flex-col gap-[18px]">
         <SuperpowerReveal routing={outcome.routing} copy={outcome.copy} />
-        <div className="mx-auto w-full max-w-xl">
-          <button
-            type="button"
-            onClick={restart}
-            className="text-xs underline opacity-70 hover:opacity-100"
-          >
-            Retake the quiz
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={restart}
+          className="sp-ghost self-start text-[10px] uppercase"
+          style={{ ...MONO, letterSpacing: '.16em', color: 'var(--bars-text-muted)' }}
+        >
+          ↺ Retake the quiz
+        </button>
       </div>
     )
   }
 
+  const current = Math.min(step + 1, TOTAL_STEPS)
+  const pct = Math.round((current / TOTAL_STEPS) * 100)
+
+  const options = item
+    ? item.options.map((opt) => ({ label: opt.label, onClick: () => chooseItemOption(opt.id) }))
+    : ORIENTATION_ITEM.options.map((opt) => ({
+        label: opt.label,
+        onClick: () => chooseOrientation(opt.orientation),
+      }))
+  const situation = item ? item.situation : ORIENTATION_ITEM.prompt
+
   return (
-    <div className="mx-auto w-full max-w-xl space-y-5">
-      <ProgressIndicator current={step + 1} total={TOTAL_STEPS} />
-
-      {item ? (
-        <fieldset className="space-y-3" disabled={pending}>
-          <legend className="text-base font-semibold leading-snug">{item.situation}</legend>
-          <div className="space-y-2">
-            {item.options.map((opt) => (
-              <button
-                key={opt.id}
-                type="button"
-                onClick={() => chooseItemOption(opt.id)}
-                className="block w-full rounded-lg border border-white/15 px-4 py-3 text-left text-sm hover:border-white/40 focus:outline-none focus:ring-2 focus:ring-white/40"
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </fieldset>
-      ) : (
-        <fieldset className="space-y-3" disabled={pending}>
-          <legend className="text-base font-semibold leading-snug">{ORIENTATION_ITEM.prompt}</legend>
-          <div className="space-y-2">
-            {ORIENTATION_ITEM.options.map((opt) => (
-              <button
-                key={opt.id}
-                type="button"
-                onClick={() => chooseOrientation(opt.orientation)}
-                className="block w-full rounded-lg border border-white/15 px-4 py-3 text-left text-sm hover:border-white/40 focus:outline-none focus:ring-2 focus:ring-white/40"
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </fieldset>
-      )}
-
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => setStep((s) => Math.max(0, s - 1))}
-          disabled={step === 0 || pending}
-          className="text-xs underline opacity-70 hover:opacity-100 disabled:opacity-30"
+    <div className="mt-[26px] flex flex-col gap-[22px]">
+      {/* Progress */}
+      <div className="flex flex-col gap-[7px]">
+        <div
+          className="flex items-baseline justify-between text-[10px] uppercase"
+          style={{ ...MONO, letterSpacing: '.18em', color: 'var(--bars-text-secondary)' }}
         >
-          ← Back
-        </button>
-        {pending ? <span className="text-xs opacity-70">Reading your spread…</span> : null}
+          <span>
+            Question {current} / {TOTAL_STEPS}
+          </span>
+          <span className="tabular-nums" style={{ color: 'var(--bars-gold)' }}>
+            {pct}%
+          </span>
+        </div>
+        <div
+          className="h-[3px] w-full overflow-hidden rounded-full"
+          style={{ background: 'rgba(255,255,255,0.07)', boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.4)' }}
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <span
+            className="block h-full rounded-full"
+            style={{
+              width: `${pct}%`,
+              background: 'var(--bars-gold)',
+              boxShadow: '0 0 10px -1px var(--bars-gold)',
+              transition: 'width .45s cubic-bezier(0.16,1,0.3,1)',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Question card */}
+      <fieldset key={`step-${step}`} className="sp-rise m-0 flex flex-col gap-4 border-0 p-0" disabled={pending}>
+        {isOrientationStep ? (
+          <span
+            className="text-[9.5px] uppercase"
+            style={{ ...MONO, letterSpacing: '.22em', color: 'var(--bars-liminal-glow)' }}
+          >
+            Final · Orientation
+          </span>
+        ) : null}
+        <legend
+          className="p-0 text-[21px] font-semibold"
+          style={{ ...DISPLAY, letterSpacing: '-.01em', lineHeight: 1.28, color: 'var(--bars-text-primary)' }}
+        >
+          {situation}
+        </legend>
+
+        <div className="flex flex-col gap-[10px]">
+          {options.map((opt, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={opt.onClick}
+              className="sp-opt w-full rounded-xl px-4 py-[15px] text-left text-[14.5px] font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+              style={{
+                ...BODY,
+                lineHeight: 1.45,
+                color: 'var(--bars-text-primary)',
+                background: 'var(--bars-surface-card)',
+                border: '1px solid var(--bars-line)',
+                boxShadow: 'inset 0 1px 0 var(--bars-inset-top)',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Footer nav */}
+      <div className="flex min-h-[18px] items-center justify-between">
+        {step > 0 ? (
+          <button
+            type="button"
+            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            disabled={pending}
+            className="sp-ghost text-[10px] uppercase disabled:opacity-40"
+            style={{ ...MONO, letterSpacing: '.16em', color: 'var(--bars-text-muted)' }}
+          >
+            ← Back
+          </button>
+        ) : (
+          <span />
+        )}
+        <span
+          className="text-[9.5px] uppercase"
+          style={{ ...MONO, letterSpacing: '.16em', color: 'var(--bars-text-muted)' }}
+        >
+          {pending ? 'Reading your spread…' : 'No sign-up · instant result'}
+        </span>
       </div>
 
       {error ? (
-        <p role="alert" className="text-sm text-red-400">
+        <p role="alert" className="text-sm" style={{ color: 'var(--bars-fire-gem)' }}>
           {error}
         </p>
       ) : null}
-    </div>
-  )
-}
-
-function ProgressIndicator({ current, total }: { current: number; total: number }) {
-  const pct = Math.round((Math.min(current, total) / total) * 100)
-  return (
-    <div className="space-y-1">
-      <div className="flex justify-between text-xs opacity-70">
-        <span>
-          Question {Math.min(current, total)} of {total}
-        </span>
-        <span className="tabular-nums">{pct}%</span>
-      </div>
-      <div
-        className="h-1.5 w-full overflow-hidden rounded bg-white/10"
-        role="progressbar"
-        aria-valuenow={pct}
-        aria-valuemin={0}
-        aria-valuemax={100}
-      >
-        <span className="block h-full bg-white/40" style={{ width: `${pct}%` }} />
-      </div>
     </div>
   )
 }

--- a/src/components/superpowers/SuperpowerReveal.tsx
+++ b/src/components/superpowers/SuperpowerReveal.tsx
@@ -2,18 +2,35 @@
 
 /**
  * SuperpowerReveal — the discovery result surface (campaign Phase 2, FR7;
- * quiz-design Phase 3, FR7/T3.2).
+ * quiz-design Phase 3, FR7/T3.2; superpower-route design handoff).
  *
- * Renders a scored result as a lens, not a verdict: primary + secondary + a
- * visible margin band + the primary's shadow + the mechanism disclosure. NO email
- * gate. UI_COVENANT: CultivationCard for the card aesthetic (element=color via the
- * superpower's channel; altitude=confidence), Tailwind for layout only — zero
- * hardcoded hex.
+ * Renders a scored result as a lens, not a verdict, in the dark "OS that
+ * contains cards" language:
+ *   a. primary card — element-coded (arc anchor, ADR 0002) with a floating
+ *      Wuxing sigil gem, the gift, and the shadow / at-best rows;
+ *   b. margin band — how close the runner-up sits;
+ *   c. Aligned Action bridge — the reserved liminal-purple treatment that routes
+ *      the taker from *finding* their superpower to *making one concrete move* in
+ *      The Crossing (their superpower lens on the campaign + a matched role move);
+ *   d. full spectrum — all seven ranked, so the result reads as a position;
+ *   e. framing note — lens, not verdict; the taker is the authority.
+ *
+ * NO email gate. All element color flows through --bars-* tokens (scoped via
+ * data-element). The liminal-purple action ramp is the reserved non-element
+ * action hue (see bars-tokens.css). UI_COVENANT: layout only in Tailwind/inline.
  */
 import Link from 'next/link'
-import { CultivationCard } from '@/components/ui/CultivationCard'
+import type { CSSProperties, ReactNode } from 'react'
 import { SUPERPOWER_DEFS } from '@/lib/superpowers/types'
-import { arcAnchorElement } from '@/lib/superpowers/arc'
+import { SUPERPOWER_TRANSLATION } from '@/lib/superpowers/matrix'
+import {
+  CROSSING_PATH,
+  crossingRoleHref,
+  superpowerNation,
+  superpowerSigil,
+  superpowerElement,
+  THE_CROSSING_HREF,
+} from '@/lib/superpowers/crossing-path'
 import type { SuperpowerRoutingResult } from '@/lib/superpowers/routing'
 import type { ResultCopy } from '@/lib/superpowers/quiz/descriptions'
 
@@ -27,99 +44,349 @@ const ORIENTATION_LABEL = {
   external: 'External — world-facing allyship',
 } as const
 
+const MONO: CSSProperties = { fontFamily: 'var(--bars-font-mono)' }
+const DISPLAY: CSSProperties = { fontFamily: 'var(--bars-font-display)' }
+const BODY: CSSProperties = { fontFamily: 'var(--bars-font-body)' }
+
+// Reserved liminal-purple action ramp (non-element; see bars-tokens.css).
+const PURPLE = { lite: '#a78bfa', chip: '#b794f6', deep: '#7c3aed', mid: '#8b5cf6', outline: '#cdbff5' }
+
 export function SuperpowerReveal({ routing, copy }: SuperpowerRevealProps) {
-  const primaryDef = SUPERPOWER_DEFS[routing.superpower]
+  const primary = routing.superpower
+  const primaryDef = SUPERPOWER_DEFS[primary]
   const secondaryDef = SUPERPOWER_DEFS[routing.secondary]
-  const marginPct = copy.marginPct
+  const element = superpowerElement(primary)
+
+  // The Aligned Action lens uses the chosen orientation; fall back to the
+  // world-facing lens when the orientation item was skipped.
+  const orientation = routing.orientation ?? 'external'
+  const cell = SUPERPOWER_TRANSLATION[primary][orientation]
+  const path = CROSSING_PATH[primary]
+
+  const marginWidth = `${Math.max(6, Math.min(100, copy.marginPct))}%`
 
   return (
-    <div className="mx-auto w-full max-w-xl space-y-5">
-      {/* Primary result card — frame uses the arc's neutral anchor element (a
-          superpower is not a single element; identity color is its accent — ADR 0002).
-          altitude = confidence. */}
-      <CultivationCard element={arcAnchorElement(primaryDef.arc)} altitude={routing.confident ? 'satisfied' : 'neutral'} stage="growing">
-        <div className="space-y-3 p-4">
-          <div className="flex items-baseline justify-between gap-3">
-            <h2 className="text-lg font-bold tracking-tight">{primaryDef.label}</h2>
-            {routing.orientation ? (
-              <span className="text-xs opacity-80">{ORIENTATION_LABEL[routing.orientation]}</span>
-            ) : null}
+    <div className="flex flex-col gap-[18px]">
+      <span
+        className="text-[10px] uppercase"
+        style={{ ...MONO, letterSpacing: '.26em', color: 'var(--bars-text-secondary)' }}
+      >
+        Your reading · primary lens
+      </span>
+
+      {/* a. Primary card — element-coded (arc anchor). altitude ≈ satisfied. */}
+      <div
+        data-element={element}
+        className="relative overflow-hidden rounded-[14px] p-5"
+        style={{
+          background: 'var(--bars-surface-card)',
+          boxShadow:
+            'inset 0 1px 0 var(--bars-inset-top), 0 0 0 2px var(--bars-element-frame), 0 0 28px -6px var(--bars-element-glow)',
+        }}
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(120% 80% at 88% -10%, color-mix(in srgb, var(--bars-element-glow) 16%, transparent) 0%, transparent 56%)',
+          }}
+        />
+        <div className="relative flex flex-col gap-[14px]">
+          <div className="flex items-start justify-between gap-[14px]">
+            <div className="flex min-w-0 flex-col gap-[7px]">
+              <span
+                className="text-[9.5px] uppercase"
+                style={{ ...MONO, letterSpacing: '.2em', color: 'var(--bars-element-gem)' }}
+              >
+                {superpowerNation(primary)}
+              </span>
+              <h2
+                className="text-[30px] font-bold"
+                style={{ ...DISPLAY, letterSpacing: '-.02em', lineHeight: 1, color: 'var(--bars-text-primary)' }}
+              >
+                {primaryDef.label}
+              </h2>
+              {routing.orientation ? (
+                <span
+                  className="text-[9px] uppercase"
+                  style={{ ...MONO, letterSpacing: '.12em', color: 'var(--bars-text-secondary)' }}
+                >
+                  {ORIENTATION_LABEL[routing.orientation]}
+                </span>
+              ) : null}
+            </div>
+            <span
+              aria-hidden
+              className="sp-float inline-flex h-[50px] w-[50px] flex-none items-center justify-center rounded-[14px] text-[24px]"
+              style={{
+                color: 'var(--bars-element-gem)',
+                background: 'color-mix(in srgb, var(--bars-element-frame) 22%, var(--bars-surface-inset))',
+                boxShadow:
+                  'inset 0 0 0 1px color-mix(in srgb, var(--bars-element-frame) 60%, transparent), 0 0 18px -4px var(--bars-element-glow)',
+                textShadow: '0 0 12px var(--bars-element-glow)',
+              }}
+            >
+              {superpowerSigil(primary)}
+            </span>
           </div>
 
-          <p className="text-sm leading-relaxed">{copy.primary.gift}</p>
-
-          {/* Shadow — included on purpose (anti-Barnum: favorability not equalized) */}
-          <p className="text-sm leading-relaxed opacity-80">
-            <span className="font-semibold">Shadow:</span> {copy.primary.shadow}
+          <p
+            className="text-[14.5px]"
+            style={{ ...BODY, lineHeight: 1.6, color: 'var(--bars-text-primary)' }}
+          >
+            {copy.primary.gift}
           </p>
-          <p className="text-sm leading-relaxed">
-            <span className="font-semibold">At your best:</span> {copy.primary.atBest}
-          </p>
-        </div>
-      </CultivationCard>
 
-      {/* Margin band + secondary ("try the adjacent one") */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between text-xs">
-          <span className="font-medium">{primaryDef.label}</span>
-          <span className="opacity-70">{secondaryDef.label}</span>
+          <div
+            className="flex flex-col gap-[9px] pt-[13px]"
+            style={{ borderTop: '1px solid var(--bars-line)' }}
+          >
+            <ProseRow label="Shadow">{copy.primary.shadow}</ProseRow>
+            <ProseRow label="At best">{copy.primary.atBest}</ProseRow>
+          </div>
         </div>
-        <MarginBar primary={primaryDef.label} marginPct={marginPct} />
-        <p className="text-sm opacity-90">{copy.tryAdjacent}</p>
+      </div>
+
+      {/* b. Margin band + secondary */}
+      <div
+        className="flex flex-col gap-[9px] rounded-xl px-4 py-[15px]"
+        style={{ background: 'var(--bars-surface-inset)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.03)' }}
+      >
+        <div
+          className="flex items-baseline justify-between text-[10px] uppercase"
+          style={{ ...MONO, letterSpacing: '.1em' }}
+        >
+          <span style={{ color: 'var(--bars-text-primary)' }}>{primaryDef.label}</span>
+          <span style={{ color: 'var(--bars-text-muted)' }}>{secondaryDef.label}</span>
+        </div>
+        <div
+          className="h-[6px] w-full overflow-hidden rounded-full"
+          style={{ background: 'rgba(255,255,255,0.06)' }}
+          role="img"
+          aria-label={`${primaryDef.label} leads by ${copy.marginPct} percent`}
+        >
+          <span
+            data-element={element}
+            className="block h-full rounded-full"
+            style={{
+              width: marginWidth,
+              background: 'var(--bars-element-gem)',
+              boxShadow: '0 0 8px -1px var(--bars-element-glow)',
+              transition: 'width .6s cubic-bezier(0.16,1,0.3,1)',
+            }}
+          />
+        </div>
+        <p className="text-[13px]" style={{ ...BODY, lineHeight: 1.5, color: 'var(--bars-text-secondary)' }}>
+          {copy.tryAdjacent}
+        </p>
         {!routing.confident ? (
-          <p className="text-xs opacity-70">
+          <p className="text-[12px]" style={{ ...BODY, lineHeight: 1.5, color: 'var(--bars-text-muted)' }}>
             These two are close — you may carry both. Read each and choose for yourself.
           </p>
         ) : null}
       </div>
 
-      {/* Full spectrum — all seven, so the result reads as a position, not a box */}
-      <details className="rounded-lg border border-white/10 p-3">
-        <summary className="cursor-pointer text-xs font-medium opacity-80">See your full spectrum</summary>
-        <ul className="mt-3 space-y-2">
-          {routing.ranked.map((r) => (
-            <li key={r.superpower} className="flex items-center gap-3 text-xs">
-              <span className="w-28 shrink-0">{SUPERPOWER_DEFS[r.superpower].label}</span>
-              <span className="h-1.5 flex-1 overflow-hidden rounded bg-white/10" aria-hidden="true">
-                <span className="block h-full bg-white/40" style={{ width: `${Math.round(r.pct * 100)}%` }} />
+      {/* c. Aligned Action bridge — reserved liminal-purple action treatment. */}
+      <div className="flex flex-col gap-[11px]">
+        <span
+          className="text-[10px] uppercase"
+          style={{ ...MONO, letterSpacing: '.24em', color: 'var(--bars-liminal-glow)' }}
+        >
+          Move into aligned action · live
+        </span>
+
+        <div
+          className="relative overflow-hidden rounded-2xl px-[18px] pb-[18px] pt-[19px]"
+          style={{
+            background: 'linear-gradient(168deg, #16111f 0%, #111110 52%)',
+            boxShadow:
+              'inset 0 1px 0 rgba(255,255,255,0.06), 0 0 0 1px rgba(124,58,237,0.30), 0 0 34px -10px rgba(124,58,237,0.55)',
+          }}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            style={{ background: 'radial-gradient(120% 80% at 90% -12%, rgba(124,58,237,0.22) 0%, transparent 55%)' }}
+          />
+          <div className="relative flex flex-col gap-[14px]">
+            <div className="flex flex-col gap-[6px]">
+              <span
+                className="text-[9.5px] uppercase"
+                style={{ ...MONO, letterSpacing: '.16em', color: PURPLE.lite }}
+              >
+                ◇ The Allyship Launch · Barn Raising
               </span>
-              <span className="w-9 shrink-0 text-right tabular-nums opacity-70">{Math.round(r.pct * 100)}%</span>
-            </li>
-          ))}
-        </ul>
+              <h3
+                className="text-[25px] font-bold"
+                style={{ ...DISPLAY, letterSpacing: '-.02em', lineHeight: 1, color: '#f4f2ec' }}
+              >
+                The Crossing
+              </h3>
+              <p
+                className="text-[13.5px]"
+                style={{ ...BODY, lineHeight: 1.5, color: 'var(--bars-text-secondary)' }}
+              >
+                Wendell needs a reliable car to keep showing up. Every superpower has a way in.
+              </p>
+            </div>
+
+            {/* Your lens on this campaign */}
+            <div
+              className="flex flex-col gap-[8px] rounded-xl px-[14px] py-[13px]"
+              style={{ background: 'rgba(124,58,237,0.07)', border: '1px solid rgba(124,58,237,0.18)' }}
+            >
+              <span
+                className="text-[9px] uppercase"
+                style={{ ...MONO, letterSpacing: '.14em', color: PURPLE.lite }}
+              >
+                Your {primaryDef.label} lens · {orientation === 'internal' ? 'self-allyship' : 'world-facing'}
+              </span>
+              <p
+                className="text-[16px] font-semibold"
+                style={{ ...DISPLAY, lineHeight: 1.32, letterSpacing: '-.01em', color: 'var(--bars-text-primary)' }}
+              >
+                {cell.prompt}
+              </p>
+              <p
+                className="text-[12.5px]"
+                style={{ ...BODY, lineHeight: 1.45, color: 'var(--bars-text-secondary)' }}
+              >
+                <span
+                  className="mr-[6px] text-[8.5px] uppercase"
+                  style={{ ...MONO, letterSpacing: '.14em', color: 'var(--bars-text-muted)' }}
+                >
+                  Make
+                </span>
+                {cell.suggestedArtifact}
+              </p>
+            </div>
+
+            {/* Matched move */}
+            <div className="flex items-start gap-3">
+              <span
+                aria-hidden
+                className="inline-flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[11px] text-center text-[9px] font-bold uppercase"
+                style={{
+                  ...MONO,
+                  letterSpacing: '.02em',
+                  lineHeight: 1.05,
+                  color: '#0a0908',
+                  background: `linear-gradient(150deg, ${PURPLE.chip}, ${PURPLE.deep})`,
+                  boxShadow: '0 8px 18px -10px #7c3aed',
+                }}
+              >
+                {path.abbr}
+              </span>
+              <div className="flex min-w-0 flex-col gap-[3px]">
+                <span
+                  className="text-[9px] uppercase"
+                  style={{ ...MONO, letterSpacing: '.14em', color: 'var(--bars-text-muted)' }}
+                >
+                  Your path · {path.roleLabel}
+                </span>
+                <span
+                  className="text-[13.5px] font-semibold"
+                  style={{ ...BODY, lineHeight: 1.42, color: 'var(--bars-text-primary)' }}
+                >
+                  {path.move}
+                </span>
+              </div>
+            </div>
+
+            <div className="mt-[2px] flex flex-wrap gap-[10px]">
+              <Link
+                href={crossingRoleHref(path.roleId)}
+                className="min-w-[170px] flex-1 rounded-[11px] px-4 py-3 text-center text-[14px] font-semibold no-underline"
+                style={{
+                  ...DISPLAY,
+                  color: '#fff',
+                  background: `linear-gradient(150deg, ${PURPLE.mid}, ${PURPLE.deep})`,
+                  boxShadow: '0 10px 26px -12px #7c3aed, inset 0 1px 0 rgba(255,255,255,0.18)',
+                }}
+              >
+                Take this move in The Crossing →
+              </Link>
+              <Link
+                href={THE_CROSSING_HREF}
+                className="flex-none rounded-[11px] px-4 py-3 text-center text-[14px] font-semibold no-underline"
+                style={{
+                  ...DISPLAY,
+                  color: PURPLE.outline,
+                  background: 'transparent',
+                  border: '1px solid rgba(124,58,237,0.42)',
+                }}
+              >
+                See all paths
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* d. Full spectrum — all seven ranked. */}
+      <details
+        className="overflow-hidden rounded-xl"
+        style={{ background: 'var(--bars-surface-card)', boxShadow: 'inset 0 1px 0 var(--bars-inset-top), 0 0 0 1px var(--bars-line)' }}
+      >
+        <summary
+          className="cursor-pointer list-none px-4 py-[14px] text-[10px] uppercase"
+          style={{ ...MONO, letterSpacing: '.16em', color: 'var(--bars-text-secondary)' }}
+        >
+          See your full spectrum ▾
+        </summary>
+        <div className="flex flex-col gap-[11px] px-4 pb-[17px] pt-[2px]">
+          {routing.ranked.map((r) => {
+            const pctStr = `${Math.round(r.pct * 100)}%`
+            return (
+              <div key={r.superpower} data-element={superpowerElement(r.superpower)} className="flex items-center gap-[11px]">
+                <span
+                  className="w-24 flex-none text-[13px] font-medium"
+                  style={{ ...DISPLAY, color: 'var(--bars-text-primary)' }}
+                >
+                  {SUPERPOWER_DEFS[r.superpower].label}
+                </span>
+                <span
+                  className="h-[5px] flex-1 overflow-hidden rounded-full"
+                  style={{ background: 'rgba(255,255,255,0.06)' }}
+                  aria-hidden
+                >
+                  <span
+                    className="block h-full rounded-full"
+                    style={{ width: pctStr, background: 'var(--bars-element-gem)', opacity: 0.85 }}
+                  />
+                </span>
+                <span
+                  className="w-[34px] flex-none text-right text-[10px] tabular-nums"
+                  style={{ ...MONO, color: 'var(--bars-text-secondary)' }}
+                >
+                  {pctStr}
+                </span>
+              </div>
+            )
+          })}
+        </div>
       </details>
 
-      {/* Mechanism disclosure — lens, not verdict; taker is the authority */}
-      <p className="text-xs leading-relaxed opacity-60">{copy.framing}</p>
-
-      {/* Next step — turn this superpower into a requestable offer */}
-      <div className="space-y-2 rounded-lg border border-white/10 p-4">
-        <p className="text-sm leading-relaxed">
-          <span className="font-semibold">Make it a move.</span> Turn{' '}
-          {primaryDef.label.toLowerCase().startsWith('the ') ? primaryDef.label : `the ${primaryDef.label}`} into a
-          scoped, consent-forward offer someone can actually request.
-        </p>
-        <Link
-          href="/forge"
-          className="inline-flex w-full items-center justify-center rounded-md bg-[var(--bars-liminal)] px-4 py-3 text-sm font-bold text-white shadow-[0_0_26px_-7px_var(--bars-liminal-glow),inset_0_1px_0_rgba(255,255,255,0.18)]"
-        >
-          Forge a promise move →
-        </Link>
-      </div>
+      {/* e. Framing — lens, not verdict. */}
+      <p className="text-[12px]" style={{ ...BODY, lineHeight: 1.6, color: 'var(--bars-text-muted)' }}>
+        {copy.framing}
+      </p>
     </div>
   )
 }
 
-/** Visual margin between primary and secondary, labeled for screen readers. */
-function MarginBar({ primary, marginPct }: { primary: string; marginPct: number }) {
-  const clamped = Math.max(0, Math.min(100, marginPct))
+/** A mono uppercase inline label (element-gem) followed by body prose. */
+function ProseRow({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div
-      className="h-2 w-full overflow-hidden rounded bg-white/10"
-      role="img"
-      aria-label={`${primary} leads by ${clamped} percent`}
-    >
-      <span className="block h-full bg-white/50" style={{ width: `${clamped}%` }} />
-    </div>
+    <p className="text-[13px]" style={{ ...BODY, lineHeight: 1.55, color: 'var(--bars-text-secondary)' }}>
+      <span
+        className="mr-[6px] text-[9.5px] uppercase"
+        style={{ ...MONO, letterSpacing: '.14em', color: 'var(--bars-element-gem)' }}
+      >
+        {label}
+      </span>
+      {children}
+    </p>
   )
 }

--- a/src/lib/superpowers/crossing-path.ts
+++ b/src/lib/superpowers/crossing-path.ts
@@ -1,0 +1,112 @@
+/**
+ * Reveal → Aligned Action data (superpower-route design handoff).
+ *
+ * Bridges a scored superpower to (a) its element channel + Wuxing nation label
+ * used to color the reveal card, and (b) its matched path in The Crossing — the
+ * live campaign — so a taker can move from *finding* their superpower to *making
+ * one concrete move* with minimal friction.
+ *
+ * The element channel is the arc's neutral anchor element (ADR 0002: a superpower
+ * is an arc, not a single Wuxing channel — this is a card-frame default, not an
+ * identity claim). The Crossing path map mirrors the real roles in
+ * `the-crossing-support-moves.ts`; if a role id changes, update it here.
+ */
+import type { Superpower } from './types'
+import { SUPERPOWER_DEFS } from './types'
+import { arcAnchorElement } from './arc'
+import type { ElementKey } from '@/lib/ui/card-tokens'
+import { ELEMENT_TOKENS } from '@/lib/ui/card-tokens'
+import type { TheCrossingSupportRoleId } from '@/lib/the-crossing-support-moves'
+
+/** Wuxing nation label per element (mirrors NATION_KEY_TO_ELEMENT). */
+const NATION_LABEL: Record<ElementKey, string> = {
+  fire: 'Pyrakanth · Fire',
+  water: 'Lamenth · Water',
+  wood: 'Virelune · Wood',
+  metal: 'Argyra · Metal',
+  earth: 'Meridia · Earth',
+}
+
+/** Element channel that colors a superpower's reveal card + sigil (arc anchor). */
+export function superpowerElement(sp: Superpower): ElementKey {
+  return arcAnchorElement(SUPERPOWER_DEFS[sp].arc)
+}
+
+/** The Wuxing glyph (火水木金土) for a superpower's element channel. */
+export function superpowerSigil(sp: Superpower): string {
+  return ELEMENT_TOKENS[superpowerElement(sp)].sigil
+}
+
+/** Nation eyebrow (e.g. "MERIDIA · EARTH") for a superpower's element channel. */
+export function superpowerNation(sp: Superpower): string {
+  return NATION_LABEL[superpowerElement(sp)]
+}
+
+/** A superpower's matched way in to The Crossing. */
+export interface CrossingPath {
+  /** Real role id in `the-crossing-support-moves.ts` — links to its detail page. */
+  roleId: TheCrossingSupportRoleId
+  /** Human role name as shown on the campaign. */
+  roleLabel: string
+  /** Short chip abbreviation for the matched-move badge. */
+  abbr: string
+  /** The one-tiny-move sentence this superpower can make right now. */
+  move: string
+}
+
+/**
+ * Superpower → matched Crossing path. Role ids are the real ones on the campaign
+ * (`car_scout`, `car_expert`, `connector`, `signal_booster`, `encourager`).
+ */
+export const CROSSING_PATH: Record<Superpower, CrossingPath> = {
+  connector: {
+    roleId: 'connector',
+    roleLabel: 'Connector',
+    abbr: 'Intro',
+    move: 'Make one warm introduction toward a car or funds.',
+  },
+  storyteller: {
+    roleId: 'signal_booster',
+    roleLabel: 'Signal Booster',
+    abbr: 'Boost',
+    move: 'Share the ask with one sentence on why it matters.',
+  },
+  strategist: {
+    roleId: 'car_scout',
+    roleLabel: 'Car Scout',
+    abbr: 'Scout',
+    move: 'Surface one concrete car lead Wendell can act on.',
+  },
+  disruptor: {
+    roleId: 'car_expert',
+    roleLabel: 'Car Expert',
+    abbr: 'Vet',
+    move: 'Pressure-test a listing — catch the bad deal before it happens.',
+  },
+  alchemist: {
+    roleId: 'encourager',
+    roleLabel: 'Encourager',
+    abbr: 'Tend',
+    move: 'Send one note that keeps the momentum — and the person — alive.',
+  },
+  escape_artist: {
+    roleId: 'car_expert',
+    roleLabel: 'Car Expert',
+    abbr: 'Off-ramp',
+    move: 'Call the honest go / no-go — name the off-ramp from a bad buy.',
+  },
+  coach: {
+    roleId: 'encourager',
+    roleLabel: 'Encourager',
+    abbr: 'Call up',
+    move: 'Send one note that calls someone up to their next step.',
+  },
+}
+
+/** Link to a role's detail page on The Crossing. */
+export function crossingRoleHref(roleId: TheCrossingSupportRoleId): string {
+  return `/campaign/the-crossing/role/${roleId}`
+}
+
+/** The Crossing campaign landing (the "See all paths" target). */
+export const THE_CROSSING_HREF = '/campaign/the-crossing'

--- a/src/styles/superpower-quiz.css
+++ b/src/styles/superpower-quiz.css
@@ -1,0 +1,51 @@
+/* /superpower — quiz + reveal motion and interaction states.
+ * Source: superpower-route design handoff. Aesthetic classes live here;
+ * layout stays Tailwind/inline. All color flows through --bars-* tokens.
+ */
+
+@keyframes sp-rise {
+  from { transform: translateY(9px); }
+  to   { transform: none; }
+}
+
+@keyframes sp-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-3px); }
+}
+
+/* Question / result entry — transform only (element must stay visible). */
+.sp-rise {
+  animation: sp-rise 0.42s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Floating sigil gem on the primary reveal card. */
+.sp-float {
+  animation: sp-float 5.5s ease-in-out infinite;
+}
+
+/* Option button hover/press. */
+.sp-opt {
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.08s ease;
+}
+.sp-opt:hover {
+  border-color: var(--bars-line-strong);
+  background: rgba(255, 255, 255, 0.025);
+}
+.sp-opt:active {
+  transform: scale(0.985);
+}
+
+/* Ghost mono buttons (Back / Retake). */
+.sp-ghost {
+  transition: color 0.2s ease;
+}
+.sp-ghost:hover {
+  color: var(--bars-text-primary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sp-rise,
+  .sp-float {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Redesigns the SuperpowerReveal component to match the "dark OS that contains cards" visual language from the superpower-route design handoff. Introduces the Aligned Action bridge—a liminal-purple treatment that routes users from discovering their superpower to making a concrete move in The Crossing campaign. Removes CultivationCard dependency in favor of custom element-coded cards with inline styling and CSS variables.

## Key Changes

**SuperpowerReveal.tsx**
- Replaced CultivationCard with custom primary card using `data-element` attribute for color scoping via `--bars-*` tokens
- Added floating Wuxing sigil gem with animation and glow effects
- Restructured card layout: nation eyebrow → superpower label → orientation → gift/shadow/at-best rows
- Redesigned margin band with animated progress bar and secondary superpower context
- **New: Aligned Action bridge** — reserved liminal-purple section that bridges discovery to action:
  - Shows The Crossing campaign context (Wendell's car need)
  - Displays superpower lens prompt based on orientation (internal/external)
  - Suggested artifact for the chosen orientation
  - Matched role move with abbreviation badge and direct link to role detail page
  - Two-button footer: primary action to take the move, secondary to see all paths
- Refactored full spectrum details section with element-scoped bars
- Added `ProseRow` helper component for consistent label + prose styling
- Introduced font family CSS variables (MONO, DISPLAY, BODY) for consistent typography
- Removed hardcoded hex colors; all element colors now flow through `--bars-element-*` tokens

**SuperpowerQuiz.tsx**
- Updated progress indicator with new visual treatment (gold bar, percentage display)
- Redesigned question card with `sp-rise` animation class
- Refactored option buttons with `sp-opt` class for hover/active states
- Updated footer navigation with mono uppercase labels
- Changed "Retake the quiz" button styling to match new ghost button aesthetic
- Added font family CSS variables for consistency

**crossing-path.ts** (new file)
- Bridges scored superpower to element channel and Crossing campaign path
- Exports `superpowerElement()`, `superpowerSigil()`, `superpowerNation()` helpers
- Defines `CROSSING_PATH` map: each superpower → matched role (connector, car_scout, car_expert, etc.)
- Provides `crossingRoleHref()` for linking to role detail pages
- Mirrors real role ids from the-crossing-support-moves.ts

**superpower-quiz.css** (new file)
- `@keyframes sp-rise` — entry animation for question cards (translateY + easing)
- `@keyframes sp-float` — continuous float animation for sigil gem
- `.sp-opt` — option button transitions (border, background, transform on hover/active)
- `.sp-ghost` — ghost button styling for Back/Retake links
- Respects `prefers-reduced-motion`

**superpower/page.tsx**
- Updated layout to full-height centered container with radial gradient background
- Increased max-width to 460px for better card presentation
- Redesigned header with mono eyebrow, larger display heading, and secondary body text
- All typography now uses CSS variable font families

**globals.css**
- Added import for new `superpower-quiz.css`

## Implementation Details

- **Color system**: All element colors scoped via `data-element` attribute and `--bars-element-*` tokens (gem, frame, glow). Liminal-purple action ramp uses reserved non-element hues (lite, chip, deep, mid, outline).
- **Typography**: Font families (mono, display, body) defined as inline CSSProperties objects and applied consistently across components.
- **Motion**: Animations defined in CSS with cubic-bezier easing; respects prefers-reduced-motion.
- **Accessibility**: Margin bar uses `role="img"` with aria-label; progress bar uses `role="progressbar"` with aria-valuenow; all buttons keyboard-operable.
- **No email gate**: Instant result display; no authentication

https://claude.ai/code/session_017BTas3TKJ4fPr2ag3pjNux