### PR TITLE
Fix deck sign-in redirect and full-hand Send to BARS

### DIFF
--- a/src/actions/send-deck-card-to-bars.ts
+++ b/src/actions/send-deck-card-to-bars.ts
@@ -13,9 +13,10 @@ import {
   PENDING_DECK_TTL_MS,
 } from '@/lib/deck-pending-intent'
 import type { SeedSubject } from '@/lib/allyship-deck/seed'
+import type { OverflowContext } from '@/lib/hand-service'
 
 export type SendDeckCardResult =
-  | { success: true; barId: string; placedInHand: boolean }
+  | { success: true; barId: string; placedInHand: boolean; overflow?: OverflowContext }
   | { needsAuth: true; pendingToken: string }
   | { error: string }
 

--- a/src/app/deck/page.tsx
+++ b/src/app/deck/page.tsx
@@ -27,6 +27,7 @@ export default async function DeckPage() {
         authed={access.authed}
         learnMoreHref="/deck/sales"
         learnMoreLabel="What's in the deck?"
+        returnTo="/deck"
       />
     )
   }

--- a/src/components/deck/SendToBarsButton.tsx
+++ b/src/components/deck/SendToBarsButton.tsx
@@ -3,9 +3,11 @@
 import { useState, useTransition, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
 import { sendDeckCardToBars } from '@/actions/send-deck-card-to-bars'
+import { resolveOverflow } from '@/actions/hand'
 import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
 import { DECK_FONTS, DECK_GOLD, LIMINAL } from '@/lib/allyship-deck/card-visuals'
 import type { MoveCard } from '@/lib/allyship-deck/types'
+import type { OverflowContext } from '@/lib/hand-service'
 import type { CardSubject } from './AllyshipCard'
 
 /**
@@ -19,6 +21,8 @@ import type { CardSubject } from './AllyshipCard'
  * default, but the per-card choice wins.
  *
  * - Logged in → the BAR lands in the Hand; we route to NOW home (`/`).
+ * - Logged in, Hand full → we never let it land silently: an overflow sheet asks
+ *   which Hand card to compost back to the Vault to make room for this one.
  * - Logged out → no dead end: the intent is captured server-side and we route to
  *   MGA signup; the BAR is materialized after the account is created.
  * - Genuine failures → inline message (never "Not logged in").
@@ -39,6 +43,9 @@ export function SendToBarsButton({
   // The reading the player wants to work the card through — defaults to the
   // page's subject toggle, then becomes a deliberate per-card choice.
   const [reading, setReading] = useState<CardSubject>(subject)
+  // Set when the Hand is full: the new BAR waits in the Vault and the player
+  // picks a Hand card to compost back to the Vault to make room.
+  const [overflow, setOverflow] = useState<OverflowContext | null>(null)
 
   const send = (chosen: CardSubject) => {
     setError(null)
@@ -48,10 +55,39 @@ export function SendToBarsButton({
         router.push('/signup?returnTo=/deck')
       } else if ('error' in res) {
         setError(res.error)
+      } else if (res.placedInHand) {
+        router.push('/')
+      } else if (res.overflow) {
+        // Hand full — don't let the BAR land silently in the Vault. Close the
+        // reading sheet and ask which Hand card to compost to make room.
+        setChoosing(false)
+        setOverflow(res.overflow)
       } else {
+        // Placed in the Vault with no room to swap into — still a real BAR.
         router.push('/')
       }
     })
+  }
+
+  // Compost the chosen Hand card to the Vault; the new BAR takes the freed slot.
+  const compostForRoom = (depositBarId: string) => {
+    if (!overflow) return
+    setError(null)
+    startTransition(async () => {
+      const res = await resolveOverflow({ newBarId: overflow.newBarId, depositBarId })
+      if ('error' in res) {
+        setError(res.error)
+        return
+      }
+      setOverflow(null)
+      router.push('/')
+    })
+  }
+
+  // Decline the swap — the new BAR stays safe in the Vault.
+  const keepInVault = () => {
+    setOverflow(null)
+    router.push('/')
   }
 
   return (
@@ -81,10 +117,122 @@ export function SendToBarsButton({
         />
       )}
 
+      {overflow && (
+        <OverflowChooser
+          overflow={overflow}
+          pending={pending}
+          error={error}
+          onCompost={compostForRoom}
+          onKeepInVault={keepInVault}
+        />
+      )}
+
       {/* Inline error also shown outside the sheet (e.g. if it was dismissed). */}
-      {!choosing && error && (
+      {!choosing && !overflow && error && (
         <p style={errorText}>{error}</p>
       )}
+    </div>
+  )
+}
+
+/**
+ * The "your Hand is full" prompt. The new BAR is already safe in the Vault; the
+ * player composts one of the six Hand cards back to the Vault to carry this one
+ * instead — or keeps it in the Vault. Mirrors the NOW-home capture overflow flow
+ * (see `CaptureBox`), styled for the deck surface.
+ */
+function OverflowChooser({
+  overflow,
+  pending,
+  error,
+  onCompost,
+  onKeepInVault,
+}: {
+  overflow: OverflowContext
+  pending: boolean
+  error: string | null
+  onCompost: (depositBarId: string) => void
+  onKeepInVault: () => void
+}) {
+  return (
+    <div
+      onClick={onKeepInVault}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 60,
+        background: 'rgba(5,4,3,.78)',
+        backdropFilter: 'blur(6px)',
+        WebkitBackdropFilter: 'blur(6px)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 'min(440px, 100%)',
+          margin: '0 auto',
+          background: SURFACE_TOKENS.surfaceElevated,
+          borderRadius: 18,
+          padding: 20,
+          boxShadow: 'inset 0 1px 0 rgba(255,255,255,.06), 0 24px 48px -16px rgba(0,0,0,.9)',
+        }}
+      >
+        <p style={{ ...kicker, color: '#e0a0a0' }}>Hand full · 6 / 6</p>
+        <h3 style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 19, color: '#fff', margin: '4px 0 2px' }}>
+          Make room for this BAR
+        </h3>
+        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 12.5, color: SURFACE_TOKENS.textSecondary, margin: '0 0 16px', lineHeight: 1.5 }}>
+          “{overflow.newBarTitle}” is safe in your Vault. Compost a card from your
+          Hand back to the Vault to carry this one instead.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 260, overflowY: 'auto' }}>
+          {overflow.currentHand.map((item) => (
+            <button
+              key={item.barId}
+              type="button"
+              onClick={() => onCompost(item.barId)}
+              disabled={pending}
+              style={{
+                textAlign: 'left',
+                cursor: pending ? 'not-allowed' : 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 11,
+                padding: '11px 13px',
+                borderRadius: 12,
+                background: SURFACE_TOKENS.surfaceInset,
+                border: '1px solid rgba(255,255,255,.12)',
+                opacity: pending ? 0.5 : 1,
+                transition: 'border-color .15s',
+              }}
+            >
+              <span style={{ flex: '0 0 auto', width: 8, height: 8, borderRadius: '50%', background: DECK_GOLD, boxShadow: `0 0 7px 1px ${DECK_GOLD}88` }} />
+              <span style={{ flex: 1, minWidth: 0, fontFamily: DECK_FONTS.body, fontSize: 13, color: '#fff', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {item.title}
+              </span>
+              <span style={{ flex: '0 0 auto', fontFamily: DECK_FONTS.mono, fontSize: 9, letterSpacing: '0.08em', textTransform: 'uppercase', color: SURFACE_TOKENS.textMuted }}>
+                → Vault
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {error && <p style={errorText}>{error}</p>}
+
+        <button
+          type="button"
+          onClick={onKeepInVault}
+          disabled={pending}
+          style={{ ...ghostBtn, width: '100%', marginTop: 14, textAlign: 'center' }}
+        >
+          Keep it in the Vault
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/launch/Paywall.tsx
+++ b/src/components/launch/Paywall.tsx
@@ -12,6 +12,7 @@ export function Paywall({
   authed,
   learnMoreHref,
   learnMoreLabel,
+  returnTo,
 }: {
   title: string
   message?: string
@@ -19,7 +20,10 @@ export function Paywall({
   /** Optional top-of-funnel link (e.g. a Sales page) for visitors who want the pitch first. */
   learnMoreHref?: string
   learnMoreLabel?: string
+  /** Where to send the visitor back after they sign in (e.g. this gated surface). */
+  returnTo?: string
 }) {
+  const signInHref = returnTo ? `/login?returnTo=${encodeURIComponent(returnTo)}` : '/login'
   return (
     <main className="min-h-screen bg-[#0a0908] px-4 py-16">
       <div className="mx-auto max-w-md space-y-8 text-center">
@@ -59,7 +63,7 @@ export function Paywall({
         {!authed && (
           <p className="text-xs text-[#6b6965]">
             Already bought it?{' '}
-            <Link href="/login" className="text-purple-400 underline-offset-2 hover:underline">
+            <Link href={signInHref} className="text-purple-400 underline-offset-2 hover:underline">
               Sign in
             </Link>{' '}
             to unlock.

--- a/src/lib/deck-bar.ts
+++ b/src/lib/deck-bar.ts
@@ -14,7 +14,7 @@ import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
 import { assembleDeck } from '@/lib/allyship-deck/assemble'
 import { buildDeckSeed, type SeedSubject } from '@/lib/allyship-deck/seed'
-import { addBarToHandForPlayer } from '@/lib/hand-service'
+import { addBarToHandForPlayer, type OverflowContext } from '@/lib/hand-service'
 import {
   PENDING_DECK_COOKIE,
   verifyPendingIntent,
@@ -22,7 +22,7 @@ import {
 import type { AllyshipDeck, MoveCard } from '@/lib/allyship-deck/types'
 
 export type MaterializeResult =
-  | { success: true; barId: string; placedInHand: boolean }
+  | { success: true; barId: string; placedInHand: boolean; overflow?: OverflowContext }
   | { error: string }
 
 /** Authoritative deck, assembled deterministically (no AI/DB) and memoized per process. */
@@ -74,16 +74,20 @@ export async function materializeDeckBar(
       },
     })
 
-    // Try to drop it straight into the Hand; if full, it stays in the Vault.
+    // Try to drop it straight into the Hand. If the Hand is full, the BAR waits
+    // in the Vault and we hand the caller an OverflowContext so it can offer to
+    // compost a Hand card to the Vault to make room (never a silent landing).
     const placed = await addBarToHandForPlayer(playerId, bar.id)
     const placedInHand = 'success' in placed && placed.success === true
+    const overflow =
+      'success' in placed && placed.success === false ? placed.overflow : undefined
 
     revalidatePath('/')
     revalidatePath('/vault')
     revalidatePath('/bars')
     revalidatePath('/hand')
 
-    return { success: true, barId: bar.id, placedInHand }
+    return { success: true, barId: bar.id, placedInHand, overflow }
   } catch (e) {
     return { error: e instanceof Error ? e.message : 'Failed to send to BARS' }
   }


### PR DESCRIPTION
## Summary

Two fixes for the `/deck` product surface:

### 1. Sign-in now redirects back to `/deck`
When a locked visitor tapped **"Sign in to unlock"** on the deck Paywall, the link pointed at bare `/login` with no `returnTo`, so `loginMga`/`signupMga` fell back to NOW home (`/`) — the player never landed on the deck they were trying to unlock.

- `Paywall` gains an optional `returnTo` prop and builds its sign-in link as `/login?returnTo=<encoded>`.
- `/deck` passes `returnTo="/deck"`. `/login` already honors a safe `returnTo` via `isSafeAppPath`, so the player now lands back on the deck after signing in.

### 2. A full hand no longer silently swallows the BAR
Sending a deck card to BARS with a full Hand let the BAR land in the Vault with **no feedback** — `materializeDeckBar` discarded the overflow signal and returned `placedInHand: false`.

- `materializeDeckBar` now surfaces the `OverflowContext` (the six cards occupying the Hand) when the Hand is full.
- `sendDeckCardToBars`'s result type carries the optional `overflow` through.
- `SendToBarsButton` opens an overflow sheet listing the current Hand cards; picking one composts it back to the Vault (via the existing `resolveOverflow` action) and the new BAR takes the freed slot. **"Keep it in the Vault"** declines. This mirrors the established NOW-home capture overflow flow in `CaptureBox`.

The logged-out → signup path (and the login/signup pending-claim path) still parks a BAR in the Vault when the Hand is full — there's no interactive surface there to resolve a swap, which is the existing, correct behavior.

## Files changed
- `src/components/launch/Paywall.tsx` — optional `returnTo` prop → `signInHref`
- `src/app/deck/page.tsx` — pass `returnTo="/deck"`
- `src/lib/deck-bar.ts` — `materializeDeckBar` surfaces `OverflowContext`
- `src/actions/send-deck-card-to-bars.ts` — result type carries `overflow`
- `src/components/deck/SendToBarsButton.tsx` — overflow/compost sheet + `resolveOverflow`

## Testing
`tsc --noEmit` reports zero errors in all five changed files. A full `npm run check` could not run in the dev environment because the proxy blocks Prisma's engine binary download, so the Prisma client can't be generated (all other tsc errors cascade from that missing client and are unrelated to this change). CI should exercise the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYm1USruZVRv79o86jXgea)_