### PR TITLE
[codex] Add Myths Read campaign seed flow

### DIFF
--- a/.specify/specs/myths-read-diagnostic/plan.md
+++ b/.specify/specs/myths-read-diagnostic/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan
+
+## Phase 1: Public Quiz Slice
+
+- Add canonical myth/item data and a deterministic scorer in `src/lib/mastering-allyship`.
+- Add focused scorer tests.
+- Add a client quiz component under `src/app/mastering-allyship/myths-read`.
+- Add a public route page with metadata.
+
+## Phase 2: Verification
+
+- Run the focused scorer test.
+- Run route validation or type checking where feasible.
+
+## Phase 3: Follow-up
+
+- Apply the `myth_reads` migration in shared environments.
+- Wire the Chapter 0 manuscript/page pointer to this route once its source location is confirmed.
+- Replace the generic seeded BAR redirect with exact single-player campaign scene routes once confirmed.

--- a/.specify/specs/myths-read-diagnostic/spec.md
+++ b/.specify/specs/myths-read-diagnostic/spec.md
@@ -1,0 +1,24 @@
+# Myths Read Diagnostic
+
+## Requirements
+
+- Add a public `Myths Read` diagnostic for Chapter 0 of Mastering the Game of Allyship.
+- Present the flow as intro, twelve behavioral questions, and a result screen.
+- Score answers exactly from the handoff: weighted raw/max/pct, peak tie-break, canonical order, floor rule, and strength labels.
+- Result must show surfaced myth cards, a whole-board map, Emotional Alchemy charge capture, funnel CTAs, optional email save, and retake.
+- Charge capture must ask what game the player wants to play with the emerged energy; do not route by emotion alone.
+- Supported game doors: Shaman / Emotional Alchemy, Challenger / MythBusting, Regent / Map the Terrain, Architect / Build The System, Diplomat / RelationshipCraft, Sage / Build your own Allyship Campaign.
+- Keep belief roots internal and do not display them on the result screen.
+
+## Acceptance Criteria
+
+- A visitor can open the route, start the quiz, answer all twelve items, and land on results.
+- Back preserves answers.
+- Result surfaces at least one myth and no more than three, with rank, strength, claim, diagnosis, chapter, and one move.
+- Selecting a surfaced myth and charge flavor/intensity reveals a seeded BAR summary and a route label.
+- Optional email save validates for `@` and swaps to a confirmation.
+- The page links to the Allyship Deck sales surface, the Superpower quiz, and the book/manual path.
+
+## Deferred
+
+- Routing into exact live campaign scenes remains a follow-up once route targets are confirmed. The current slice saves the read and can seed a logged-in visitor's `charge_capture` BAR with the selected game face.

--- a/.specify/specs/myths-read-diagnostic/tasks.md
+++ b/.specify/specs/myths-read-diagnostic/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Add Myths Read data and scorer.
+- [x] Add scorer tests for cross-loads, floor rule, and tie order.
+- [x] Add interactive quiz/result client component.
+- [x] Add `/mastering-allyship/myths-read` route page.
+- [x] Add `myth_reads` schema and migration.
+- [x] Wire save/metabolize actions to persist reads and seed logged-in charge BARs.
+- [x] Add GM-face game selection as the routing vector after myth/charge/intensity.
+- [x] Verify focused tests.
+- [x] Note deferred persistence/routing work.

--- a/prisma/migrations/20260702204000_add_myth_read/migration.sql
+++ b/prisma/migrations/20260702204000_add_myth_read/migration.sql
@@ -1,0 +1,34 @@
+-- Myths Read diagnostic persistence for the Mastering the Game of Allyship
+-- Chapter 0 funnel. Standalone enough for anonymous visitors; optionally links
+-- to a Player and to the seeded BAR created from the charge capture.
+CREATE TABLE "myth_reads" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "email" TEXT,
+    "source" TEXT NOT NULL DEFAULT 'mastering-allyship-ch0',
+    "responses" JSONB NOT NULL,
+    "mythScores" JSONB NOT NULL,
+    "topMyths" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "rootBeliefs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "recommendedDestinations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "capturedCharge" JSONB,
+    "seedBarDrafts" JSONB,
+    "ctaPrimary" TEXT NOT NULL DEFAULT 'deck',
+    "consent" BOOLEAN NOT NULL DEFAULT false,
+    "createdBarId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "myth_reads_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "myth_reads_userId_createdAt_idx" ON "myth_reads"("userId", "createdAt");
+CREATE INDEX "myth_reads_email_idx" ON "myth_reads"("email");
+CREATE INDEX "myth_reads_source_createdAt_idx" ON "myth_reads"("source", "createdAt");
+
+ALTER TABLE "myth_reads"
+    ADD CONSTRAINT "myth_reads_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "players"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "myth_reads"
+    ADD CONSTRAINT "myth_reads_createdBarId_fkey"
+    FOREIGN KEY ("createdBarId") REFERENCES "custom_bars"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,6 +130,7 @@ model Player {
   contributionRecords            ContributionRecord[]        @relation("PlayerContributions")
   claimedBars                    CustomBar[]                 @relation("ClaimedBars")
   createdBars                    CustomBar[]                 @relation("CreatedBars")
+  mythReads                      MythRead[]
   daemonSummons                  DaemonSummon[]
   daemons                        Daemon[]
   daemonPromotedFrom             Daemon?                     @relation("DaemonPromotedToNpc")
@@ -452,6 +453,7 @@ model CustomBar {
   spokeMoveBedKernelRows               SpokeMoveBedKernel?    @relation("SpokeMoveBedKernelBar")
   spokeMoveBedKernelSources            SpokeMoveBedKernel[]   @relation("SpokeMoveBedKernelSource")
   spokeMoveBedAnchor                   SpokeMoveBed?          @relation("SpokeMoveBedAnchor")
+  mythReadsCreated                     MythRead[]             @relation("MythReadCreatedBar")
   threadQuests                         ThreadQuest[]
   handSlots                            HandSlot[]
 
@@ -4608,4 +4610,32 @@ model FunnelSignup {
   @@index([intent, createdAt])
   @@index([email])
   @@map("funnel_signups")
+}
+
+/// Myths Read diagnostic — public Chapter 0 quiz result, optionally linked to
+/// a logged-in player and/or a spawned seeded BAR.
+model MythRead {
+  id                      String     @id @default(cuid())
+  userId                  String?
+  email                   String?
+  source                  String     @default("mastering-allyship-ch0")
+  responses               Json
+  mythScores              Json
+  topMyths                String[]
+  rootBeliefs             String[]   @default([])
+  recommendedDestinations String[]   @default([])
+  capturedCharge          Json?
+  seedBarDrafts           Json?
+  ctaPrimary              String     @default("deck")
+  consent                 Boolean    @default(false)
+  createdBarId            String?
+  createdAt               DateTime   @default(now())
+
+  user       Player?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  createdBar CustomBar? @relation("MythReadCreatedBar", fields: [createdBarId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([email])
+  @@index([source, createdAt])
+  @@map("myth_reads")
 }

--- a/src/actions/myths-read.ts
+++ b/src/actions/myths-read.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
+import type { Prisma } from '@prisma/client'
 import { getCurrentPlayer } from '@/lib/auth'
 import { mergeSeedMetabolization } from '@/lib/bar-seed-metabolization/parse'
 import {
@@ -103,7 +104,7 @@ export async function saveMythRead(input: {
             intensity: String(capturedCharge.intensity),
             seedMetabolization: mergeSeedMetabolization(null, {
               maturity: 'captured',
-              soilKind: 'myths_read',
+              soilKind: 'holding_pen',
               contextNote: `${myth.short} · ${flavor.label} · ${intensityLabel}`,
             }),
             agentMetadata: JSON.stringify({
@@ -135,8 +136,10 @@ export async function saveMythRead(input: {
           topMyths: payload.topMyths,
           rootBeliefs: payload.rootBeliefs,
           recommendedDestinations: payload.recommendedDestinations,
-          capturedCharge: payload.capturedCharge,
-          seedBarDrafts: payload.seedBarDrafts,
+          ...(payload.capturedCharge
+            ? { capturedCharge: payload.capturedCharge as unknown as Prisma.InputJsonValue }
+            : {}),
+          seedBarDrafts: payload.seedBarDrafts as unknown as Prisma.InputJsonValue,
           ctaPrimary: 'deck',
           consent: Boolean(input.consent),
           createdBarId: barId,

--- a/src/actions/myths-read.ts
+++ b/src/actions/myths-read.ts
@@ -1,0 +1,209 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { db } from '@/lib/db'
+import { getCurrentPlayer } from '@/lib/auth'
+import { mergeSeedMetabolization } from '@/lib/bar-seed-metabolization/parse'
+import {
+  MYTH_BY_ID,
+  MYTH_CHARGE_FLAVORS,
+  MYTH_GAME_FACES,
+  MYTH_READ_ITEMS,
+  buildMythReadPersistencePayload,
+  type MythChargeIntensity,
+  type MythGameFaceKey,
+  type MythReadAnswerValue,
+  type MythReadCharge,
+  type MythReadItem,
+} from '@/lib/mastering-allyship/myths-read'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export type SaveMythReadState =
+  | { ok: true; mythReadId: string; barId: string | null; redirectTo: string }
+  | { ok: false; error: string }
+
+export async function saveMythRead(input: {
+  answers: Partial<Record<MythReadItem['id'], MythReadAnswerValue>>
+  email?: string
+  consent?: boolean
+  source?: string
+  capturedCharge?: MythReadCharge | null
+  gameFace?: MythGameFaceKey | null
+  createSeedBar?: boolean
+}): Promise<SaveMythReadState> {
+  const answers = normalizeAnswers(input.answers)
+  if (Object.keys(answers).length < MYTH_READ_ITEMS.length) {
+    return { ok: false, error: 'Finish the read before saving it.' }
+  }
+
+  const email = input.email?.trim().toLowerCase() || null
+  if (email && !EMAIL_RE.test(email)) {
+    return { ok: false, error: 'Please enter a valid email.' }
+  }
+
+  const gameFace = normalizeGameFace(input.gameFace ?? input.capturedCharge?.gameFace)
+  const capturedCharge = normalizeCharge(
+    input.capturedCharge ? { ...input.capturedCharge, gameFace } : null,
+  )
+  if (input.createSeedBar && !capturedCharge) {
+    return { ok: false, error: 'Choose a myth, flavor, and intensity before metabolizing.' }
+  }
+  if (input.createSeedBar && !gameFace) {
+    return { ok: false, error: 'Choose the game you want to play with this energy.' }
+  }
+
+  const player = await getCurrentPlayer()
+  const payload = buildMythReadPersistencePayload(answers, capturedCharge)
+  const source = input.source?.trim().slice(0, 120) || 'mastering-allyship-ch0'
+
+  try {
+    const created = await db.$transaction(async (tx) => {
+      let barId: string | null = null
+
+      if (input.createSeedBar && capturedCharge && player) {
+        const myth = MYTH_BY_ID[capturedCharge.mythId]
+        const flavor = MYTH_CHARGE_FLAVORS.find((entry) => entry.key === capturedCharge.flavor)!
+        const game = MYTH_GAME_FACES.find((entry) => entry.key === gameFace)!
+        const intensityLabel = intensityToLabel(capturedCharge.intensity)
+        const title = `${game.gameName}: ${myth.short}`.slice(0, 80)
+        const description = [
+          `"${myth.claim}"`,
+          '',
+          `Charge: ${flavor.label.toLowerCase()} at ${intensityLabel.toLowerCase()} strength.`,
+          `Game: ${game.gameName} (${game.face}).`,
+          `Next step: ${game.nextStep}`,
+          '',
+          myth.move,
+        ].join('\n')
+
+        const bar = await tx.customBar.create({
+          data: {
+            creatorId: player.id,
+            title,
+            description,
+            type: 'charge_capture',
+            reward: 0,
+            visibility: 'private',
+            status: 'active',
+            inputs: JSON.stringify({
+              source: 'myths_read',
+              mythId: myth.id,
+              mythShort: myth.short,
+              flavor: capturedCharge.flavor,
+              intensity: capturedCharge.intensity,
+              gameFace: game.key,
+              gameName: game.gameName,
+              nextStep: game.nextStep,
+            }),
+            rootId: 'temp',
+            questSource: 'myths_read',
+            campaignRef: 'mastering-allyship',
+            emotionalAlchemyTag: capturedCharge.flavor,
+            intensity: String(capturedCharge.intensity),
+            seedMetabolization: mergeSeedMetabolization(null, {
+              maturity: 'captured',
+              soilKind: 'myths_read',
+              contextNote: `${myth.short} · ${flavor.label} · ${intensityLabel}`,
+            }),
+            agentMetadata: JSON.stringify({
+              schemaVersion: 'myths-read.v1',
+              source,
+              mythId: myth.id,
+              flavor: capturedCharge.flavor,
+              intensity: capturedCharge.intensity,
+              gameFace: game.key,
+              gameName: game.gameName,
+              nextStep: game.nextStep,
+              savedAt: new Date().toISOString(),
+            }),
+          },
+          select: { id: true },
+        })
+
+        barId = bar.id
+        await tx.customBar.update({ where: { id: barId }, data: { rootId: barId } })
+      }
+
+      const mythRead = await tx.mythRead.create({
+        data: {
+          userId: player?.id ?? null,
+          email,
+          source,
+          responses: payload.responses,
+          mythScores: payload.mythScores,
+          topMyths: payload.topMyths,
+          rootBeliefs: payload.rootBeliefs,
+          recommendedDestinations: payload.recommendedDestinations,
+          capturedCharge: payload.capturedCharge,
+          seedBarDrafts: payload.seedBarDrafts,
+          ctaPrimary: 'deck',
+          consent: Boolean(input.consent),
+          createdBarId: barId,
+        },
+        select: { id: true },
+      })
+
+      return { mythReadId: mythRead.id, barId }
+    })
+
+    revalidatePath('/mastering-allyship/myths-read')
+    if (created.barId) {
+      revalidatePath('/vault')
+      revalidatePath('/bars/garden')
+    }
+
+    return {
+      ok: true,
+      mythReadId: created.mythReadId,
+      barId: created.barId,
+      redirectTo: created.barId
+        ? `/bars/${created.barId}?source=myths-read`
+        : `/login?next=${encodeURIComponent('/mastering-allyship/myths-read')}`,
+    }
+  } catch (err) {
+    console.error('[myths-read] failed to save read', err)
+    return { ok: false, error: 'Something went wrong saving that read. Please try again.' }
+  }
+}
+
+function normalizeAnswers(
+  answers: Partial<Record<MythReadItem['id'], MythReadAnswerValue>>,
+): Partial<Record<MythReadItem['id'], MythReadAnswerValue>> {
+  const normalized: Partial<Record<MythReadItem['id'], MythReadAnswerValue>> = {}
+  for (const item of MYTH_READ_ITEMS) {
+    const value = answers[item.id]
+    if (value === 0 || value === 1 || value === 2 || value === 3 || value === 4) {
+      normalized[item.id] = value
+    }
+  }
+  return normalized
+}
+
+function normalizeCharge(charge: MythReadCharge | null | undefined): MythReadCharge | null {
+  if (!charge) return null
+  if (!MYTH_BY_ID[charge.mythId]) return null
+  if (!MYTH_CHARGE_FLAVORS.some((entry) => entry.key === charge.flavor)) return null
+  if (![2, 4, 6, 8, 10].includes(charge.intensity)) return null
+  return charge
+}
+
+function normalizeGameFace(gameFace: MythGameFaceKey | null | undefined): MythGameFaceKey | null {
+  if (!gameFace) return null
+  return MYTH_GAME_FACES.some((entry) => entry.key === gameFace) ? gameFace : null
+}
+
+function intensityToLabel(intensity: MythChargeIntensity): string {
+  switch (intensity) {
+    case 2:
+      return 'Faint'
+    case 4:
+      return 'Mild'
+    case 6:
+      return 'Live'
+    case 8:
+      return 'Heavy'
+    case 10:
+      return 'Overwhelming'
+  }
+}

--- a/src/app/mastering-allyship/myths-read/MythsReadClient.module.css
+++ b/src/app/mastering-allyship/myths-read/MythsReadClient.module.css
@@ -1,0 +1,901 @@
+.shell {
+  min-height: 100dvh;
+  display: flex;
+  justify-content: center;
+  padding: 24px 12px;
+  background: radial-gradient(120% 46% at 50% -6%, #17110b 0%, var(--bars-bg-base, #0a0908) 54%);
+  color: var(--bars-text-primary, #e8e6e0);
+}
+
+.phone {
+  width: min(100%, 390px);
+  min-height: min(844px, calc(100dvh - 48px));
+  border-radius: 28px;
+  overflow: hidden;
+  background: radial-gradient(120% 46% at 50% -6%, #17110b 0%, var(--bars-bg-base, #0a0908) 54%);
+  box-shadow: 0 32px 80px -40px rgba(0, 0, 0, 0.9), 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.screen {
+  min-height: min(844px, calc(100dvh - 48px));
+  padding: 46px 22px 30px;
+  animation: mrRise 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.introScreen {
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+}
+
+.wordmark {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: #e0a92a;
+}
+
+.trigram {
+  width: 24px;
+  display: grid;
+  gap: 4px;
+}
+
+.trigram i {
+  height: 3px;
+  border-radius: 99px;
+  background: #e0a92a;
+  box-shadow: 0 0 10px rgba(224, 169, 42, 0.45);
+}
+
+.trigram i:nth-child(2) {
+  background: linear-gradient(90deg, #e0a92a 0 38%, transparent 38% 62%, #e0a92a 62%);
+}
+
+.introCopy {
+  margin-top: 28px;
+}
+
+.introCopy h1,
+.resultHeader h1,
+.questionBody h1 {
+  margin: 0;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+
+.introCopy h1 {
+  font-size: 33px;
+  line-height: 1.06;
+}
+
+.introCopy p,
+.resultHeader p,
+.chargePanel p,
+.deckCta p {
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  color: var(--bars-text-secondary, #a09e98);
+  line-height: 1.62;
+}
+
+.introCopy p {
+  margin: 16px 0 0;
+  font-size: 15.5px;
+}
+
+.specList {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  border-radius: 14px;
+  background: var(--bars-line, rgba(255, 255, 255, 0.1));
+}
+
+.specRow {
+  display: flex;
+  gap: 12px;
+  padding: 15px 16px;
+  background: var(--bars-surface-card, #1a1a18);
+}
+
+.specRow > span {
+  width: 22px;
+  flex: 0 0 auto;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  color: #e0a92a;
+  font-size: 14px;
+}
+
+.specRow strong {
+  display: block;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 14px;
+}
+
+.specRow p {
+  margin: 3px 0 0;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 12.5px;
+  color: var(--bars-text-muted, #6b6965);
+}
+
+.goldButton,
+.purpleButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 13px;
+  padding: 16px;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 17px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.goldButton {
+  width: 100%;
+  margin-top: auto;
+  color: #0a0807;
+  background: linear-gradient(150deg, #f0c04a, #d4a017);
+  box-shadow: 0 16px 34px -14px rgba(212, 160, 23, 0.7), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.goldButton:hover,
+.purpleButton:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+.finePrint,
+.kicker,
+.goldKicker,
+.purpleKicker,
+.stepLabel,
+.progressHeader,
+.questionFooter,
+.endLabels {
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  text-transform: uppercase;
+}
+
+.finePrint {
+  margin: -8px 0 0;
+  text-align: center;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  color: var(--bars-text-muted, #6b6965);
+}
+
+.questionScreen {
+  display: flex;
+  flex-direction: column;
+}
+
+.progressHeader div:first-child,
+.questionFooter,
+.endLabels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--bars-text-muted, #6b6965);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+}
+
+.pips {
+  display: flex;
+  gap: 4px;
+  margin-top: 14px;
+}
+
+.pips span {
+  flex: 1;
+  height: 3px;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.08);
+  transition: background 0.35s;
+}
+
+.pips .pipAnswered {
+  background: #e0a92a;
+}
+
+.pips .pipCurrent {
+  background: rgba(224, 169, 42, 0.5);
+}
+
+.questionBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.kicker {
+  margin: 0 0 18px;
+  color: var(--bars-text-muted, #6b6965);
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+}
+
+.questionBody h1 {
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 24px;
+  line-height: 1.34;
+  text-wrap: pretty;
+}
+
+.scale {
+  display: flex;
+  align-items: flex-end;
+  gap: 9px;
+}
+
+.scaleButton {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 11px;
+  min-height: 96px;
+  padding: 14px 4px 11px;
+  border: 1px solid var(--bars-line, rgba(255, 255, 255, 0.1));
+  border-radius: 12px;
+  background: var(--bars-surface-card, #1a1a18);
+  color: var(--bars-text-secondary, #a09e98);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+}
+
+.scaleButton > span:last-child {
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 8.5px;
+  line-height: 1.15;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.scaleDot {
+  margin: auto 0 0;
+  border-radius: 50%;
+  border: 2px solid #54524d;
+}
+
+.scaleSelected {
+  border-color: rgba(224, 169, 42, 0.55);
+  background: rgba(224, 169, 42, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 0 20px -8px rgba(224, 169, 42, 0.6);
+  color: #e0a92a;
+}
+
+.scaleSelected .scaleDot {
+  border-color: #e0a92a;
+  background: #e0a92a;
+  box-shadow: 0 0 12px rgba(224, 169, 42, 0.7);
+}
+
+.endLabels {
+  margin-top: 10px;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+}
+
+.questionFooter {
+  margin-top: 22px;
+}
+
+.questionFooter button {
+  border: 0;
+  background: transparent;
+  color: var(--bars-text-muted, #6b6965);
+  font: inherit;
+  cursor: pointer;
+}
+
+.questionFooter button:hover {
+  color: var(--bars-text-primary, #e8e6e0);
+}
+
+.resultScreen {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-top: 34px;
+}
+
+.resultHeader h1 {
+  margin-top: 8px;
+  font-size: 27px;
+  line-height: 1.1;
+}
+
+.resultHeader p:last-child {
+  margin: 10px 0 0;
+  font-size: 13.5px;
+}
+
+.goldKicker,
+.purpleKicker {
+  margin: 0;
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  color: #e0a92a;
+}
+
+.mythStack {
+  display: grid;
+  gap: 12px;
+}
+
+.mythCard {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--bars-surface-card, #1a1a18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(224, 169, 42, 0.3), 0 0 26px -8px rgba(224, 169, 42, 0.42);
+}
+
+.mythCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 80% at 88% -10%, rgba(224, 169, 42, 0.14), transparent 58%);
+  pointer-events: none;
+}
+
+.cardTapLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.cardFace,
+.cardBack {
+  position: relative;
+  z-index: 1;
+  padding: 18px;
+}
+
+.cardMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  color: #e0a92a;
+}
+
+.strength {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  letter-spacing: 0.08em;
+}
+
+.strength i {
+  width: 34px;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(224, 169, 42, 0.16);
+}
+
+.strength b {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #e0a92a;
+}
+
+.cardFace h2 {
+  margin: 18px 0 22px;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 1.16;
+  text-wrap: balance;
+}
+
+.cardFace p {
+  margin: 0;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--bars-text-muted, #6b6965);
+  text-transform: uppercase;
+}
+
+.mythReveal {
+  background: var(--bars-surface-inset, #111110);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(224, 169, 42, 0.5), 0 0 30px -8px rgba(224, 169, 42, 0.55);
+}
+
+.cardBack {
+  display: grid;
+  gap: 12px;
+}
+
+.cardBack div + div {
+  border-top: 1px solid var(--bars-line, rgba(255, 255, 255, 0.1));
+  padding-top: 12px;
+}
+
+.cardBack span {
+  display: block;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #e0a92a;
+}
+
+.cardBack p {
+  margin: 5px 0 0;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 13.5px;
+  line-height: 1.45;
+}
+
+.workButton {
+  position: relative;
+  z-index: 3;
+  border: 0;
+  border-radius: 10px;
+  padding: 12px 13px;
+  background: rgba(224, 169, 42, 0.11);
+  color: #f0c04a;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.chargePanel,
+.boardPanel,
+.emailPanel {
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.chargePanel {
+  background: linear-gradient(168deg, #0f1220, #100f0d 60%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(124, 58, 237, 0.26), 0 0 32px -12px rgba(124, 58, 237, 0.45);
+}
+
+.purpleKicker {
+  color: #a78bfa;
+  letter-spacing: 0.2em;
+  font-size: 9.5px;
+}
+
+.chargePanel h2,
+.deckCta h2,
+.emailPanel h2 {
+  margin: 10px 0 0;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 19px;
+  line-height: 1.15;
+}
+
+.chargePanel > p {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+}
+
+.chargeBlock {
+  margin-top: 16px;
+}
+
+.stepLabel {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--bars-text-muted, #6b6965);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+}
+
+.chipGrid,
+.intensityGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip,
+.intensityChip {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 8px 11px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--bars-text-secondary, #a09e98);
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-weight: 600;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.chipSelected {
+  border-color: rgba(139, 92, 246, 0.6);
+  background: rgba(124, 58, 237, 0.22);
+  color: #fff;
+}
+
+.flavorList {
+  display: grid;
+  gap: 8px;
+}
+
+.gameGrid {
+  display: grid;
+  gap: 9px;
+}
+
+.gameCard {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--bars-text-primary, #e8e6e0);
+  text-align: left;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.gameCard span {
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 8.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #a78bfa;
+}
+
+.gameCard strong {
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 15px;
+  line-height: 1.1;
+}
+
+.gameCard small {
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--bars-text-secondary, #a09e98);
+}
+
+.gameSelected {
+  border-color: rgba(139, 92, 246, 0.66);
+  background: rgba(124, 58, 237, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 0 22px -10px rgba(124, 58, 237, 0.8);
+}
+
+.flavorRow {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 11px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.025);
+  text-align: left;
+  color: var(--bars-text-primary, #e8e6e0);
+  cursor: pointer;
+}
+
+.flavorSelected {
+  border-color: var(--flavor-color);
+  background: color-mix(in srgb, var(--flavor-color) 14%, var(--bars-surface-inset, #111110));
+  box-shadow: 0 0 18px -8px var(--flavor-color);
+}
+
+.flavorSigil {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  background: color-mix(in srgb, var(--flavor-color) 16%, transparent);
+  color: var(--flavor-color);
+  text-shadow: 0 0 12px var(--flavor-color);
+}
+
+.flavorRow strong,
+.flavorRow small {
+  display: block;
+}
+
+.flavorRow strong {
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-size: 13.5px;
+}
+
+.flavorRow small {
+  margin-top: 2px;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  color: var(--bars-text-secondary, #a09e98);
+  font-size: 11px;
+}
+
+.intensityChip span {
+  margin-left: 5px;
+  opacity: 0.72;
+}
+
+.readout {
+  margin: 9px 0 0;
+  color: #a78bfa !important;
+  font-size: 11.5px;
+  font-style: italic;
+}
+
+.seededBar {
+  margin-top: 16px;
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(124, 58, 237, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.4);
+}
+
+.seededBar p,
+.seededBar span {
+  margin: 0;
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a78bfa;
+}
+
+.seededBar strong {
+  display: block;
+  margin: 9px 0 12px;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.purpleButton {
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 13px;
+  color: #fff;
+  background: linear-gradient(150deg, #8b5cf6, #7c3aed);
+  box-shadow: 0 14px 30px -12px #7c3aed;
+  font-size: 15px;
+}
+
+.seedPrompt {
+  margin: 14px 0 0 !important;
+  font-size: 12px;
+  color: var(--bars-text-muted, #6b6965) !important;
+}
+
+.boardPanel,
+.emailPanel {
+  background: var(--bars-surface-inset, #111110);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(255, 255, 255, 0.07);
+}
+
+.boardPanel ol {
+  display: grid;
+  gap: 8px;
+  margin: 13px 0 10px;
+  padding: 0;
+  list-style: none;
+}
+
+.boardPanel li {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  opacity: 0.42;
+}
+
+.boardPanel li span {
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  border: 1.5px solid #6b6965;
+}
+
+.boardPanel .boardLit {
+  opacity: 1;
+}
+
+.boardLit span {
+  border-color: #e0a92a !important;
+  background: #e0a92a;
+  box-shadow: 0 0 12px rgba(224, 169, 42, 0.7);
+}
+
+.boardPanel p {
+  margin: 0;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  font-size: 12px;
+  color: var(--bars-text-secondary, #a09e98);
+}
+
+.boardPanel li p {
+  color: var(--bars-text-primary, #e8e6e0);
+}
+
+.boardPanel small {
+  font-family: var(--bars-font-mono, 'Space Mono', monospace);
+  font-size: 8.5px;
+  color: var(--bars-text-muted, #6b6965);
+}
+
+.funnel {
+  display: grid;
+  gap: 12px;
+}
+
+.deckCta {
+  padding: 18px;
+  border-radius: 14px;
+  background: var(--bars-surface-card, #1a1a18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(224, 169, 42, 0.28);
+}
+
+.deckCta .goldButton {
+  margin-top: 14px;
+}
+
+.companionCta {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 9px 12px;
+  align-items: center;
+  padding: 14px;
+  border-radius: 12px;
+  text-decoration: none;
+  color: var(--bars-text-primary, #e8e6e0);
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(224, 169, 42, 0.22);
+}
+
+.companionCta span {
+  grid-row: span 2;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: rgba(224, 169, 42, 0.12);
+  color: #e0a92a;
+}
+
+.companionCta strong {
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+}
+
+.companionCta small {
+  color: var(--bars-text-secondary, #a09e98);
+}
+
+.bookLink,
+.retake {
+  justify-self: center;
+  border: 0;
+  background: transparent;
+  color: var(--bars-text-secondary, #a09e98);
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.emailPanel h2 {
+  margin: 0 0 12px;
+}
+
+.emailRow {
+  display: flex;
+  gap: 8px;
+}
+
+.emailRow input {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid var(--bars-line-strong, rgba(255, 255, 255, 0.14));
+  border-radius: 10px;
+  padding: 11px 12px;
+  background: var(--bars-bg-base, #0a0908);
+  color: var(--bars-text-primary, #e8e6e0);
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+}
+
+.emailRow button {
+  border: 0;
+  border-radius: 10px;
+  padding: 0 13px;
+  background: rgba(224, 169, 42, 0.1);
+  color: #e0a92a;
+  font-family: var(--bars-font-display, 'Jost', sans-serif);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.emailError {
+  margin: 9px 0 0;
+  color: #fca5a5;
+  font-size: 12px;
+}
+
+.emailSaved {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.emailSaved span {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border-radius: 9px;
+  background: rgba(224, 169, 42, 0.12);
+  color: #e0a92a;
+}
+
+.emailSaved p {
+  margin: 0;
+  font-family: var(--bars-font-body, 'Nunito', sans-serif);
+  color: var(--bars-text-secondary, #a09e98);
+}
+
+.retake {
+  margin: 4px auto 0;
+  color: var(--bars-text-muted, #6b6965);
+}
+
+@keyframes mrRise {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .screen,
+  .goldButton,
+  .purpleButton,
+  .pips span {
+    animation: none;
+    transition: none;
+  }
+}
+
+@media (max-width: 430px) {
+  .shell {
+    padding: 0;
+  }
+
+  .phone,
+  .screen {
+    min-height: 100dvh;
+    border-radius: 0;
+  }
+}

--- a/src/app/mastering-allyship/myths-read/MythsReadClient.tsx
+++ b/src/app/mastering-allyship/myths-read/MythsReadClient.tsx
@@ -1,0 +1,565 @@
+'use client'
+
+import Link from 'next/link'
+import type { CSSProperties } from 'react'
+import { useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { saveMythRead } from '@/actions/myths-read'
+import {
+  MYTHS,
+  MYTH_CHARGE_FLAVORS,
+  MYTH_CHARGE_INTENSITIES,
+  MYTH_GAME_FACES,
+  MYTH_READ_ITEMS,
+  MYTH_SCALE,
+  scoreMyths,
+  type MythChargeFlavorKey,
+  type MythChargeIntensity,
+  type MythGameFaceKey,
+  type MythId,
+  type MythReadAnswerValue,
+  type MythReadItem,
+  type RankedMyth,
+} from '@/lib/mastering-allyship/myths-read'
+import styles from './MythsReadClient.module.css'
+
+type Phase = 'intro' | 'quiz' | 'result'
+
+export function MythsReadClient() {
+  const router = useRouter()
+  const [isSaving, startSaving] = useTransition()
+  const [isMetabolizing, startMetabolizing] = useTransition()
+  const [phase, setPhase] = useState<Phase>('intro')
+  const [step, setStep] = useState(0)
+  const [answers, setAnswers] = useState<Partial<Record<MythReadItem['id'], MythReadAnswerValue>>>({})
+  const [flipped, setFlipped] = useState<Partial<Record<MythId, boolean>>>({})
+  const [chargeMythId, setChargeMythId] = useState<MythId | null>(null)
+  const [chargeFlavor, setChargeFlavor] = useState<MythChargeFlavorKey | null>(null)
+  const [chargeIntensity, setChargeIntensity] = useState<MythChargeIntensity | null>(null)
+  const [gameFace, setGameFace] = useState<MythGameFaceKey | null>(null)
+  const [email, setEmail] = useState('')
+  const [emailSaved, setEmailSaved] = useState(false)
+  const [emailError, setEmailError] = useState('')
+
+  const outcome = useMemo(() => scoreMyths(answers), [answers])
+  const activeChargeMythId = chargeMythId ?? outcome.surfaced[0]?.myth.id ?? 'M8'
+  const activeChargeMyth = outcome.scores[activeChargeMythId]?.myth ?? outcome.surfaced[0]?.myth
+  const selectedFlavor = MYTH_CHARGE_FLAVORS.find((flavor) => flavor.key === chargeFlavor) ?? null
+  const selectedIntensity = MYTH_CHARGE_INTENSITIES.find((item) => item.value === chargeIntensity) ?? null
+  const selectedGame = MYTH_GAME_FACES.find((game) => game.key === gameFace) ?? null
+
+  function chooseAnswer(value: MythReadAnswerValue) {
+    const item = MYTH_READ_ITEMS[step]
+    setAnswers((current) => ({ ...current, [item.id]: value }))
+
+    window.setTimeout(() => {
+      if (step >= MYTH_READ_ITEMS.length - 1) {
+        setPhase('result')
+      } else {
+        setStep((current) => Math.min(current + 1, MYTH_READ_ITEMS.length - 1))
+      }
+    }, 190)
+  }
+
+  function reset() {
+    setPhase('intro')
+    setStep(0)
+    setAnswers({})
+    setFlipped({})
+    setChargeMythId(null)
+    setChargeFlavor(null)
+    setChargeIntensity(null)
+    setGameFace(null)
+    setEmail('')
+    setEmailSaved(false)
+    setEmailError('')
+  }
+
+  function saveEmail() {
+    if (!email.includes('@')) {
+      setEmailError('Use an email with @ so this read can find you again.')
+      return
+    }
+    setEmailError('')
+    startSaving(async () => {
+      const result = await saveMythRead({
+        answers,
+        email,
+        consent: true,
+        source: 'mastering-allyship-ch0-save',
+        capturedCharge:
+          chargeFlavor && chargeIntensity
+            ? { mythId: activeChargeMythId, flavor: chargeFlavor, intensity: chargeIntensity, gameFace }
+            : null,
+        gameFace,
+      })
+
+      if (!result.ok) {
+        setEmailError(result.error)
+        return
+      }
+
+      setEmailSaved(true)
+    })
+  }
+
+  function metabolizeCharge() {
+    if (!chargeFlavor || !chargeIntensity || !gameFace) return
+    startMetabolizing(async () => {
+      const result = await saveMythRead({
+        answers,
+        email: email || undefined,
+        consent: Boolean(email),
+        source: 'mastering-allyship-ch0-metabolize',
+        capturedCharge: {
+          mythId: activeChargeMythId,
+          flavor: chargeFlavor,
+          intensity: chargeIntensity,
+          gameFace,
+        },
+        gameFace,
+        createSeedBar: true,
+      })
+
+      if (!result.ok) {
+        setEmailError(result.error)
+        return
+      }
+
+      router.push(result.redirectTo)
+    })
+  }
+
+  return (
+    <main className={styles.shell}>
+      <section className={styles.phone} aria-label="Myths Read diagnostic">
+        {phase === 'intro' && (
+          <div className={`${styles.screen} ${styles.introScreen}`}>
+            <Wordmark />
+            <div className={styles.introCopy}>
+              <h1>You&apos;re playing at least a few of these.</h1>
+              <p>
+                This does not flatter you. It reads the moves you actually make under pressure,
+                then shows which allyship myths are alive right now.
+              </p>
+            </div>
+
+            <div className={styles.specList} aria-label="Quiz specs">
+              <SpecRow mark="12" title="Behavioral prompts" body="Short, direct, first-person." />
+              <SpecRow mark="5" title="Frequency scale" body="Never through almost always." />
+              <SpecRow mark="♦" title="One first BAR" body="A charge you can metabolize into play." />
+            </div>
+
+            <button type="button" className={styles.goldButton} onClick={() => setPhase('quiz')}>
+              Read my myths →
+            </button>
+            <p className={styles.finePrint}>Honest beats fast. The result is a map, not a verdict.</p>
+          </div>
+        )}
+
+        {phase === 'quiz' && (
+          <QuestionScreen
+            step={step}
+            answers={answers}
+            onAnswer={chooseAnswer}
+            onBack={() => setStep((current) => Math.max(0, current - 1))}
+          />
+        )}
+
+        {phase === 'result' && (
+          <div className={`${styles.screen} ${styles.resultScreen}`}>
+            <header className={styles.resultHeader}>
+              <p className={styles.goldKicker}>YOUR READ · {outcome.surfaced.length} MYTHS SURFACED</p>
+              <h1>These are the myths you&apos;re playing.</h1>
+              <p>
+                A myth is a false claim, not a verdict. It names where your strategy has gone
+                stale so the book and the deck can give you a move.
+              </p>
+            </header>
+
+            <div className={styles.mythStack}>
+              {outcome.surfaced.map((entry, index) => (
+                <MythCard
+                  key={entry.myth.id}
+                  entry={entry}
+                  rank={index + 1}
+                  flipped={Boolean(flipped[entry.myth.id])}
+                  active={activeChargeMythId === entry.myth.id}
+                  onFlip={() =>
+                    setFlipped((current) => ({
+                      ...current,
+                      [entry.myth.id]: !current[entry.myth.id],
+                    }))
+                  }
+                  onWork={() => {
+                    setChargeMythId(entry.myth.id)
+                    setFlipped((current) => ({ ...current, [entry.myth.id]: true }))
+                  }}
+                />
+              ))}
+            </div>
+
+            {activeChargeMyth && (
+              <section className={styles.chargePanel}>
+                <p className={styles.purpleKicker}>◇ EMOTIONAL ALCHEMY · METABOLIZE THE CHARGE</p>
+                <h2>A myth is just a claim until you feel the charge under it.</h2>
+                <p>
+                  Pick the myth that feels most alive, name the flavor of the charge, then set its
+                  intensity. Then choose the game you want to play with that energy.
+                </p>
+
+                <div className={styles.chargeBlock}>
+                  <span className={styles.stepLabel}>Step 1 · myth</span>
+                  <div className={styles.chipGrid}>
+                    {outcome.surfaced.map((entry) => (
+                      <button
+                        key={entry.myth.id}
+                        type="button"
+                        className={`${styles.chip} ${
+                          activeChargeMythId === entry.myth.id ? styles.chipSelected : ''
+                        }`}
+                        onClick={() => setChargeMythId(entry.myth.id)}
+                      >
+                        {entry.myth.short}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className={styles.chargeBlock}>
+                  <span className={styles.stepLabel}>Step 2 · flavor</span>
+                  <div className={styles.flavorList}>
+                    {MYTH_CHARGE_FLAVORS.map((flavor) => (
+                      <button
+                        key={flavor.key}
+                        type="button"
+                        className={`${styles.flavorRow} ${
+                          chargeFlavor === flavor.key ? styles.flavorSelected : ''
+                        }`}
+                        style={{ '--flavor-color': flavor.color } as CSSProperties}
+                        onClick={() => setChargeFlavor(flavor.key)}
+                      >
+                        <span className={styles.flavorSigil}>{flavor.sigil}</span>
+                        <span>
+                          <strong>{flavor.label}</strong>
+                          <small>{flavor.sub}</small>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className={styles.chargeBlock}>
+                  <span className={styles.stepLabel}>Step 3 · intensity</span>
+                  <div className={styles.intensityGrid}>
+                    {MYTH_CHARGE_INTENSITIES.map((item) => (
+                      <button
+                        key={item.value}
+                        type="button"
+                        className={`${styles.intensityChip} ${
+                          chargeIntensity === item.value ? styles.chipSelected : ''
+                        }`}
+                        onClick={() => setChargeIntensity(item.value)}
+                      >
+                        {item.label}
+                        <span>{item.value}</span>
+                      </button>
+                    ))}
+                  </div>
+                  <p className={styles.readout}>
+                    {selectedIntensity?.readout ?? 'Pick the closest strength. You can change it later.'}
+                  </p>
+                </div>
+
+                <div className={styles.chargeBlock}>
+                  <span className={styles.stepLabel}>Step 4 · choose the game</span>
+                  <div className={styles.gameGrid}>
+                    {MYTH_GAME_FACES.map((game) => (
+                      <button
+                        key={game.key}
+                        type="button"
+                        className={`${styles.gameCard} ${gameFace === game.key ? styles.gameSelected : ''}`}
+                        onClick={() => setGameFace(game.key)}
+                      >
+                        <span>{game.face}</span>
+                        <strong>{game.gameName}</strong>
+                        <small>{game.prompt}</small>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {selectedFlavor && selectedIntensity && selectedGame ? (
+                  <div className={styles.seededBar}>
+                    <p>♦ YOUR FIRST CAMPAIGN SEED</p>
+                    <strong>
+                      &quot;{activeChargeMyth.short}&quot;, held as {selectedFlavor.label.toLowerCase()}{' '}
+                      at {selectedIntensity.label.toLowerCase()} strength. You chose{' '}
+                      {selectedGame.gameName}: {selectedGame.nextStep}
+                    </strong>
+                    <button
+                      type="button"
+                      className={styles.purpleButton}
+                      onClick={metabolizeCharge}
+                      disabled={isMetabolizing}
+                    >
+                      {isMetabolizing ? 'Seeding…' : 'Seed this campaign →'}
+                    </button>
+                    <span>
+                      Your emotion is the fuel. The game you chose is the vector.
+                    </span>
+                  </div>
+                ) : (
+                  <p className={styles.seedPrompt}>
+                    Choose a flavor, intensity, and game to seed the campaign.
+                  </p>
+                )}
+              </section>
+            )}
+
+            <WholeBoard surfacedIds={outcome.surfaced.map((entry) => entry.myth.id)} />
+            <FunnelCtas count={outcome.surfaced.length} />
+
+            <section className={styles.emailPanel}>
+              {emailSaved ? (
+                <div className={styles.emailSaved}>
+                  <span>♦</span>
+                  <p>Your read is saved. The myth, charge, and chosen game can travel with you.</p>
+                </div>
+              ) : (
+                <>
+                  <h2>Save your read</h2>
+                  <div className={styles.emailRow}>
+                    <input
+                      value={email}
+                      type="email"
+                      placeholder="you@example.com"
+                      onChange={(event) => setEmail(event.target.value)}
+                    />
+                    <button type="button" onClick={saveEmail} disabled={isSaving}>
+                      {isSaving ? 'Saving' : 'Save'}
+                    </button>
+                  </div>
+                  {emailError && <p className={styles.emailError}>{emailError}</p>}
+                </>
+              )}
+            </section>
+
+            <button type="button" className={styles.retake} onClick={reset}>
+              ↺ Retake the read
+            </button>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function QuestionScreen({
+  step,
+  answers,
+  onAnswer,
+  onBack,
+}: {
+  step: number
+  answers: Partial<Record<MythReadItem['id'], MythReadAnswerValue>>
+  onAnswer: (value: MythReadAnswerValue) => void
+  onBack: () => void
+}) {
+  const item = MYTH_READ_ITEMS[step]
+  const selected = answers[item.id]
+
+  return (
+    <div className={`${styles.screen} ${styles.questionScreen}`} key={`q${step}`}>
+      <header className={styles.progressHeader}>
+        <div>
+          <span>{String(step + 1).padStart(2, '0')} / 12</span>
+          <span>honest, not fast</span>
+        </div>
+        <div className={styles.pips} aria-hidden="true">
+          {MYTH_READ_ITEMS.map((quizItem, index) => (
+            <span
+              key={quizItem.id}
+              className={
+                answers[quizItem.id] != null
+                  ? styles.pipAnswered
+                  : index === step
+                    ? styles.pipCurrent
+                    : ''
+              }
+            />
+          ))}
+        </div>
+      </header>
+
+      <section className={styles.questionBody}>
+        <p className={styles.kicker}>HOW OFTEN IS THIS TRUE OF YOU?</p>
+        <h1>{item.text}</h1>
+      </section>
+
+      <section className={styles.scaleWrap} aria-label="Frequency scale">
+        <div className={styles.scale}>
+          {MYTH_SCALE.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={`${styles.scaleButton} ${selected === option.value ? styles.scaleSelected : ''}`}
+              onClick={() => onAnswer(option.value)}
+            >
+              <span
+                className={styles.scaleDot}
+                style={{ width: 12 + option.value * 5, height: 12 + option.value * 5 }}
+              />
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>
+        <div className={styles.endLabels}>
+          <span>Never</span>
+          <span>Almost always</span>
+        </div>
+      </section>
+
+      <footer className={styles.questionFooter}>
+        {step > 0 ? (
+          <button type="button" onClick={onBack}>
+            ← Back
+          </button>
+        ) : (
+          <span />
+        )}
+        <span>tap to answer</span>
+      </footer>
+    </div>
+  )
+}
+
+function MythCard({
+  entry,
+  rank,
+  flipped,
+  active,
+  onFlip,
+  onWork,
+}: {
+  entry: RankedMyth
+  rank: number
+  flipped: boolean
+  active: boolean
+  onFlip: () => void
+  onWork: () => void
+}) {
+  const pct = Math.round(entry.pct * 100)
+
+  return (
+    <article className={`${styles.mythCard} ${flipped ? styles.mythReveal : ''}`}>
+      <button type="button" className={styles.cardTapLayer} onClick={onFlip}>
+        <span className="sr-only">Toggle {entry.myth.claim}</span>
+      </button>
+      {!flipped ? (
+        <div className={styles.cardFace}>
+          <div className={styles.cardMeta}>
+            <span>MYTH · RANK {rank}</span>
+            <span className={styles.strength}>
+              {entry.strength}
+              <i>
+                <b style={{ width: `${pct}%` }} />
+              </i>
+            </span>
+          </div>
+          <h2>&quot;{entry.myth.claim}&quot;</h2>
+          <p>Tap to turn it over ↻</p>
+        </div>
+      ) : (
+        <div className={styles.cardBack}>
+          <div>
+            <span>The diagnosis</span>
+            <p>{entry.myth.diagnosis}</p>
+          </div>
+          <div>
+            <span>
+              Where the book solves it · {entry.myth.chapter}
+            </span>
+            <p>{entry.myth.destination}</p>
+          </div>
+          <div>
+            <span>One move now</span>
+            <p>{entry.myth.move}</p>
+          </div>
+          <button type="button" className={styles.workButton} onClick={onWork}>
+            {active ? '✓ Working this one' : "This one's alive — work it ↓"}
+          </button>
+        </div>
+      )}
+    </article>
+  )
+}
+
+function WholeBoard({ surfacedIds }: { surfacedIds: MythId[] }) {
+  return (
+    <section className={styles.boardPanel}>
+      <p className={styles.goldKicker}>THE WHOLE BOARD · {surfacedIds.length} LIT FOR YOU</p>
+      <ol>
+        {MYTHS.map((myth) => {
+          const lit = surfacedIds.includes(myth.id)
+          return (
+            <li key={myth.id} className={lit ? styles.boardLit : ''}>
+              <span aria-hidden="true" />
+              <p>{myth.claim}</p>
+              <small>{myth.chapter}</small>
+            </li>
+          )
+        })}
+      </ol>
+      <p>Unlit myths aren&apos;t absent — just quiet today.</p>
+    </section>
+  )
+}
+
+function FunnelCtas({ count }: { count: number }) {
+  return (
+    <section className={styles.funnel}>
+      <div className={styles.deckCta}>
+        <p className={styles.goldKicker}>{count} ALIVE FOR YOU · WHERE THEY GET WORKED</p>
+        <h2>The deck turns this read into practice.</h2>
+        <p>Draw a move, make it concrete, and let the charge become something you can play.</p>
+        <Link className={styles.goldButton} href="/deck/sales">
+          Get the Allyship Deck →
+        </Link>
+      </div>
+      <Link className={styles.companionCta} href="/superpower">
+        <span>✦</span>
+        <strong>Now see how you ally →</strong>
+        <small>Discover your Allyship Superpower</small>
+      </Link>
+      <Link className={styles.bookLink} href="/mastering-allyship/hub">
+        Or read the manual — the book
+      </Link>
+    </section>
+  )
+}
+
+function Wordmark() {
+  return (
+    <div className={styles.wordmark}>
+      <span className={styles.trigram} aria-hidden="true">
+        <i />
+        <i />
+        <i />
+      </span>
+      <span>MYTHS READ</span>
+    </div>
+  )
+}
+
+function SpecRow({ mark, title, body }: { mark: string; title: string; body: string }) {
+  return (
+    <div className={styles.specRow}>
+      <span>{mark}</span>
+      <div>
+        <strong>{title}</strong>
+        <p>{body}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/mastering-allyship/myths-read/page.tsx
+++ b/src/app/mastering-allyship/myths-read/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import { MythsReadClient } from './MythsReadClient'
+
+export const metadata: Metadata = {
+  title: 'Myths Read — Mastering the Game of Allyship',
+  description:
+    'A short diagnostic that surfaces the allyship myths you are playing and routes them into the book, deck, and first BAR seed.',
+}
+
+/**
+ * @page /mastering-allyship/myths-read
+ * @entity CAMPAIGN
+ * @description Public Chapter 0 Myths Read diagnostic for Mastering the Game of Allyship.
+ * @permissions public
+ * @relationships Mastering Allyship book funnel, Allyship Deck sales, Superpower quiz
+ * @agentDiscoverable true
+ */
+export default function MythsReadPage() {
+  return <MythsReadClient />
+}

--- a/src/lib/mastering-allyship/__tests__/myths-read.test.ts
+++ b/src/lib/mastering-allyship/__tests__/myths-read.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import {
+  MYTH_READ_ITEMS,
+  buildMythReadPersistencePayload,
+  scoreMyths,
+  type MythReadAnswerValue,
+  type MythReadItem,
+} from '../myths-read'
+
+type AnswerMap = Partial<Record<MythReadItem['id'], MythReadAnswerValue>>
+
+function run(name: string, fn: () => void) {
+  fn()
+  console.log(`✓ ${name}`)
+}
+
+run('q10 cross-loads M9 fully and M1 half', () => {
+  const outcome = scoreMyths({ q10: 4 })
+
+  assert.equal(outcome.scores.M9.raw, 4)
+  assert.equal(outcome.scores.M9.max, 4)
+  assert.equal(outcome.scores.M9.pct, 1)
+
+  assert.equal(outcome.scores.M1.raw, 2)
+  assert.equal(outcome.scores.M1.max, 6)
+  assert.equal(outcome.scores.M1.pct, 1 / 3)
+})
+
+run('floor rule keeps rank one and filters weak rank two/three', () => {
+  const outcome = scoreMyths({ q1: 4, q2: 1, q3: 1 })
+
+  assert.deepEqual(
+    outcome.surfaced.map((entry) => entry.myth.id),
+    ['M1'],
+  )
+})
+
+run('canonical order breaks ties after pct and peak', () => {
+  const answers = Object.fromEntries(
+    MYTH_READ_ITEMS.map((item) => [item.id, 0]),
+  ) as AnswerMap
+  const outcome = scoreMyths(answers)
+
+  assert.deepEqual(
+    outcome.ranked.slice(0, 4).map((entry) => entry.myth.id),
+    ['M8', 'M7', 'M1', 'M5'],
+  )
+})
+
+run('double-loaded myths compare by normalized pct', () => {
+  const outcome = scoreMyths({ q7: 4, q12: 4, q8: 2, q9: 2 })
+
+  assert.equal(outcome.ranked[0].myth.id, 'M7')
+  assert.equal(outcome.scores.M7.pct, 1)
+  assert.equal(outcome.scores.M8.pct, 0.5)
+})
+
+run('campaign seed stores the chosen game as vector, not emotion route', () => {
+  const payload = buildMythReadPersistencePayload(
+    { q8: 4, q9: 4, q7: 2, q12: 2 },
+    { mythId: 'M8', flavor: 'anger', intensity: 8, gameFace: 'challenger' },
+  )
+
+  assert.deepEqual(payload.capturedCharge, {
+    mythId: 'M8',
+    flavor: 'anger',
+    intensity: 8,
+    gameFace: 'challenger',
+  })
+  assert.equal(payload.seedBarDrafts[0].gameName, 'MythBusting')
+  assert.equal(payload.seedBarDrafts[0].gameFace, 'challenger')
+})

--- a/src/lib/mastering-allyship/myths-read.ts
+++ b/src/lib/mastering-allyship/myths-read.ts
@@ -1,0 +1,484 @@
+export type MythId =
+  | 'M1'
+  | 'M2'
+  | 'M3'
+  | 'M4'
+  | 'M5'
+  | 'M6'
+  | 'M7'
+  | 'M8'
+  | 'M9'
+  | 'M10'
+
+export type MythReadAnswerValue = 0 | 1 | 2 | 3 | 4
+export type MythChargeFlavorKey = 'sadness' | 'anger' | 'fear' | 'numbness' | 'restlessness'
+export type MythChargeIntensity = 2 | 4 | 6 | 8 | 10
+export type MythGameFaceKey =
+  | 'shaman'
+  | 'challenger'
+  | 'regent'
+  | 'architect'
+  | 'diplomat'
+  | 'sage'
+
+export interface MythReadCharge {
+  mythId: MythId
+  flavor: MythChargeFlavorKey
+  intensity: MythChargeIntensity
+  gameFace?: MythGameFaceKey | null
+}
+
+export interface MythReadMyth {
+  id: MythId
+  claim: string
+  rootBelief: string
+  chapter: string
+  destination: string
+  diagnosis: string
+  move: string
+  short: string
+}
+
+export interface MythReadItem {
+  id: `q${number}`
+  text: string
+  weights: Partial<Record<MythId, number>>
+}
+
+export interface RankedMyth {
+  myth: MythReadMyth
+  raw: number
+  max: number
+  pct: number
+  peak: number
+  strength: 'Loud' | 'Clear' | 'Faint'
+}
+
+export interface MythReadOutcome {
+  ranked: RankedMyth[]
+  surfaced: RankedMyth[]
+  scores: Record<MythId, RankedMyth>
+}
+
+export interface MythReadPersistencePayload {
+  responses: { item: MythReadItem['id']; value: MythReadAnswerValue }[]
+  mythScores: {
+    myth: MythId
+    pct: number
+    raw: number
+    max: number
+    peak: number
+    strength: RankedMyth['strength']
+  }[]
+  topMyths: MythId[]
+  rootBeliefs: string[]
+  recommendedDestinations: string[]
+  capturedCharge: MythReadCharge | null
+  seedBarDrafts: {
+    myth: MythId
+    prompt: string
+    gameFace: MythGameFaceKey | null
+    gameName: string | null
+    nextStep: string
+  }[]
+}
+
+export const MYTHS: readonly MythReadMyth[] = [
+  {
+    id: 'M1',
+    claim: 'Allyship means being good.',
+    rootBelief: 'Not good enough',
+    chapter: 'Ch 0',
+    destination: 'The redefinition + the counter-con',
+    diagnosis: 'A private trial where the other person becomes your evidence.',
+    move: "Name the verdict you're trying to win.",
+    short: 'being good',
+  },
+  {
+    id: 'M2',
+    claim: 'Allyship means saying the right words.',
+    rootBelief: 'Not ready',
+    chapter: 'Ch 2',
+    destination: 'The Shaman: the felt record under the language',
+    diagnosis: 'Fluency that signals safety without proving it.',
+    move: 'Name one thing you feel that you have no vocabulary for.',
+    short: 'right words',
+  },
+  {
+    id: 'M3',
+    claim: 'Allyship means helping the less powerful.',
+    rootBelief: 'Insignificant',
+    chapter: 'Ch 0',
+    destination: 'The redefinition: charity vs. allyship',
+    diagnosis: "Turns a person into a project. That's charity.",
+    move: 'Name where the mutuality is.',
+    short: 'the less powerful',
+  },
+  {
+    id: 'M4',
+    claim: 'Allyship means following the right people.',
+    rootBelief: 'Not capable',
+    chapter: 'Ch 3',
+    destination: "The Challenger: keep your discernment or you're staff",
+    diagnosis: "Discernment surrendered to someone's authority.",
+    move: 'Name one thing you disagreed with and swallowed.',
+    short: 'the right people',
+  },
+  {
+    id: 'M5',
+    claim: 'Allyship means sacrificing yourself.',
+    rootBelief: 'Not worthy',
+    chapter: 'Ch 0',
+    destination: 'The Token System + self-allyship',
+    diagnosis: 'Self-abandonment that sends an invoice.',
+    move: 'Name what actually refills you.',
+    short: 'sacrificing yourself',
+  },
+  {
+    id: 'M6',
+    claim: 'Allyship means never causing harm.',
+    rootBelief: "Don't belong",
+    chapter: 'Ch 6',
+    destination: 'Diplomat: the Repairer channel',
+    diagnosis: 'Innocence protected by never moving.',
+    move: "Name a rupture you've been avoiding repairing.",
+    short: 'never causing harm',
+  },
+  {
+    id: 'M7',
+    claim: 'Allyship means fixing the problem.',
+    rootBelief: 'Not capable',
+    chapter: 'Ch 0',
+    destination: 'The Gates + Emotional Alchemy',
+    diagnosis: 'Wanting it more than they do; help curdles to pressure.',
+    move: 'Name the charge under your urge to fix.',
+    short: 'fixing it',
+  },
+  {
+    id: 'M8',
+    claim: 'Allyship means having the right framework.',
+    rootBelief: 'Not good enough',
+    chapter: 'Ch 7',
+    destination: 'The Sage: seeing that replaces acting + Two Readings',
+    diagnosis: 'The map becomes the destination.',
+    move: "Name a pattern you see clearly and still haven't moved on.",
+    short: 'the right framework',
+  },
+  {
+    id: 'M9',
+    claim: 'Allyship means being seen doing it.',
+    rootBelief: "Don't belong",
+    chapter: 'Ch 0',
+    destination: "The Ticket System: optics aren't tickets",
+    diagnosis: "Optics on someone else's ledger.",
+    move: "Name a move you'd make if no one saw.",
+    short: 'being seen',
+  },
+  {
+    id: 'M10',
+    claim: 'Allyship means paying down what you owe.',
+    rootBelief: 'Not worthy',
+    chapter: 'Ch 0',
+    destination: 'The infinite-game frame',
+    diagnosis: 'An inherited, unpayable debt.',
+    move: 'Name what accurate accounting would actually say.',
+    short: 'a debt to pay',
+  },
+] as const
+
+export const MYTH_BY_ID = Object.fromEntries(MYTHS.map((myth) => [myth.id, myth])) as Record<
+  MythId,
+  MythReadMyth
+>
+
+export const MYTH_READ_ITEMS: readonly MythReadItem[] = [
+  {
+    id: 'q1',
+    text: 'When I do something for a cause, some part of me is quietly checking whether it makes me a good person.',
+    weights: { M1: 1 },
+  },
+  {
+    id: 'q2',
+    text: "I relax in a room once I've heard people use the right language — I know I'm safe there.",
+    weights: { M2: 1 },
+  },
+  {
+    id: 'q3',
+    text: "I feel most useful when I'm helping someone who clearly can't help themselves.",
+    weights: { M3: 1 },
+  },
+  {
+    id: 'q4',
+    text: 'When someone with more standing or lived experience takes a position, I go along with it even when something in me disagrees.',
+    weights: { M4: 1 },
+  },
+  {
+    id: 'q5',
+    text: 'I gauge whether I did enough by how drained I feel afterward.',
+    weights: { M5: 1 },
+  },
+  {
+    id: 'q6',
+    text: "I'd rather stay quiet than risk saying the wrong thing and being seen as harmful.",
+    weights: { M6: 1 },
+  },
+  {
+    id: 'q7',
+    text: "When someone I care about is struggling, I keep offering my solution even after they've stopped asking for it.",
+    weights: { M7: 1 },
+  },
+  {
+    id: 'q8',
+    text: 'Before I act, I reach for a framework or an analysis so I feel like I\'m standing on solid ground.',
+    weights: { M8: 1 },
+  },
+  {
+    id: 'q9',
+    text: 'I understand my own patterns far better than I actually change them.',
+    weights: { M8: 1 },
+  },
+  {
+    id: 'q10',
+    text: 'It matters to me that the right people notice I showed up.',
+    weights: { M9: 1, M1: 0.5 },
+  },
+  {
+    id: 'q11',
+    text: "I carry a sense that I owe something for advantages I didn't earn, and that I have to keep paying it down.",
+    weights: { M10: 1 },
+  },
+  {
+    id: 'q12',
+    text: "It's hard for me to let someone struggle when I'm sure I know what would help.",
+    weights: { M7: 1 },
+  },
+] as const
+
+export const MYTH_TIE_ORDER: readonly MythId[] = [
+  'M8',
+  'M7',
+  'M1',
+  'M5',
+  'M6',
+  'M4',
+  'M2',
+  'M3',
+  'M9',
+  'M10',
+] as const
+
+export const MYTH_SCALE = [
+  { value: 0 as const, label: 'Never' },
+  { value: 1 as const, label: 'Rarely' },
+  { value: 2 as const, label: 'Sometimes' },
+  { value: 3 as const, label: 'Often' },
+  { value: 4 as const, label: 'Almost always' },
+] as const
+
+export const MYTH_CHARGE_FLAVORS: readonly {
+  key: MythChargeFlavorKey
+  sigil: string
+  label: string
+  sub: string
+  color: string
+}[] = [
+  {
+    key: 'sadness',
+    sigil: '水',
+    label: 'Sadness',
+    sub: 'Heavy — grief, something feels distant',
+    color: '#2980b9',
+  },
+  {
+    key: 'anger',
+    sigil: '火',
+    label: 'Anger',
+    sub: "Heated — a boundary's been crossed",
+    color: '#c1392b',
+  },
+  {
+    key: 'fear',
+    sigil: '金',
+    label: 'Fear',
+    sub: 'Anxious — dread, bracing for it',
+    color: '#8e9aab',
+  },
+  {
+    key: 'numbness',
+    sigil: '土',
+    label: 'Numbness',
+    sub: 'Shut down — going through the motions',
+    color: '#9a8f6e',
+  },
+  {
+    key: 'restlessness',
+    sigil: '木',
+    label: 'Restlessness',
+    sub: 'Forced — performing okay-ness',
+    color: '#2ecc71',
+  },
+] as const
+
+export const MYTH_GAME_FACES: readonly {
+  key: MythGameFaceKey
+  face: string
+  gameName: string
+  prompt: string
+  nextStep: string
+}[] = [
+  {
+    key: 'shaman',
+    face: 'Shaman',
+    gameName: 'Emotional Alchemy',
+    prompt: 'I want to understand what this charge is carrying.',
+    nextStep: 'Track the feeling under the myth before turning it into action.',
+  },
+  {
+    key: 'challenger',
+    face: 'Challenger',
+    gameName: 'MythBusting',
+    prompt: 'I want to stop obeying this pattern.',
+    nextStep: 'Find the bargain the myth is making and break one small piece of it.',
+  },
+  {
+    key: 'regent',
+    face: 'Regent',
+    gameName: 'Map the Terrain',
+    prompt: 'I want to take responsibility without self-punishment.',
+    nextStep: 'Name the actual field of responsibility and what is not yours to carry.',
+  },
+  {
+    key: 'architect',
+    face: 'Architect',
+    gameName: 'Build The System',
+    prompt: 'I want to build a repeatable practice.',
+    nextStep: 'Turn the charge into a structure, ritual, checklist, or support system.',
+  },
+  {
+    key: 'diplomat',
+    face: 'Diplomat',
+    gameName: 'RelationshipCraft',
+    prompt: 'I think this points to repair or conversation.',
+    nextStep: 'Shape the next relational move with consent, timing, and repair in mind.',
+  },
+  {
+    key: 'sage',
+    face: 'Sage',
+    gameName: 'Build your own Allyship Campaign',
+    prompt: 'I want to turn this into a longer campaign of practice.',
+    nextStep: 'Seed a single-player campaign from this myth, charge, and chosen posture.',
+  },
+] as const
+
+export const MYTH_CHARGE_INTENSITIES: readonly {
+  value: MythChargeIntensity
+  label: string
+  readout: string
+}[] = [
+  { value: 2, label: 'Faint', readout: 'Faint — it is present, but not steering.' },
+  { value: 4, label: 'Mild', readout: 'Mild — it tugs at the edge of things.' },
+  { value: 6, label: 'Live', readout: 'Live — it wants attention now.' },
+  { value: 8, label: 'Heavy', readout: 'Heavy — it colors everything.' },
+  { value: 10, label: 'Overwhelming', readout: 'Overwhelming — go slowly and bring support.' },
+] as const
+
+export function strengthForPct(pct: number): RankedMyth['strength'] {
+  if (pct >= 0.72) return 'Loud'
+  if (pct >= 0.55) return 'Clear'
+  return 'Faint'
+}
+
+export function scoreMyths(
+  answers: Partial<Record<MythReadItem['id'], MythReadAnswerValue>>,
+): MythReadOutcome {
+  const raw = Object.fromEntries(MYTHS.map((myth) => [myth.id, 0])) as Record<MythId, number>
+  const max = Object.fromEntries(MYTHS.map((myth) => [myth.id, 0])) as Record<MythId, number>
+  const peak = Object.fromEntries(MYTHS.map((myth) => [myth.id, 0])) as Record<MythId, number>
+
+  for (const item of MYTH_READ_ITEMS) {
+    const answer = answers[item.id] ?? 0
+    for (const [mythId, weight] of Object.entries(item.weights) as [MythId, number][]) {
+      const contribution = answer * weight
+      raw[mythId] += contribution
+      max[mythId] += 4 * weight
+      peak[mythId] = Math.max(peak[mythId], contribution)
+    }
+  }
+
+  const ranked = MYTHS.map((myth) => {
+    const pct = max[myth.id] > 0 ? raw[myth.id] / max[myth.id] : 0
+    return {
+      myth,
+      raw: raw[myth.id],
+      max: max[myth.id],
+      pct,
+      peak: peak[myth.id],
+      strength: strengthForPct(pct),
+    }
+  }).sort((a, b) => {
+    return (
+      b.pct - a.pct ||
+      b.peak - a.peak ||
+      MYTH_TIE_ORDER.indexOf(a.myth.id) - MYTH_TIE_ORDER.indexOf(b.myth.id)
+    )
+  })
+
+  const surfaced = ranked.slice(0, 3).filter((entry, index) => index === 0 || entry.pct >= 0.4)
+  const scores = Object.fromEntries(ranked.map((entry) => [entry.myth.id, entry])) as Record<
+    MythId,
+    RankedMyth
+  >
+
+  return { ranked, surfaced, scores }
+}
+
+export function buildMythReadPersistencePayload(
+  answers: Partial<Record<MythReadItem['id'], MythReadAnswerValue>>,
+  capturedCharge: MythReadCharge | null = null,
+): MythReadPersistencePayload {
+  const outcome = scoreMyths(answers)
+  const responses = MYTH_READ_ITEMS.flatMap((item) => {
+    const value = answers[item.id]
+    return value == null ? [] : [{ item: item.id, value }]
+  })
+  const topMyths = outcome.surfaced.map((entry) => entry.myth.id)
+  const rootBeliefs = Array.from(new Set(outcome.surfaced.map((entry) => entry.myth.rootBelief)))
+  const recommendedDestinations = Array.from(
+    new Set(outcome.surfaced.map((entry) => `${entry.myth.chapter}: ${entry.myth.destination}`)),
+  )
+  const flavor = capturedCharge
+    ? MYTH_CHARGE_FLAVORS.find((entry) => entry.key === capturedCharge.flavor)
+    : null
+  const game = capturedCharge?.gameFace
+    ? MYTH_GAME_FACES.find((entry) => entry.key === capturedCharge.gameFace)
+    : null
+  const chargedMyth = capturedCharge ? MYTH_BY_ID[capturedCharge.mythId] : null
+
+  return {
+    responses,
+    mythScores: outcome.ranked.map((entry) => ({
+      myth: entry.myth.id,
+      pct: entry.pct,
+      raw: entry.raw,
+      max: entry.max,
+      peak: entry.peak,
+      strength: entry.strength,
+    })),
+    topMyths,
+    rootBeliefs,
+    recommendedDestinations,
+    capturedCharge,
+    seedBarDrafts:
+      flavor && chargedMyth
+        ? [
+            {
+              myth: chargedMyth.id,
+              prompt: chargedMyth.move,
+              gameFace: game?.key ?? null,
+              gameName: game?.gameName ?? null,
+              nextStep: game?.nextStep ?? 'Choose the game you want to play with this energy.',
+            },
+          ]
+        : [],
+  }
+}


### PR DESCRIPTION
## What changed

Adds the public `/mastering-allyship/myths-read` diagnostic flow from the Chapter 0 Myths Read handoff.

- Adds canonical myth data, scoring, and focused tests.
- Adds the interactive quiz/result UI with myth cards, charge capture, GM-face game selection, CTAs, save, and retake.
- Adds `myth_reads` persistence for anonymous/email/logged-in reads.
- Lets logged-in players seed a `charge_capture` BAR from myth + charge + intensity + chosen game.
- Uses GM-face game selection as the routing vector instead of emotion-only routing.

## Why

The handoff pointed toward a single-player campaign seed, not a deterministic emotion-to-route table. This PR keeps emotion as fuel and asks the player what game they want to play with that energy.

## Validation

- `node --import tsx src/lib/mastering-allyship/__tests__/myths-read.test.ts`
- `npx eslint src/actions/myths-read.ts src/app/mastering-allyship/myths-read src/lib/mastering-allyship/myths-read.ts src/lib/mastering-allyship/__tests__/myths-read.test.ts`
- `node --import tsx scripts/verify-prisma-schema.ts`
- Next dev route check: `HEAD /mastering-allyship/myths-read` returned `200 OK`

## Notes

The `myth_reads` migration is included but has not been applied manually outside CI/preview deploy flow.