### PR TITLE
feat(ttv): rationalize task actions for born-as-quests + surface them in Show Up

### DIFF
--- a/src/actions/tap-the-vein.ts
+++ b/src/actions/tap-the-vein.ts
@@ -105,6 +105,22 @@ async function ensureBarForTask(
   }
 }
 
+/**
+ * The CustomBar a task's gestures (keep / plant) should act on. Since QLA, a
+ * committed task is **born as a quest** — its artifact is `task.questId`. Prefer
+ * that; fall back to a legacy projected BAR (`task.barId`); only mint a BAR for
+ * pre-QLA tasks that have neither. This is what stops keep/plant from re-minting
+ * a second, disconnected BAR beside the quest.
+ */
+async function artifactIdForTask(
+  playerId: string,
+  task: { id: string; questId: string | null; barId: string | null; originalText: string; lensGoalId?: string | null; attachSnapshot?: unknown },
+): Promise<string | null> {
+  if (task.questId) return task.questId
+  if (task.barId) return task.barId
+  return ensureBarForTask(playerId, task)
+}
+
 /** Lifecycle: committed → in_progress → (terminal exit states). Player is the authority. */
 const EXIT_STATES = new Set([
   'completed',
@@ -603,12 +619,14 @@ export async function promoteTaskToBar(taskId: string): Promise<TtvResult<{ barI
   try {
     const task = await db.tapTheVeinTask.findUnique({
       where: { id: taskId },
-      select: { id: true, playerId: true, barId: true, originalText: true, lensGoalId: true, attachSnapshot: true },
+      select: { id: true, playerId: true, questId: true, barId: true, originalText: true, lensGoalId: true, attachSnapshot: true },
     })
     if (!task) return { error: 'Task not found' }
     if (task.playerId !== player.id) return { error: 'Forbidden' }
 
-    const barId = await ensureBarForTask(player.id, task)
+    // Born-as-quest: the artifact already exists (the quest). Return it instead of
+    // minting a second, disconnected BAR. Legacy tasks fall back to a projected BAR.
+    const barId = await artifactIdForTask(player.id, task)
     if (!barId) return { error: 'Failed to plant task as a BAR' }
 
     revalidatePath('/tap-the-vein')
@@ -643,12 +661,14 @@ export async function plantTask(input: {
   try {
     const task = await db.tapTheVeinTask.findUnique({
       where: { id: input.taskId },
-      select: { id: true, playerId: true, barId: true, originalText: true, lensGoalId: true, attachSnapshot: true },
+      select: { id: true, playerId: true, questId: true, barId: true, originalText: true, lensGoalId: true, attachSnapshot: true },
     })
     if (!task) return { error: 'Task not found' }
     if (task.playerId !== player.id) return { error: 'Forbidden' }
 
-    const barId = await ensureBarForTask(player.id, task)
+    // Plant the task's existing artifact (the born-as-quest) — do not mint a
+    // second BAR. Writes the EA triad + gardenId onto the quest itself.
+    const barId = await artifactIdForTask(player.id, task)
     if (!barId) return { error: 'Failed to plant task' }
 
     await writePlantTriadToBar(player.id, barId, {

--- a/src/app/tap-the-vein/TapTheVeinRunner.tsx
+++ b/src/app/tap-the-vein/TapTheVeinRunner.tsx
@@ -22,9 +22,7 @@ import {
   commitTask,
   updateTaskStatus,
   carryTask,
-  promoteTaskToBar,
   plantTask,
-  upgradeTaskToQuest,
   sealSession,
 } from '@/actions/tap-the-vein'
 import { MAX_TASKS_PER_DAY } from '@/lib/tap-the-vein/constants'
@@ -156,8 +154,6 @@ export function TapTheVeinRunner({ initial, element, nationName, vibulons, campa
             return updateTaskStatus({ taskId: id, status: 'completed' })
           case 'carry':
             return carryTask(id)
-          case 'keep':
-            return promoteTaskToBar(id)
           case 'plant':
             return plantTask({
               taskId: id,
@@ -168,8 +164,6 @@ export function TapTheVeinRunner({ initial, element, nationName, vibulons, campa
               if (!('error' in res)) setPlantedTrace(res.plantSnapshot ?? null)
               return res
             })
-          case 'upgrade':
-            return upgradeTaskToQuest(id)
           case 'compost':
             return updateTaskStatus({ taskId: id, status: 'composted', compostReason: a.reason })
           case 'assign':

--- a/src/app/tap-the-vein/TaskActionSheet.tsx
+++ b/src/app/tap-the-vein/TaskActionSheet.tsx
@@ -19,9 +19,7 @@ export type SheetAction =
   | { kind: 'start' }
   | { kind: 'complete' }
   | { kind: 'carry' }
-  | { kind: 'keep' }
   | { kind: 'plant'; experienceIntent: string; dissatisfaction: string[]; satisfaction: string[] }
-  | { kind: 'upgrade' }
   | { kind: 'compost'; reason: string }
   | { kind: 'assign'; campaignId: string; visibility: 'campaign' | null }
 
@@ -130,18 +128,9 @@ export function TaskActionSheet({
             )}
             <ActionRow icon="✓" iconColor={gem} label="Complete" hint="pave a brick · ♦+1" disabled={busy} onClick={() => onAction({ kind: 'complete' })} />
             <ActionRow icon="↻" label="Carry to tomorrow" hint="keeps the thread" disabled={busy} onClick={() => onAction({ kind: 'carry' })} />
-            <ActionRow icon="❖" label="Keep as a BAR" hint="plant in the loop" disabled={busy} onClick={() => onAction({ kind: 'keep' })} />
-            <ActionRow icon="❀" label="Plant in Garden" hint="grow it under today's lens" disabled={busy} onClick={() => setMode('plant')} />
+            <ActionRow icon="❀" label="Plant in Garden" hint="grow this quest under today's lens" disabled={busy} onClick={() => setMode('plant')} />
             <ActionRow icon="↩" label="Compost" hint="return to field" disabled={busy} onClick={() => setMode('compost')} />
             <ActionRow icon="◇" label="Assign to campaign" hint="private by default" disabled={busy} onClick={() => setMode('assign')} />
-            <ActionRow
-              icon="✦"
-              label="Upgrade — quest or daemon"
-              hint="out of hand →"
-              highlight
-              disabled={busy}
-              onClick={() => onAction({ kind: 'upgrade' })}
-            />
           </div>
         )}
 

--- a/src/lib/vault-queries.ts
+++ b/src/lib/vault-queries.ts
@@ -47,7 +47,13 @@ export function chargeRoomWhere(playerId: string) {
 export const unplacedPersonalQuestWhere = (playerId: string) => ({
     creatorId: playerId,
     type: 'quest' as const,
-    OR: [{ sourceBarId: { not: null } }, { source321SessionId: { not: null } }],
+    // Personal quests: grown from a BAR, from a 3·2·1 session, or born from a
+    // Tap-the-Vein commit (QLA — `questSource` tags the origin, e.g. 'tap_the_vein').
+    OR: [
+        { sourceBarId: { not: null } },
+        { source321SessionId: { not: null } },
+        { questSource: { not: null } },
+    ],
     parentId: null,
     status: 'active' as const,
     archivedAt: null,


### PR DESCRIPTION
## Summary

Follow-up to the QLA arc (PR #157). Now that a committed Tap-the-Vein task is **born as a quest**, the old task gestures were either re-minting a second, disconnected BAR beside the quest or acting as no-ops, and the born-as-quests only showed in *All BARs* — not the curated Show-Up room. This cleans both up.

## Task action sheet

- **Removed "Keep as a BAR"** — the task is already a quest sitting in the Hand/Vault; the gesture only re-minted a duplicate, disconnected BAR.
- **Removed "Upgrade — quest or daemon"** — obsolete; `upgradeTaskToQuest` was already an idempotent no-op for born-as-quests.
- **"Plant in Garden" now acts on the quest itself** via a new `artifactIdForTask` helper (prefers `task.questId`, falls back to a legacy `task.barId`, and only mints a BAR for pre-QLA tasks with neither). Writes the EA triad + `gardenId` onto the existing quest instead of a second artifact. `promoteTaskToBar` got the same guard.
- Dropped the now-dead `'keep'` / `'upgrade'` `SheetAction` variants, runner switch cases, and imports.

The sheet is now purely the quest's day: **Start · Complete · Carry · Plant · Compost · Assign**.

## Show Up room

- `unplacedPersonalQuestWhere` now also matches `questSource != null`, so `tap_the_vein`-born quests appear in **`/vault/quests`** (and its lobby count), reusing the `questSource` origin hint set at commit time.

## Files

- `src/actions/tap-the-vein.ts` — `artifactIdForTask` helper; `plantTask` / `promoteTaskToBar` repointed to the born-as-quest artifact.
- `src/app/tap-the-vein/TaskActionSheet.tsx` — removed the two obsolete rows + dead union variants.
- `src/app/tap-the-vein/TapTheVeinRunner.tsx` — removed dead handler cases + imports.
- `src/lib/vault-queries.ts` — `questSource` added to the unplaced-quest filter.

## Verification

- **ESLint clean** on all four files.
- Full `npm run build` / `tsc` could **not** run in the authoring sandbox (Prisma engine download is blocked); relying on CI for the build gate.

## Notes / follow-ups

- A *planted* quest still matches the Show-Up filter (it doesn't exclude garden/matured items), so a planted quest can appear in both the Garden and the Show-Up room — a minor double-surface, easy to tighten later.
- No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G97irTjRgj4pXFzGbHjxkQ)_