### PR TITLE
launch: scope /launch to book + deck + Founding Ally, move packs to deck sales

### DIFF
--- a/src/app/deck/sales/page.tsx
+++ b/src/app/deck/sales/page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/launch/deck-sales-copy'
 import { DeckFanHero } from '@/components/deck/DeckFanHero'
 import { MovePip } from '@/components/deck/MovePip'
+import { LAUNCH_OFFERS, formatPrice, isOfferLive, isSuperpowerPackKey } from '@/lib/launch/offers'
 
 export const metadata: Metadata = {
   title: 'The Allyship Deck — 120 moves for doing the work',
@@ -174,6 +175,9 @@ export default function DeckSalesPage() {
         </div>
       </section>
 
+      {/* Expansion-pack upsell */}
+      <PackUpsell />
+
       {/* Social proof */}
       <section
         style={{
@@ -219,6 +223,137 @@ function Stat({ value, label }: { value: string; label: string }) {
         {label}
       </div>
     </div>
+  )
+}
+
+/**
+ * Expansion-pack upsell — the seven $8 superpower packs, sold beside the deck
+ * (their home surface; they are held back from the /launch grid). Reads the
+ * launch registry so name/price/link never drift; a pack with no Gumroad URL
+ * shows an honest "Coming soon" instead of a dead link.
+ */
+function PackUpsell() {
+  const packs = LAUNCH_OFFERS.filter((o) => isSuperpowerPackKey(o.key))
+  if (packs.length === 0) return null
+
+  return (
+    <section style={{ marginBottom: 52 }}>
+      <SectionLabel>Go deeper · expansion packs</SectionLabel>
+      <p
+        style={{
+          fontFamily: DECK_FONTS.body,
+          fontSize: 14,
+          lineHeight: 1.5,
+          color: SURFACE_TOKENS.textSecondary,
+          textAlign: 'center',
+          margin: '10px auto 0',
+          maxWidth: 520,
+        }}
+      >
+        Add your superpowers to the deck — 60 move-cards each, inner and outer.
+        {' '}
+        {formatPrice(packs[0].priceCents)} a pack.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
+          gap: 12,
+          marginTop: 18,
+        }}
+      >
+        {packs.map((pack) => {
+          const live = isOfferLive(pack)
+          return (
+            <div
+              key={pack.key}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                padding: '16px 15px',
+                borderRadius: 10,
+                background: SURFACE_TOKENS.surfaceInset,
+                border: '1px solid rgba(255,255,255,.08)',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'block',
+                  width: 26,
+                  height: 26,
+                  borderRadius: 7,
+                  background: pack.accent ?? 'var(--bars-text-secondary)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.25)',
+                }}
+              />
+              <div
+                style={{
+                  fontFamily: DECK_FONTS.display,
+                  fontWeight: 700,
+                  fontSize: 15,
+                  color: '#fff',
+                  margin: '12px 0 4px',
+                }}
+              >
+                {pack.name}
+              </div>
+              <p
+                style={{
+                  fontFamily: DECK_FONTS.body,
+                  fontSize: 12.5,
+                  lineHeight: 1.45,
+                  color: SURFACE_TOKENS.textSecondary,
+                  margin: '0 0 14px',
+                  flex: 1,
+                }}
+              >
+                {pack.blurb}
+              </p>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 15, color: DECK_GOLD }}>
+                  {formatPrice(pack.priceCents)}
+                </span>
+                {live ? (
+                  <a
+                    href={pack.gumroadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      fontFamily: DECK_FONTS.display,
+                      fontWeight: 700,
+                      fontSize: 13,
+                      color: '#150a04',
+                      background: DECK_GOLD,
+                      padding: '8px 14px',
+                      borderRadius: 999,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    Add →
+                  </a>
+                ) : (
+                  <span
+                    style={{
+                      fontFamily: DECK_FONTS.mono,
+                      fontSize: 10,
+                      letterSpacing: '.1em',
+                      textTransform: 'uppercase',
+                      color: SURFACE_TOKENS.textSecondary,
+                      border: '1px dashed rgba(255,255,255,.2)',
+                      padding: '6px 10px',
+                      borderRadius: 999,
+                    }}
+                  >
+                    Coming soon
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
   )
 }
 

--- a/src/app/launch/LaunchOffers.tsx
+++ b/src/app/launch/LaunchOffers.tsx
@@ -87,7 +87,9 @@ function Cta({ offer, href, label }: { offer: LaunchOffer; href: string; label: 
 const HERO_BY_INTENT: Record<LaunchIntent, LaunchOffer['key']> = {
   curious: 'book-digital',
   tool: 'deck-digital',
-  practice: 'game-subscription',
+  // The game subscription is held back from this launch (hiddenFromLaunch); the
+  // deck is the ongoing practice players get today, so "I want a practice" leads here.
+  practice: 'deck-digital',
   shelf: 'founding-ally',
 }
 
@@ -577,9 +579,13 @@ export function LaunchOffers({
   isAdmin: boolean
 }) {
   const [intent, setIntent] = useState<LaunchIntent | null>(null)
-  const bundle = offersByGroup('bundle').filter(isCoreLaunchOffer)
-  const digital = offersByGroup('digital').filter(isCoreLaunchOffer)
-  const physical = offersByGroup('physical').filter(isCoreLaunchOffer)
+  // isCoreLaunchOffer narrows key to CoreOfferKey (needed to index content.offers);
+  // the second filter drops offers held back from this launch without widening the type.
+  const shown = (offers: readonly LaunchOffer[]) =>
+    offers.filter(isCoreLaunchOffer).filter((o) => !o.hiddenFromLaunch)
+  const bundle = shown(offersByGroup('bundle'))
+  const digital = shown(offersByGroup('digital'))
+  const physical = shown(offersByGroup('physical'))
   const allOffers = [...bundle, ...digital, ...physical]
   const heroKey = intent ? HERO_BY_INTENT[intent] : 'founding-ally'
   const hero = allOffers.find((offer) => offer.key === heroKey) ?? bundle[0] ?? digital[0]

--- a/src/lib/launch/offers.ts
+++ b/src/lib/launch/offers.ts
@@ -82,6 +82,13 @@ export interface LaunchOffer {
    * `priceCents` is ignored for display when set.
    */
   inquire?: boolean
+  /**
+   * Hide this offer from the /launch storefront grid while keeping it in the
+   * registry (so the webhook can still resolve its SKU and entitlements still
+   * grant). Use for SKUs sold elsewhere or paused for a given launch — e.g. the
+   * RPG handbook and game subscription are held back from the book/deck launch.
+   */
+  hiddenFromLaunch?: boolean
   /** Gumroad product URL, or '' when not yet wired. */
   gumroadUrl: string
   /** CTA verb, e.g. "Buy", "Preorder", "Subscribe". */
@@ -173,6 +180,7 @@ const CORE_LAUNCH_OFFERS: readonly LaunchOffer[] = [
     priceCents: 3000,
     gumroadUrl: GUMROAD.rpgHandbookDigital,
     cta: 'Buy',
+    hiddenFromLaunch: true,
     element: 'metal',
     altitude: 'neutral',
     stage: 'growing',
@@ -212,6 +220,7 @@ const CORE_LAUNCH_OFFERS: readonly LaunchOffer[] = [
     recurring: 'month',
     gumroadUrl: GUMROAD.gameSubscription,
     cta: 'Subscribe',
+    hiddenFromLaunch: true,
     element: 'wood',
     altitude: 'neutral',
     stage: 'growing',
@@ -238,6 +247,7 @@ const CORE_LAUNCH_OFFERS: readonly LaunchOffer[] = [
     preorder: true,
     gumroadUrl: GUMROAD.rpgHandbookPhysical,
     cta: 'Preorder',
+    hiddenFromLaunch: true,
     element: 'metal',
     altitude: 'neutral',
     stage: 'growing',

--- a/src/lib/launch/page-content.ts
+++ b/src/lib/launch/page-content.ts
@@ -71,7 +71,7 @@ export const LAUNCH_DEFAULT_CONTENT: LaunchPageContent = {
       key: 'practice',
       element: 'wood',
       label: 'I want a practice',
-      sub: 'Play the ongoing game.',
+      sub: 'Make the deck your daily practice.',
     },
     {
       key: 'shelf',
@@ -129,7 +129,7 @@ export const LAUNCH_DEFAULT_CONTENT: LaunchPageContent = {
       kicker: 'Digital deck',
       image: '/launch/allyship-deck-thumbnail-1080x1080.png',
       heroImage: '/launch/allyship-deck-cover-1280x720.png',
-      intents: ['tool'],
+      intents: ['tool', 'practice'],
     },
     'game-subscription': {
       name: 'The Game — Monthly',


### PR DESCRIPTION
## What & why

Tailors the launch storefront for the Kickstarter book/deck go-live. The Gumroad wiring itself is env/dashboard config (no code) — this PR is the page-composition changes that surface the right offers on the right surfaces.

## Changes

- **Hold the RPG handbook + game subscription back from `/launch`.** Adds a `hiddenFromLaunch` flag to the offer registry (`src/lib/launch/offers.ts`) and marks `rpg-handbook-digital`, `rpg-handbook-physical`, and `game-subscription`. They stay in the registry so the Gumroad webhook still resolves their SKUs and entitlements still grant — they just drop off the grid. `/launch` now shows **Founding Ally, Book (digital + physical), Deck (digital + physical)**.
- **Repoint the "I want a practice" chooser intent** from the now-hidden game subscription to the digital deck — the ongoing practice players get today — and tag `deck-digital` with the `practice` intent so the chooser highlights it instead of dimming every card.
- **Surface the 7 × $8 superpower expansion packs as an upsell on `/deck/sales`** (their home surface, since they're held off `/launch`). Read from the launch registry so name/price/link never drift; a pack with no Gumroad URL renders an honest "Coming soon" instead of a dead link.

## Notes

- No SKUs were deleted — `hiddenFromLaunch` is display-only, preserving webhook SKU resolution and entitlement grants.
- The `book-digital → 30-day app-access` grant is unchanged; the offer copy remains accurate once the book runs the same license-key → `/redeem` flow as the deck.

## Verification

- `tsc --noEmit` clean
- Launch + paywall tests pass (`src/lib/launch`, `book-launch-paywall`)
- `npm run launch:check` confirms the two wired products (`book-digital`, `deck-digital`) render as sellable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDKLTFu1XCPU6PNJStKjjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDKLTFu1XCPU6PNJStKjjK)_