### PR TITLE
feat(kickstarter): MTGOA Kickstarter CYOA hub (spec v2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
 @import "../styles/promise-forge.css";
 @import "../styles/superpower-quiz.css";
 @import "../styles/mastering-allyship.css";
+@import "../styles/kickstarter-hub.css";
 
 :root {
   --background: #ffffff;

--- a/src/app/kickstarter/SelfReport.tsx
+++ b/src/app/kickstarter/SelfReport.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from 'react'
+import { SELF_REPORT_CATEGORIES } from '@/lib/kickstarter-hub/content'
+
+/**
+ * Self-report — identification, not solicitation (§4). The visitor tells us who
+ * they are; we capture intent only. Where this data ultimately routes is
+ * Wendell's open decision (§9), so this component deliberately does NOT commit to
+ * a backend: on submit it composes a plain mailto to the configured address,
+ * which needs no infrastructure and prejudges nothing. Swap the mailto for a
+ * server action once the routing decision lands.
+ */
+export function SelfReport({ audience }: { audience: 'warm' | 'public' }) {
+  const [picked, setPicked] = useState<string | null>(null)
+
+  const to =
+    process.env.NEXT_PUBLIC_HUB_SELFREPORT_EMAIL?.trim() || 'wendell@masteringallyship.com'
+  const category = SELF_REPORT_CATEGORIES.find((c) => c.key === picked)
+
+  const mailtoHref = category
+    ? `mailto:${to}?subject=${encodeURIComponent(
+        `[hub] ${category.label}`,
+      )}&body=${encodeURIComponent(
+        `${category.blurb}\n\n(sent from the ${audience} kickstarter hub — self-report: ${category.key})\n\n`,
+      )}`
+    : undefined
+
+  return (
+    <div className="space-y-3">
+      <p
+        className="text-[13px]"
+        style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-secondary)' }}
+      >
+        no ask attached — just tell me who you are, so i know how to have you in this.
+      </p>
+      <div role="group" aria-label="who you are" className="grid gap-2 sm:grid-cols-2">
+        {SELF_REPORT_CATEGORIES.map((c) => (
+          <button
+            key={c.key}
+            type="button"
+            className="ks-chip"
+            aria-pressed={picked === c.key}
+            onClick={() => setPicked((prev) => (prev === c.key ? null : c.key))}
+          >
+            <span
+              className="block text-[13px] font-bold lowercase"
+              style={{ color: 'var(--bars-text-primary)' }}
+            >
+              {c.label}
+            </span>
+            <span
+              className="block text-[12px]"
+              style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+            >
+              {c.blurb}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {category && mailtoHref && (
+        <div className="ks-rise flex flex-wrap items-center gap-3 pt-1">
+          <a className="ks-cta" href={mailtoHref}>
+            send this to wendell →
+          </a>
+          <span
+            className="text-[12px]"
+            style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+          >
+            opens your mail app — nothing sent until you hit send.
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/kickstarter/ShareKit.tsx
+++ b/src/app/kickstarter/ShareKit.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { SHARE_SNIPPETS, type HubAudience } from '@/lib/kickstarter-hub/content'
+
+/**
+ * ShareKit — the concrete, low-friction "help sell the book" / "post on social"
+ * action (§4). Not "spread the word" with nothing to click: ready-to-send copy
+ * with a one-tap copy button. Anchored at #share-kit so both get-involved actions
+ * point here.
+ */
+export function ShareKit({ audience }: { audience: HubAudience }) {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  async function copy(key: string, text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(key)
+      window.setTimeout(() => setCopied((k) => (k === key ? null : k)), 2000)
+    } catch {
+      setCopied(null)
+    }
+  }
+
+  return (
+    <div id="share-kit" className="space-y-3 scroll-mt-20">
+      {SHARE_SNIPPETS.map((s) => {
+        const text = audience === 'warm' ? s.textWarm : s.textPublic
+        return (
+          <div key={s.key} className="ks-copy p-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <span className="ks-eyebrow">{s.label}</span>
+              <button
+                type="button"
+                className="ks-cta ks-cta--ghost"
+                style={{ minHeight: 36, fontSize: 13, padding: '0 14px' }}
+                onClick={() => copy(s.key, text)}
+                aria-label={`copy ${s.label} post`}
+              >
+                {copied === s.key ? 'copied ✓' : 'copy'}
+              </button>
+            </div>
+            <p
+              className="text-[13px]"
+              style={{
+                fontFamily: 'var(--bars-font-body)',
+                lineHeight: 1.55,
+                color: 'var(--bars-text-primary)',
+              }}
+            >
+              {text}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/kickstarter/chapter-1/page.tsx
+++ b/src/app/kickstarter/chapter-1/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { chapterOnePreviewReady, type HubAudience } from '@/lib/kickstarter-hub/content'
+
+/**
+ * @route GET /kickstarter/chapter-1
+ * @page /kickstarter/chapter-1
+ * @entity CAMPAIGN
+ * @description Chapter 1 preview surface for the Kickstarter hub (SPEC v2 §6).
+ *   The hub's "what's next" branch always routes here. Until the excerpt lands it
+ *   renders an honest coming-soon holding state (§5) with a real link on to
+ *   /launch — a link the reader chooses, NOT a redirect. When the excerpt is
+ *   authored, replace the ComingSoon block below with it and flip
+ *   NEXT_PUBLIC_HUB_CHAPTER1_READY=true so the hub upgrades in lockstep.
+ * @permissions public
+ * @query audience — "warm" (default) | "public"
+ * @example /kickstarter/chapter-1
+ * @agentDiscoverable true
+ */
+
+export const metadata: Metadata = {
+  title: 'Mastering the Game of Allyship — Chapter 1',
+  description:
+    'The opening chapter of Mastering the Game of Allyship — landing here very soon.',
+}
+
+function normalizeAudience(v?: string): HubAudience {
+  return v === 'public' ? 'public' : 'warm'
+}
+
+export default async function ChapterOnePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ audience?: string }>
+}) {
+  const { audience: rawAudience } = await searchParams
+  const audience = normalizeAudience(rawAudience)
+  const hubHref = audience === 'public' ? '/kickstarter?audience=public' : '/kickstarter'
+
+  // The excerpt isn't wired yet — render the coming-soon fallback. When the real
+  // Chapter 1 content is added, gate it on `ready` here.
+  const ready = chapterOnePreviewReady()
+
+  const body =
+    audience === 'warm'
+      ? "the actual opening of the book you backed — not a status update, the real thing. it's in final polish and lands right here in the next day or two. this page will upgrade itself the moment it's ready; nothing to do but check back."
+      : "the actual opening of the book — in final polish, landing right here in the next day or two. this page upgrades itself the moment it's ready."
+
+  return (
+    <main className="ks-hub flex justify-center">
+      <div className="flex w-full max-w-[620px] flex-col gap-5 px-5 pb-16 pt-8">
+        {/* Breadcrumb back to the hub — no redirect, the reader chooses. */}
+        <nav className="ks-rise">
+          <Link
+            href={hubHref}
+            className="text-[12px]"
+            style={{
+              fontFamily: 'var(--bars-font-mono)',
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--bars-text-secondary)',
+            }}
+          >
+            ← back to your next step
+          </Link>
+        </nav>
+
+        <section
+          className="ks-card ks-card--holding ks-rise p-6 sm:p-7"
+          data-accent="coral"
+          aria-label="chapter 1 — coming soon"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <span className="ks-eyebrow">05 · what’s next</span>
+            <span className="ks-pill ks-pill--soon">coming soon</span>
+          </div>
+
+          <h1
+            className="mt-2 text-[26px] font-bold lowercase sm:text-[30px]"
+            style={{
+              fontFamily: 'var(--bars-font-display)',
+              letterSpacing: '-0.02em',
+              lineHeight: 1.08,
+              color: 'var(--bars-text-primary)',
+              textWrap: 'balance',
+            }}
+          >
+            read chapter 1
+          </h1>
+
+          <p
+            className="mt-3 max-w-[54ch] text-[14px]"
+            style={{
+              fontFamily: 'var(--bars-font-body)',
+              lineHeight: 1.6,
+              color: 'var(--bars-text-secondary)',
+            }}
+          >
+            {body}
+          </p>
+
+          <p
+            className="mt-4 rounded-[10px] border border-dashed p-3 text-[13px]"
+            style={{
+              borderColor: 'var(--bars-line-dashed)',
+              fontFamily: 'var(--bars-font-body)',
+              lineHeight: 1.55,
+              color: 'var(--bars-text-muted)',
+            }}
+          >
+            coming very soon — the excerpt is in final polish. we’d rather show you the real thing
+            than a placeholder{ready ? ', and it’s nearly here' : ''}.
+          </p>
+
+          {/* A real link on to /launch — the reader's choice, not a redirect. */}
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <Link className="ks-cta" href="/launch">
+              {audience === 'warm' ? 'see everything you backed' : 'see the whole thing'} →
+            </Link>
+            <Link className="ks-cta ks-cta--ghost" href={hubHref}>
+              back to the hub
+            </Link>
+          </div>
+
+          <p
+            className="mt-3 text-[12px]"
+            style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+          >
+            the book, the deck, and the game all live on the launch page — while you wait for the
+            excerpt.
+          </p>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/app/kickstarter/page.tsx
+++ b/src/app/kickstarter/page.tsx
@@ -225,7 +225,7 @@ export default async function KickstarterHubPage({
   const { audience: rawAudience } = await searchParams
   const audience = normalizeAudience(rawAudience)
   const header = headerFor(audience)
-  const branches = hubBranches()
+  const branches = hubBranches(audience)
 
   return (
     <main className="ks-hub flex justify-center">

--- a/src/app/kickstarter/page.tsx
+++ b/src/app/kickstarter/page.tsx
@@ -1,0 +1,285 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  bodyFor,
+  headerFor,
+  hubBranches,
+  involveActions,
+  oneOnOneScheduleHref,
+  type HubAudience,
+  type HubBranch,
+  type HubCta,
+} from '@/lib/kickstarter-hub/content'
+import { SelfReport } from './SelfReport'
+import { ShareKit } from './ShareKit'
+
+/**
+ * @route GET /kickstarter
+ * @page /kickstarter
+ * @entity CAMPAIGN
+ * @description MTGOA Kickstarter CYOA hub (SPEC v2). A single interactive page,
+ *   linked from the July 17 backer email (warm) and social (public), that lets a
+ *   backer self-select their next step. A persistent fulfillment header answers
+ *   "how/when do I get my stuff" without a click; seven branches mirror the
+ *   book's own developmental spine (wake up → open up → clean up → show up →
+ *   what's next → get involved → help fund). Every branch carries a visible
+ *   status and a non-dead fallback. `?audience=public` switches to the public
+ *   register; default is the warm (backer) register.
+ * @permissions public
+ * @query audience — "warm" (default) | "public"
+ * @example /kickstarter
+ * @example /kickstarter?audience=public
+ * @agentDiscoverable true
+ */
+
+export const metadata: Metadata = {
+  title: 'Mastering the Game of Allyship — Your Next Step',
+  description:
+    'The book ships August 1 — and a game, two quizzes, and a deck for doing the work are ready to play with right now. Pick your next step.',
+}
+
+function normalizeAudience(v?: string): HubAudience {
+  return v === 'public' ? 'public' : 'warm'
+}
+
+function StatusPill({ status }: { status: HubBranch['status'] }) {
+  return status === 'ready' ? (
+    <span className="ks-pill ks-pill--ready">ready now</span>
+  ) : (
+    <span className="ks-pill ks-pill--soon">coming soon</span>
+  )
+}
+
+function Cta({ cta }: { cta: HubCta }) {
+  const cls = cta.secondary ? 'ks-cta ks-cta--ghost' : 'ks-cta'
+  if (cta.external) {
+    return (
+      <a className={cls} href={cta.href} target="_blank" rel="noopener noreferrer">
+        {cta.label} →
+      </a>
+    )
+  }
+  return (
+    <Link className={cls} href={cta.href}>
+      {cta.label} →
+    </Link>
+  )
+}
+
+/** The expanded get-involved branch (§4): four concrete actions, then the share
+ *  kit, then the identification-not-solicitation self-report. */
+function GetInvolved({ audience }: { audience: HubAudience }) {
+  const actions = involveActions()
+  const scheduleHref = oneOnOneScheduleHref()
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {actions.map((a) => (
+          <div key={a.key} className="ks-card ks-card--interactive p-4" data-accent="coral">
+            <div className="flex items-start justify-between gap-3">
+              <h4 className="text-[15px] font-bold lowercase" style={{ color: 'var(--bars-text-primary)' }}>
+                {a.title}
+              </h4>
+              <StatusPill status={a.status} />
+            </div>
+            <p
+              className="mt-1.5 text-[13px]"
+              style={{
+                fontFamily: 'var(--bars-font-body)',
+                lineHeight: 1.5,
+                color: 'var(--bars-text-secondary)',
+              }}
+            >
+              {audience === 'warm' ? a.bodyWarm : a.bodyPublic}
+            </p>
+            {a.key === '1on1' && scheduleHref && (
+              <p
+                className="mt-1 text-[12px]"
+                style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+              >
+                pay via gumroad, then pick your time on{' '}
+                <a
+                  href={scheduleHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                  style={{ color: 'var(--ks-teal-lite)' }}
+                >
+                  calendly
+                </a>
+                .
+              </p>
+            )}
+            <div className="mt-3">
+              <Cta cta={a.cta} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Help sell the book / post on social — the concrete copy to paste. */}
+      <div>
+        <span className="ks-eyebrow">ready-to-send copy</span>
+        <div className="mt-2">
+          <ShareKit audience={audience} />
+        </div>
+      </div>
+
+      {/* Self-report — identification, not solicitation. */}
+      <div>
+        <span className="ks-eyebrow">or just tell me who you are</span>
+        <div className="mt-2">
+          <SelfReport audience={audience} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Branch({ branch, audience }: { branch: HubBranch; audience: HubAudience }) {
+  const isHolding = branch.status === 'coming-soon'
+  const interactive = Boolean(branch.ctas?.length) || branch.order === 6
+  const cardClass = [
+    'ks-card',
+    'p-5 sm:p-6',
+    'ks-rise',
+    branch.primary ? 'ks-card--primary' : '',
+    isHolding ? 'ks-card--holding' : '',
+    interactive ? 'ks-card--interactive' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <section
+      className={cardClass}
+      data-accent={branch.accent}
+      aria-label={`step ${branch.order}: ${branch.move}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <span className="ks-eyebrow">{branch.eyebrow}</span>
+        <StatusPill status={branch.status} />
+      </div>
+
+      <h2
+        className="mt-2 text-[22px] font-bold lowercase sm:text-[26px]"
+        style={{
+          fontFamily: 'var(--bars-font-display)',
+          letterSpacing: '-0.02em',
+          lineHeight: 1.08,
+          color: branch.primary ? 'var(--ks-accent-lite)' : 'var(--bars-text-primary)',
+          textWrap: 'balance',
+        }}
+      >
+        {branch.title}
+      </h2>
+
+      <p
+        className="mt-2 max-w-[52ch] text-[14px]"
+        style={{
+          fontFamily: 'var(--bars-font-body)',
+          lineHeight: 1.6,
+          color: 'var(--bars-text-secondary)',
+        }}
+      >
+        {bodyFor(branch, audience)}
+      </p>
+
+      {branch.order === 6 && (
+        <div className="mt-5">
+          <GetInvolved audience={audience} />
+        </div>
+      )}
+
+      {branch.ctas && branch.ctas.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          {branch.ctas.map((cta) => (
+            <Cta key={cta.href + cta.label} cta={cta} />
+          ))}
+        </div>
+      )}
+
+      {/* Coming-soon holding state (§5): "here's what's coming and why", never a dead link. */}
+      {isHolding && branch.holding && (
+        <p
+          className="mt-4 rounded-[10px] border border-dashed p-3 text-[13px]"
+          style={{
+            borderColor: 'var(--bars-line-dashed)',
+            fontFamily: 'var(--bars-font-body)',
+            lineHeight: 1.55,
+            color: 'var(--bars-text-muted)',
+          }}
+        >
+          {branch.holding}
+        </p>
+      )}
+    </section>
+  )
+}
+
+export default async function KickstarterHubPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ audience?: string }>
+}) {
+  const { audience: rawAudience } = await searchParams
+  const audience = normalizeAudience(rawAudience)
+  const header = headerFor(audience)
+  const branches = hubBranches()
+
+  return (
+    <main className="ks-hub flex justify-center">
+      <div className="flex w-full max-w-[680px] flex-col gap-5 px-5 pb-16 pt-8">
+        {/* Kicker */}
+        <header className="ks-rise flex flex-col gap-2">
+          <span className="ks-eyebrow">{header.kicker}</span>
+
+          {/* Persistent fulfillment header (§2) — answers Q1 before any choice. */}
+          <div className="ks-fulfillment mt-1 p-4 sm:p-5">
+            <p
+              className="text-[17px] font-bold lowercase sm:text-[19px]"
+              style={{
+                fontFamily: 'var(--bars-font-display)',
+                letterSpacing: '-0.01em',
+                lineHeight: 1.18,
+                color: 'var(--bars-text-primary)',
+                textWrap: 'balance',
+              }}
+            >
+              {header.statusLine}
+            </p>
+            <p
+              className="mt-2 text-[13.5px]"
+              style={{
+                fontFamily: 'var(--bars-font-body)',
+                lineHeight: 1.55,
+                color: 'var(--bars-text-secondary)',
+              }}
+            >
+              {header.subline}
+            </p>
+          </div>
+
+          <p
+            className="mt-1 text-[13px]"
+            style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+          >
+            pick where you want to go next — most doors are open right now.
+          </p>
+        </header>
+
+        {/* The spine (§3) */}
+        {branches.map((branch) => (
+          <Branch key={branch.order} branch={branch} audience={audience} />
+        ))}
+
+        <p
+          className="mt-2 text-center text-[12px]"
+          style={{ fontFamily: 'var(--bars-font-body)', color: 'var(--bars-text-muted)' }}
+        >
+          the book ships august 1. everything marked “ready now” is yours to use today.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/kickstarter-hub/content.ts
+++ b/src/lib/kickstarter-hub/content.ts
@@ -244,9 +244,18 @@ export const SHARE_SNIPPETS: ShareSnippet[] = [
   },
 ]
 
+/** Internal link to the Chapter 1 surface, keeping the reader's register. Always
+ *  a real destination — the excerpt when ready, else the coming-soon page (§5/§6);
+ *  never a redirect and never a dead link. */
+export function chapterOneHref(audience: HubAudience): string {
+  const base = '/kickstarter/chapter-1'
+  return audience === 'public' ? `${base}?audience=public` : base
+}
+
 // ── The spine (§3) ──────────────────────────────────────────────────────────
 
-export function hubBranches(): HubBranch[] {
+export function hubBranches(audience: HubAudience = 'warm'): HubBranch[] {
+  const chapterReady = chapterOnePreviewReady()
   return [
     // 1 — Wake Up: framing beat. New copy, no build. Must explain the *point*
     // before asking for a quiz answer.
@@ -322,13 +331,18 @@ export function hubBranches(): HubBranch[] {
         "proof, not a status update: the actual opening of the book you backed. it's in final polish and lands here in the next day or two — this page upgrades itself the moment it's ready.",
       bodyPublic:
         "the actual opening of the book — in final polish, landing here in the next day or two. this page upgrades itself the moment it's ready.",
-      status: chapterOnePreviewReady() ? 'ready' : 'coming-soon',
+      status: chapterReady ? 'ready' : 'coming-soon',
       accent: 'coral',
-      ctas: chapterOnePreviewReady()
-        ? [{ label: 'read chapter 1', href: '/kickstarter/chapter-1' }]
-        : undefined,
+      // Always a real destination: the excerpt when ready, else the coming-soon
+      // page (which itself points on to /launch). Never a dead link (§5).
+      ctas: [
+        {
+          label: chapterReady ? 'read chapter 1' : 'see what’s coming',
+          href: chapterOneHref(audience),
+        },
+      ],
       holding:
-        "coming very soon — the excerpt is in final polish. nothing to click yet on purpose; we'd rather show you the real thing than a placeholder. check back tomorrow.",
+        "coming very soon — the excerpt is in final polish. we'd rather show you the real thing than a placeholder, so it lands here in the next day or two.",
     },
     // 6 — Get involved: expanded self-report + concrete CTAs. Rendered by the
     // page from involveActions() + SELF_REPORT_CATEGORIES + SHARE_SNIPPETS.

--- a/src/lib/kickstarter-hub/content.ts
+++ b/src/lib/kickstarter-hub/content.ts
@@ -1,0 +1,370 @@
+/**
+ * Kickstarter CYOA Hub — content model.
+ *
+ * Single source of truth for the July 17 Kickstarter hub (SPEC v2,
+ * .specify docs: SPEC_KICKSTARTER_CYOA_HUB v2). The hub is a single interactive
+ * page that answers a backer's three real questions without a click:
+ *   1. how and when do I get my stuff   → the persistent fulfillment header (§2)
+ *   2. what's next for MTGOA             → the Chapter 1 preview branch (§6)
+ *   3. how can I get involved            → the expanded get-involved branch (§4)
+ *
+ * Branches are sequenced to mirror the reader's own journey through the book
+ * (§3), not a product inventory. Every branch carries an explicit, visible
+ * status and — when its asset isn't ready — a defined non-dead fallback (§5).
+ *
+ * Warm vs public (§7): the same branch set renders in two registers. The warm
+ * hub (linked from the backer email) references the backing relationship and
+ * "yours now, all of it"; the public hub (linked from social) drops that and
+ * reframes as an invitation, while still stating the Aug 1 ship date plainly.
+ *
+ * Copy is deliberately lowercase (§8, visual system). Wording marked
+ * "Wendell to finalize" in the spec is set here as a sensible default and is
+ * safe to edit in place — this file is content, not logic.
+ */
+
+import { offerHref } from '@/lib/launch/offers'
+
+export type HubAudience = 'warm' | 'public'
+
+/** Every branch is visibly either actionable now, or honestly not-yet (§5). */
+export type BranchStatus = 'ready' | 'coming-soon'
+
+/** Accent channel (§8): coral is the primary action color; teal is reserved
+ *  for the core transformation moves (open up / clean up / show up). */
+export type HubAccent = 'coral' | 'teal'
+
+export interface HubCta {
+  label: string
+  href: string
+  /** Opens in a new tab (external commerce / scheduling surfaces). */
+  external?: boolean
+  /** Secondary CTAs render as a quieter ghost link beside the primary. */
+  secondary?: boolean
+}
+
+export interface HubBranch {
+  /** 1-based position in the spine (§3). */
+  order: number
+  /** The developmental move this step mirrors, e.g. "wake up". */
+  move: string
+  /** Small mono eyebrow, e.g. "01 · wake up". */
+  eyebrow: string
+  title: string
+  /** Body copy — the warm register (references backing where relevant). */
+  bodyWarm: string
+  /** Body copy — the public register (invitation; no backer relationship). */
+  bodyPublic: string
+  status: BranchStatus
+  accent: HubAccent
+  /** The deck leads (§3 order 4): promoted, not equal-weight with the rest. */
+  primary?: boolean
+  /** Primary + optional secondary actions. Coming-soon branches may have none. */
+  ctas?: HubCta[]
+  /** Shown only on coming-soon branches: "here's what's coming and why" (§5). */
+  holding?: string
+}
+
+/** Resolve the copy for one register. */
+export function bodyFor(branch: HubBranch, audience: HubAudience): string {
+  return audience === 'warm' ? branch.bodyWarm : branch.bodyPublic
+}
+
+// ── The persistent fulfillment header (§2) ──────────────────────────────────
+// Always visible, above every branch, answering Q1 before any choice is made.
+// Public register drops the four-year wait but still states the ship date.
+
+export const SHIP_DATE = 'august 1'
+
+export interface HubHeader {
+  /** Mono kicker over the header. */
+  kicker: string
+  /** The plain fulfillment fact — the first thing an anxious backer reads. */
+  statusLine: string
+  /** One supporting line under the fact. */
+  subline: string
+}
+
+export function headerFor(audience: HubAudience): HubHeader {
+  if (audience === 'warm') {
+    return {
+      kicker: 'mastering the game of allyship',
+      statusLine: `the book ships ${SHIP_DATE} — and everything else here is yours now, all of it.`,
+      subline:
+        'you backed this four years ago. this page is the rest of what you backed, ready to use today while the book makes its way to you.',
+    }
+  }
+  return {
+    kicker: 'mastering the game of allyship',
+    statusLine: `the book ships ${SHIP_DATE} — here's everything that's ready to play with right now.`,
+    subline:
+      'a game, two quizzes, and a deck for doing the work — no wait, no account needed to start.',
+  }
+}
+
+// ── 1:1 coaching bridge (§4) ────────────────────────────────────────────────
+// A single 90-minute call, $150, one-time — NOT the premium cohort. Payment via
+// Gumroad, scheduling via Calendly (both already set up). URLs are pasted in via
+// env, matching the launch registry's pattern; absent → honest /launch fallback.
+
+export const ONE_ON_ONE_PRICE = '$150'
+export const ONE_ON_ONE_FORMAT = 'single 90-minute call, one-time'
+
+/** Where the 1:1 payment lives (Gumroad). Falls back to the launch page. */
+export function oneOnOneHref(): string {
+  const url = process.env.NEXT_PUBLIC_GUMROAD_1ON1_URL?.trim()
+  return url && url.length > 0 ? url : '/launch#coaching'
+}
+
+/** Where the 1:1 gets scheduled (Calendly), if wired separately. */
+export function oneOnOneScheduleHref(): string | null {
+  const url = process.env.NEXT_PUBLIC_CALENDLY_1ON1_URL?.trim()
+  return url && url.length > 0 ? url : null
+}
+
+// ── Get involved — the four concrete actions + self-report (§4) ──────────────
+
+export interface InvolveAction {
+  key: 'buy-deck' | '1on1' | 'sell-book' | 'social'
+  title: string
+  bodyWarm: string
+  bodyPublic: string
+  cta: HubCta
+  status: BranchStatus
+}
+
+export function involveActions(): InvolveAction[] {
+  const scheduleHref = oneOnOneScheduleHref()
+  return [
+    {
+      key: 'buy-deck',
+      title: 'buy the deck',
+      bodyWarm:
+        'played with it and want it in your hands? a clear next click to own the full 120-card deck — not folded into the sample above.',
+      bodyPublic:
+        'want the full 120-card deck for doing the work? one click to own it.',
+      cta: { label: 'buy the deck', href: offerHref('deck-digital'), external: true },
+      status: 'ready',
+    },
+    {
+      key: '1on1',
+      title: 'sit down with wendell, 1:1',
+      bodyWarm:
+        `personalized support to use the book and deck now, while the rest of the ecosystem finishes building — ${ONE_ON_ONE_FORMAT}, ${ONE_ON_ONE_PRICE}. not the cohort (that's the deeper transformation, later); this is a bridge for the gap before it exists.`,
+      bodyPublic:
+        `personalized support to put the book and deck to work — ${ONE_ON_ONE_FORMAT}, ${ONE_ON_ONE_PRICE}. a bridge, not the full cohort.`,
+      cta: {
+        label: scheduleHref ? 'book your call' : 'book your call',
+        href: oneOnOneHref(),
+        external: true,
+      },
+      status: 'ready',
+    },
+    {
+      key: 'sell-book',
+      title: 'help sell the book',
+      bodyWarm:
+        "the single most useful thing you can do. grab ready-to-send copy below — no writing required, just paste and share with someone who'd want it.",
+      bodyPublic:
+        'know someone who needs this? grab ready-to-send copy below and pass it along.',
+      // Anchors to the ShareKit on the same page — a concrete action, never "spread the word".
+      cta: { label: 'get shareable copy', href: '#share-kit' },
+      status: 'ready',
+    },
+    {
+      key: 'social',
+      title: 'post about it',
+      bodyWarm:
+        "something to actually post — not just an invitation to be enthusiastic. copy, paste, done.",
+      bodyPublic:
+        'give your feed something real — copy-paste posts ready to go.',
+      cta: { label: 'get post copy', href: '#share-kit' },
+      status: 'ready',
+    },
+  ]
+}
+
+/** Identification-not-solicitation self-report (§4, carried from v1). Routing of
+ *  this data is Wendell's open decision (§9) — the UI captures intent only. */
+export interface SelfReportCategory {
+  key: string
+  label: string
+  blurb: string
+}
+
+export const SELF_REPORT_CATEGORIES: SelfReportCategory[] = [
+  {
+    key: 'org-budget-connector',
+    label: 'i can open an org door',
+    blurb: 'i work somewhere with a budget or a team that should see this.',
+  },
+  {
+    key: 'donor-connector',
+    label: 'i can fund or connect',
+    blurb: 'i can give, or introduce you to someone who can.',
+  },
+  {
+    key: 'hype-builder',
+    label: "i'm a hype-builder",
+    blurb: "i love this and i'll help it travel.",
+  },
+  {
+    key: 'here-for-july-17',
+    label: "i'm just here for july 17",
+    blurb: 'no ask — i backed it and i wanted to look around.',
+  },
+]
+
+// ── Shareable copy (§4: "help sell the book" / "post on social") ─────────────
+// Something concrete to click and paste, per the spec's anti-"spread the word"
+// requirement. Warm and public variants.
+
+export interface ShareSnippet {
+  key: string
+  label: string
+  textWarm: string
+  textPublic: string
+}
+
+export const SHARE_SNIPPETS: ShareSnippet[] = [
+  {
+    key: 'short',
+    label: 'short & personal',
+    textWarm:
+      "i backed 'mastering the game of allyship' years ago and it's finally here — a book, a game, and a deck for doing the work instead of just talking about it. the book ships aug 1; you can play with the deck today.",
+    textPublic:
+      "'mastering the game of allyship' turns allyship into something you practice, not perform — a book, a game, and a deck. book ships aug 1; the deck's playable now.",
+  },
+  {
+    key: 'quiz',
+    label: 'lead with the quiz',
+    textWarm:
+      'took the "find your allyship superpower" quiz from mastering the game of allyship — no signup, result in two minutes. worth it. the whole thing lands aug 1.',
+    textPublic:
+      'free 2-minute quiz: find your allyship superpower. no signup. from "mastering the game of allyship" — book out aug 1.',
+  },
+]
+
+// ── The spine (§3) ──────────────────────────────────────────────────────────
+
+export function hubBranches(): HubBranch[] {
+  return [
+    // 1 — Wake Up: framing beat. New copy, no build. Must explain the *point*
+    // before asking for a quiz answer.
+    {
+      order: 1,
+      move: 'wake up',
+      eyebrow: '01 · wake up',
+      title: 'you have an allyship superpower',
+      bodyWarm:
+        "before the quiz, the point: a superpower is the specific way you're built to show up for others — the move that comes naturally to you and lands for the people around you. the book opens here, in chapter 1, because you can't play a game you can't see. so first, let's help you see yours.",
+      bodyPublic:
+        "the point first: a superpower is the specific way you're built to show up for others — the move that's natural to you and actually lands. it's where the book opens, chapter 1, because you can't play a game you can't see. so let's help you see yours.",
+      status: 'ready',
+      accent: 'coral',
+    },
+    // 2 — Open Up: superpower quiz. Built, needs wiring. Result bridges to
+    // "here's what this means for you."
+    {
+      order: 2,
+      move: 'open up',
+      eyebrow: '02 · open up',
+      title: 'find your superpower',
+      bodyWarm:
+        'twelve quick choices, no signup, result the moment you finish. you carry more than one — this shows which you lead with, and what that means for your next move.',
+      bodyPublic:
+        'twelve quick choices, no signup, result the moment you finish. a lens for your next move, not a box.',
+      status: 'ready',
+      accent: 'teal',
+      ctas: [{ label: 'find your superpower', href: '/superpower' }],
+    },
+    // 3 — Clean Up: myths quiz. Built, needs wiring. Result bridges to "one
+    // thing you can do about this today."
+    {
+      order: 3,
+      move: 'clean up',
+      eyebrow: '03 · clean up',
+      title: 'find the myth you inherited',
+      bodyWarm:
+        "the stories about allyship you never chose but still carry. this read names the one running loudest for you — and hands you one thing you can actually do about it today, not just a diagnosis.",
+      bodyPublic:
+        'the allyship stories you never chose but still carry. this read names the loudest one — and one concrete thing to do about it today.',
+      status: 'ready',
+      accent: 'teal',
+      ctas: [{ label: 'read your myths', href: '/mastering-allyship/myths-read' }],
+    },
+    // 4 — Show Up (start now): the deck. Ready today, zero caveats. THE primary
+    // "act on this right now" CTA — promoted, not equal-weight.
+    {
+      order: 4,
+      move: 'show up',
+      eyebrow: '04 · show up · start now',
+      title: 'play with the deck',
+      bodyWarm:
+        "the one thing here with nothing pending — no wait, no caveats, ready this second. 120 moves for doing the work, right now, for free. this is where you go from reading about it to actually playing.",
+      bodyPublic:
+        'nothing pending, no caveats — playable this second. 120 moves for doing the work, free. the fastest way from reading about allyship to practicing it.',
+      status: 'ready',
+      accent: 'teal',
+      primary: true,
+      ctas: [
+        { label: 'play the deck', href: '/deck/preview' },
+        { label: 'see the full deck', href: '/deck/sales', secondary: true },
+      ],
+    },
+    // 5 — What's next: Chapter 1 preview. Launches in a "coming very soon"
+    // holding state; upgraded to the real excerpt the moment it lands (§6).
+    {
+      order: 5,
+      move: "what's next",
+      eyebrow: "05 · what's next",
+      title: 'read chapter 1',
+      bodyWarm:
+        "proof, not a status update: the actual opening of the book you backed. it's in final polish and lands here in the next day or two — this page upgrades itself the moment it's ready.",
+      bodyPublic:
+        "the actual opening of the book — in final polish, landing here in the next day or two. this page upgrades itself the moment it's ready.",
+      status: chapterOnePreviewReady() ? 'ready' : 'coming-soon',
+      accent: 'coral',
+      ctas: chapterOnePreviewReady()
+        ? [{ label: 'read chapter 1', href: '/kickstarter/chapter-1' }]
+        : undefined,
+      holding:
+        "coming very soon — the excerpt is in final polish. nothing to click yet on purpose; we'd rather show you the real thing than a placeholder. check back tomorrow.",
+    },
+    // 6 — Get involved: expanded self-report + concrete CTAs. Rendered by the
+    // page from involveActions() + SELF_REPORT_CATEGORIES + SHARE_SNIPPETS.
+    {
+      order: 6,
+      move: 'get involved',
+      eyebrow: '06 · get involved',
+      title: 'four ways in',
+      bodyWarm:
+        "no single ask — pick the one that fits. buy the deck, sit down with me 1:1, help the book find its people, or just tell me who you are so i know how to have you in this.",
+      bodyPublic:
+        'pick the one that fits: buy the deck, book a 1:1, help the book find its people, or just tell us who you are.',
+      status: 'ready',
+      accent: 'coral',
+    },
+    // 7 — Help fund the crossing: car campaign. Drafted, assets pending → last,
+    // one path among several, the single explicit monetary ask (§3).
+    {
+      order: 7,
+      move: 'help fund the crossing',
+      eyebrow: '07 · help fund the crossing',
+      title: 'the car campaign',
+      bodyWarm:
+        "the one straight-up money ask, and it comes last on purpose — after everything else has already been offered to you. it funds the literal crossing that gets this work to the people who need it.",
+      bodyPublic:
+        'the one direct money ask, last on purpose. it funds the crossing that carries this work to the people who need it.',
+      status: 'coming-soon',
+      accent: 'coral',
+      holding:
+        "still coming together — the video and giving rails aren't live yet. rather than send you to a half-built page, here's the honest state: it's drafted, and it'll open here soon.",
+    },
+  ]
+}
+
+/** Chapter 1 excerpt readiness. Off until the manuscript lands (§6); flip via
+ *  env once the excerpt page ships so the branch upgrades from holding → live. */
+export function chapterOnePreviewReady(): boolean {
+  return process.env.NEXT_PUBLIC_HUB_CHAPTER1_READY === 'true'
+}

--- a/src/styles/kickstarter-hub.css
+++ b/src/styles/kickstarter-hub.css
@@ -1,0 +1,249 @@
+/* Kickstarter CYOA Hub — aesthetic layer (SPEC v2 §8).
+ *
+ * Warm near-black background (--bars-bg-base), lowercase, coral primary, teal
+ * reserved for the core transformation moves. Coral/teal are marketing-fidelity
+ * hues that live outside the Wuxing element palette (like the mastering-allyship
+ * marketing page's inline palette) — so they're defined here as scoped --ks-*
+ * vars rather than in the game token system. Surfaces, text, and near-black all
+ * still trace to --bars-* tokens. Layout stays Tailwind/inline; identity is here.
+ *
+ * WCAG AA: coral/teal text tokens below are the lightened variants used on
+ * near-black; the deep frame variants are border/glow only. All motion is
+ * guarded by prefers-reduced-motion at the bottom of the file.
+ */
+
+.ks-hub {
+  /* coral — primary action */
+  --ks-coral: #ff6a4d;
+  --ks-coral-lite: #ff8a70; /* text on near-black — ≥4.5:1 */
+  --ks-coral-deep: #c1392b;
+  --ks-coral-glow: rgba(255, 106, 77, 0.35);
+
+  /* teal — core / transformation only */
+  --ks-teal: #2fb9a0;
+  --ks-teal-lite: #6fe6c2; /* text on near-black — ≥4.5:1 */
+  --ks-teal-deep: #06120b;
+  --ks-teal-glow: rgba(47, 185, 160, 0.32);
+
+  background:
+    radial-gradient(125% 85% at 50% -8%, #15110c 0%, var(--bars-bg-base) 58%);
+  min-height: 100vh;
+  font-family: var(--bars-font-display);
+  color: var(--bars-text-primary);
+}
+
+/* Mono eyebrow, matching the quizzes' kicker treatment. */
+.ks-eyebrow {
+  font-family: var(--bars-font-mono);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: var(--bars-text-secondary);
+}
+
+/* ── Persistent fulfillment header (§2) ─────────────────────────────────── */
+.ks-fulfillment {
+  border: 1px solid var(--bars-line-strong);
+  border-radius: var(--bars-radius-lg);
+  background: linear-gradient(180deg, rgba(255, 138, 112, 0.06), rgba(0, 0, 0, 0));
+  box-shadow: var(--bars-shadow-inset-top);
+}
+
+/* ── Branch card (the game-menu tile) ───────────────────────────────────── */
+.ks-card {
+  position: relative;
+  border-radius: var(--bars-radius-lg);
+  background-color: var(--bars-surface-card);
+  border: 1px solid var(--bars-line-strong);
+  box-shadow: var(--bars-shadow-inset-top);
+  transition:
+    transform 0.15s var(--bars-ease-out),
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+/* Accent channel — coral default, teal for transformation moves. */
+.ks-card[data-accent='coral'] {
+  --ks-accent: var(--ks-coral);
+  --ks-accent-lite: var(--ks-coral-lite);
+  --ks-accent-glow: var(--ks-coral-glow);
+}
+.ks-card[data-accent='teal'] {
+  --ks-accent: var(--ks-teal);
+  --ks-accent-lite: var(--ks-teal-lite);
+  --ks-accent-glow: var(--ks-teal-glow);
+}
+
+/* A thin accent rail on the leading edge — the card's element cue. */
+.ks-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  border-radius: var(--bars-radius-lg) 0 0 var(--bars-radius-lg);
+  background: var(--ks-accent);
+  opacity: 0.55;
+}
+
+/* Hover / focus-within lift (interactive branches only). */
+.ks-card.ks-card--interactive:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--ks-accent) 55%, var(--bars-line-strong));
+  box-shadow:
+    var(--bars-shadow-inset-top),
+    0 0 22px var(--ks-accent-glow);
+}
+.ks-card.ks-card--interactive:focus-within {
+  border-color: var(--ks-accent);
+}
+
+/* The deck leads (§3 order 4): promoted, brighter frame + standing glow. */
+.ks-card--primary {
+  border-color: color-mix(in srgb, var(--ks-accent) 60%, var(--bars-line-strong));
+  box-shadow:
+    var(--bars-shadow-inset-top),
+    0 0 18px var(--ks-accent-glow);
+}
+.ks-card--primary::before {
+  opacity: 1;
+  width: 4px;
+}
+
+/* Coming-soon holding state — quieter, dashed, honestly not-yet (§5). */
+.ks-card--holding {
+  border-style: dashed;
+  border-color: var(--bars-line-dashed);
+}
+.ks-card--holding::before {
+  opacity: 0.25;
+}
+
+/* ── Status pill — visible on every branch (§5) ─────────────────────────── */
+.ks-pill {
+  font-family: var(--bars-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: var(--bars-radius-full);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.ks-pill--ready {
+  color: var(--ks-teal-lite);
+  border-color: color-mix(in srgb, var(--ks-teal) 45%, transparent);
+  background: rgba(47, 185, 160, 0.1);
+}
+.ks-pill--soon {
+  color: var(--bars-text-secondary);
+  border-color: var(--bars-line-dashed);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* ── CTAs (coral primary) ───────────────────────────────────────────────── */
+.ks-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  min-height: 44px; /* covenant: 44px touch target */
+  padding: 0 18px;
+  border-radius: var(--bars-radius-full);
+  font-family: var(--bars-font-display);
+  font-weight: 700;
+  font-size: 14px;
+  color: #1a0f0b;
+  background: var(--ks-coral);
+  border: 1px solid transparent;
+  transition:
+    transform 0.08s ease,
+    filter 0.2s ease,
+    box-shadow 0.2s ease;
+}
+.ks-cta:hover {
+  filter: brightness(1.06);
+  box-shadow: 0 0 20px var(--ks-coral-glow);
+}
+.ks-cta:active {
+  transform: scale(0.985);
+}
+.ks-cta:focus-visible {
+  outline: 2px solid var(--bars-text-primary);
+  outline-offset: 2px;
+}
+
+/* Ghost / secondary CTA. */
+.ks-cta--ghost {
+  color: var(--bars-text-primary);
+  background: transparent;
+  border-color: var(--bars-line-strong);
+}
+.ks-cta--ghost:hover {
+  border-color: var(--ks-coral-lite);
+  filter: none;
+  box-shadow: none;
+}
+
+/* ── Self-report + share chips ──────────────────────────────────────────── */
+.ks-chip {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border-radius: var(--bars-radius-md);
+  border: 1px solid var(--bars-line-strong);
+  background: var(--bars-surface-inset);
+  padding: 12px 14px;
+  min-height: 44px;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    transform 0.08s ease;
+  cursor: pointer;
+}
+.ks-chip:hover {
+  border-color: color-mix(in srgb, var(--ks-coral) 45%, var(--bars-line-strong));
+  background: rgba(255, 255, 255, 0.025);
+}
+.ks-chip:active {
+  transform: scale(0.99);
+}
+.ks-chip[aria-pressed='true'] {
+  border-color: var(--ks-coral);
+  background: rgba(255, 106, 77, 0.08);
+}
+.ks-chip:focus-visible {
+  outline: 2px solid var(--bars-text-primary);
+  outline-offset: 2px;
+}
+
+/* Copy-to-clipboard block. */
+.ks-copy {
+  border: 1px solid var(--bars-line-strong);
+  border-radius: var(--bars-radius-md);
+  background: var(--bars-surface-inset);
+}
+
+/* ── Entry motion (one ambient move; covenant Law 12) ───────────────────── */
+@keyframes ks-rise {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.ks-rise {
+  animation: ks-rise 0.42s var(--bars-ease-out) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ks-rise {
+    animation: none !important;
+  }
+  .ks-card,
+  .ks-cta,
+  .ks-chip {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
A single interactive hub at **`/kickstarter`**, linked from the July 17 backer email (warm) and social (public), that lets a backer self-select their next step instead of reading a flat bullet list. Implements SPEC v2.

## What it does

Answers a backer's three real questions without a click:

- **Persistent fulfillment header (§2):** states "the book ships august 1" plainly, above every branch — answers *how/when do I get my stuff* immediately.
- **Seven-branch spine (§3)** mirroring the book's own developmental sequence, not a product list:
  1. **wake up** — framing beat (explains *the point* before the quiz)
  2. **open up** — superpower quiz → `/superpower`
  3. **clean up** — myths quiz → `/mastering-allyship/myths-read`
  4. **show up** — the deck, promoted as the primary "start now" CTA → `/deck/preview`
  5. **what's next** — Chapter 1 preview → `/kickstarter/chapter-1`
  6. **get involved** — expanded self-report + concrete CTAs
  7. **help fund the crossing** — car campaign, last, the lone money ask
- **Expanded get-involved (§4):** buy the deck, 1:1 coaching ($150, single 90-min call via Gumroad+Calendly), help sell the book + post on social (copy-paste ShareKit), and the identification-not-solicitation self-report.
- **Ready/not-ready on every branch (§5):** a visible status pill; coming-soon branches show an honest holding state and route to a real page — never a dead link.
- **Chapter 1 (§6):** ships in a coming-soon fallback page that links on to `/launch` (reader-chosen, not a redirect); upgrades to the excerpt via `NEXT_PUBLIC_HUB_CHAPTER1_READY` without holding the hub.
- **Warm vs public split (§7):** `?audience=public` switches register; warm is the default.
- **Visual system (§8):** warm near-black, lowercase, coral primary, teal reserved for the core transformation moves; game-menu feel matching the quizzes.

## Structure

- `src/lib/kickstarter-hub/content.ts` — content model (warm/public copy, status, CTAs, share snippets, self-report). Commerce links reuse the launch registry's env-driven Gumroad pattern with honest `/launch` fallbacks.
- `src/app/kickstarter/{page.tsx, SelfReport.tsx, ShareKit.tsx}` and `src/app/kickstarter/chapter-1/page.tsx`.
- `src/styles/kickstarter-hub.css` — coral/teal marketing layer (outside the Wuxing element palette, like the mastering-allyship marketing page), 8 interaction states, reduced-motion guards. Surfaces/text/near-black still trace to `--bars-*` tokens.

## Config (env-driven, honest fallbacks)

- `NEXT_PUBLIC_GUMROAD_1ON1_URL` + `NEXT_PUBLIC_CALENDLY_1ON1_URL` — the 1:1 bridge; fall back to `/launch` until set.
- `NEXT_PUBLIC_HUB_CHAPTER1_READY=true` — flips the Chapter 1 branch/page from holding → live when the excerpt lands.
- Buy-deck reuses the existing `deck-digital` launch SKU.

## Verification

- `tsc --noEmit` clean, eslint clean on new files, route annotations valid.
- Rendered live at both audiences (200) for the hub and the Chapter 1 fallback; screenshots confirmed layout, palette, status pills, holding states, and CTAs.
- Full precommit `npm run check` passed (0 errors) on both commits.

## Left for Wendell (spec §9, deliberately not resolved)

- Where the self-report data ultimately routes (currently composes a mailto — no backend committed).
- Final slug confirmation and that `/awaken` in the Kickstarter email points here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmYiEGkXe18LeHFuZ7iAA7)_