### PR TITLE
Deck sales page: apply Claude Design handoff + honest-terms guarantee

### DIFF
--- a/src/app/deck/sales/page.tsx
+++ b/src/app/deck/sales/page.tsx
@@ -1,24 +1,15 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
-import type { CSSProperties, ReactNode } from 'react'
 import { assembleDeck } from '@/lib/allyship-deck/assemble'
 import type { MoveCard } from '@/lib/allyship-deck/types'
-import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
+import { DECK_SOCIAL_PROOF } from '@/lib/launch/deck-sales-copy'
 import {
-  DECK_FONTS,
-  DECK_GOLD,
-  MOVE_LABELS,
-  themeForMove,
-} from '@/lib/allyship-deck/card-visuals'
-import {
-  DECK_SOCIAL_PROOF,
-  HOW_IT_WORKS,
-  MOVE_STRIP_ORDER,
-  MOVE_TAGLINES,
-} from '@/lib/launch/deck-sales-copy'
-import { DeckFanHero } from '@/components/deck/DeckFanHero'
-import { MovePip } from '@/components/deck/MovePip'
-import { LAUNCH_OFFERS, formatPrice, isOfferLive, isSuperpowerPackKey } from '@/lib/launch/offers'
+  LAUNCH_OFFERS,
+  formatPrice,
+  isOfferLive,
+  isSuperpowerPackKey,
+  offerByKey,
+} from '@/lib/launch/offers'
+import { DeckSalesExperience, type SalesPack } from '@/components/deck/DeckSalesExperience'
 
 export const metadata: Metadata = {
   title: 'The Allyship Deck - moves for the moment it counts',
@@ -30,357 +21,43 @@ const isMove = (c: { kind: string }): c is MoveCard => c.kind === 'move'
 
 export default function DeckSalesPage() {
   const moves = assembleDeck().cards.filter(isMove)
-  const pick = (m: MoveCard['move']) => moves.find((c) => c.move === m)!
-  const fan: [MoveCard, MoveCard, MoveCard] = [pick('clean_up'), pick('show_up'), pick('open_up')]
+
+  // Pre-format the expansion packs on the server so the client component never
+  // pulls in the offers registry. This page is the packs' only storefront.
+  const packs: SalesPack[] = LAUNCH_OFFERS.filter((o) => isSuperpowerPackKey(o.key)).map((o) => ({
+    key: o.key,
+    name: o.name,
+    blurb: o.blurb,
+    priceLabel: formatPrice(o.priceCents),
+    accent: o.accent,
+    gumroadUrl: isOfferLive(o) ? o.gumroadUrl : undefined,
+    live: isOfferLive(o),
+  }))
+  const packLead =
+    packs.length > 0
+      ? `Add your superpowers to the deck — 60 move-cards each, inner and outer. ${packs[0]!.priceLabel} a pack.`
+      : undefined
+
+  // Real deck pricing from the launch registry (was "pending" in the design handoff).
+  const digital = offerByKey('deck-digital')
+  const physical = offerByKey('deck-physical')
+  const priceLine =
+    digital && physical
+      ? `Digital ${formatPrice(digital.priceCents)} · Physical ${formatPrice(physical.priceCents)} — preorder now, ships after the print run.`
+      : undefined
+  const ctaPrice =
+    digital && physical
+      ? `digital ${formatPrice(digital.priceCents)} · physical ${formatPrice(physical.priceCents)} preorder`
+      : undefined
 
   return (
-    <main style={{ maxWidth: 1040, margin: '0 auto', padding: '40px 18px 96px', color: SURFACE_TOKENS.textPrimary }}>
-      {/* Hero */}
-      <section style={{ textAlign: 'center', marginBottom: 44 }}>
-        <p style={{ ...kicker, color: DECK_GOLD }}>The Allyship Deck</p>
-        <h1
-          style={{
-            fontFamily: DECK_FONTS.display,
-            fontWeight: 800,
-            fontSize: 'clamp(34px, 6vw, 52px)',
-            lineHeight: 1.08,
-            color: '#fff',
-            margin: '10px auto 0',
-            maxWidth: 680,
-          }}
-        >
-          120 moves for doing the work.
-        </h1>
-        <p
-          style={{
-            fontFamily: DECK_FONTS.body,
-            fontSize: 17,
-            lineHeight: 1.55,
-            color: SURFACE_TOKENS.textSecondary,
-            margin: '16px auto 0',
-            maxWidth: 560,
-          }}
-        >
-          Draw a card. Sit with the practice. Turn it into a real quest. The deck is the
-          consultable heart of the Mastering Allyship game — five moves, four domains, six faces.
-        </p>
-
-        <div style={{ margin: '32px 0' }}>
-          <DeckFanHero cards={fan} />
-        </div>
-
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
-          <Link href="/launch" style={primaryCta}>
-            Get the deck
-          </Link>
-          <Link href="/deck/preview" style={secondaryCta}>
-            See sample cards
-          </Link>
-        </div>
-      </section>
-
-      {/* Five-moves strip */}
-      <section style={{ marginBottom: 52 }}>
-        <SectionLabel>The five moves</SectionLabel>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))',
-            gap: 12,
-            marginTop: 16,
-          }}
-        >
-          {MOVE_STRIP_ORDER.map((m) => {
-            const t = themeForMove(m)
-            return (
-              <div
-                key={m}
-                style={{
-                  padding: '16px 14px',
-                  borderRadius: 10,
-                  background: SURFACE_TOKENS.surfaceInset,
-                  border: `1px solid color-mix(in srgb, ${t.glow} 26%, transparent)`,
-                }}
-              >
-                <MovePip move={m} size={32} />
-                <div
-                  style={{
-                    fontFamily: DECK_FONTS.display,
-                    fontWeight: 700,
-                    fontSize: 16,
-                    color: '#fff',
-                    margin: '10px 0 4px',
-                  }}
-                >
-                  {MOVE_LABELS[m]}
-                </div>
-                <p style={{ fontFamily: DECK_FONTS.body, fontSize: 13, lineHeight: 1.45, color: SURFACE_TOKENS.textSecondary, margin: 0 }}>
-                  {MOVE_TAGLINES[m]}
-                </p>
-              </div>
-            )
-          })}
-        </div>
-      </section>
-
-      {/* How it works */}
-      <section style={{ marginBottom: 52 }}>
-        <SectionLabel>How it works</SectionLabel>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-            gap: 16,
-            marginTop: 16,
-          }}
-        >
-          {HOW_IT_WORKS.map((step) => (
-            <div key={step.n} style={{ padding: '4px 2px' }}>
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: 30,
-                  height: 30,
-                  borderRadius: '50%',
-                  border: `1.5px solid ${DECK_GOLD}`,
-                  color: DECK_GOLD,
-                  fontFamily: DECK_FONTS.mono,
-                  fontSize: 13,
-                  fontWeight: 700,
-                }}
-              >
-                {step.n}
-              </span>
-              <div style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 17, color: '#fff', margin: '12px 0 5px' }}>
-                {step.title}
-              </div>
-              <p style={{ fontFamily: DECK_FONTS.body, fontSize: 14, lineHeight: 1.5, color: SURFACE_TOKENS.textSecondary, margin: 0 }}>
-                {step.body}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Expansion-pack upsell */}
-      <PackUpsell />
-
-      {/* Social proof */}
-      <section
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          justifyContent: 'center',
-          gap: 'clamp(24px, 8vw, 72px)',
-          padding: '28px 20px',
-          borderRadius: 14,
-          background: SURFACE_TOKENS.surfaceInset,
-          border: '1px solid rgba(255,255,255,.08)',
-          marginBottom: 48,
-          textAlign: 'center',
-        }}
-      >
-        <Stat value={`$${DECK_SOCIAL_PROOF.raisedDollars.toLocaleString('en-US')}`} label="raised by the community" />
-        <Stat value={DECK_SOCIAL_PROOF.backers.toLocaleString('en-US')} label="backers and counting" />
-      </section>
-
-      {/* Final CTA */}
-      <section style={{ textAlign: 'center' }}>
-        <h2 style={{ fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 'clamp(26px, 5vw, 36px)', color: '#fff', margin: 0 }}>
-          Pull your first card.
-        </h2>
-        <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary, margin: '12px auto 22px', maxWidth: 480 }}>
-          The deck unlocks with the deck purchase, the game subscription, or the Founding Ally bundle.
-        </p>
-        <Link href="/launch" style={primaryCta}>
-          Get the deck
-        </Link>
-      </section>
-    </main>
+    <DeckSalesExperience
+      cards={moves}
+      packs={packs}
+      packLead={packLead}
+      socialProof={DECK_SOCIAL_PROOF}
+      priceLine={priceLine}
+      ctaPrice={ctaPrice}
+    />
   )
-}
-
-function Stat({ value, label }: { value: string; label: string }) {
-  return (
-    <div>
-      <div style={{ fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 'clamp(30px, 6vw, 44px)', color: DECK_GOLD, lineHeight: 1 }}>
-        {value}
-      </div>
-      <div style={{ fontFamily: DECK_FONTS.mono, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: SURFACE_TOKENS.textSecondary, marginTop: 8 }}>
-        {label}
-      </div>
-    </div>
-  )
-}
-
-/**
- * Expansion-pack upsell — the seven $8 superpower packs, sold beside the deck
- * (their home surface; they are held back from the /launch grid). Reads the
- * launch registry so name/price/link never drift; a pack with no Gumroad URL
- * shows an honest "Coming soon" instead of a dead link.
- */
-function PackUpsell() {
-  const packs = LAUNCH_OFFERS.filter((o) => isSuperpowerPackKey(o.key))
-  if (packs.length === 0) return null
-
-  return (
-    <section style={{ marginBottom: 52 }}>
-      <SectionLabel>Go deeper · expansion packs</SectionLabel>
-      <p
-        style={{
-          fontFamily: DECK_FONTS.body,
-          fontSize: 14,
-          lineHeight: 1.5,
-          color: SURFACE_TOKENS.textSecondary,
-          textAlign: 'center',
-          margin: '10px auto 0',
-          maxWidth: 520,
-        }}
-      >
-        Add your superpowers to the deck — 60 move-cards each, inner and outer.
-        {' '}
-        {formatPrice(packs[0].priceCents)} a pack.
-      </p>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
-          gap: 12,
-          marginTop: 18,
-        }}
-      >
-        {packs.map((pack) => {
-          const live = isOfferLive(pack)
-          return (
-            <div
-              key={pack.key}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                padding: '16px 15px',
-                borderRadius: 10,
-                background: SURFACE_TOKENS.surfaceInset,
-                border: '1px solid rgba(255,255,255,.08)',
-              }}
-            >
-              <span
-                aria-hidden="true"
-                style={{
-                  display: 'block',
-                  width: 26,
-                  height: 26,
-                  borderRadius: 7,
-                  background: pack.accent ?? 'var(--bars-text-secondary)',
-                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,.25)',
-                }}
-              />
-              <div
-                style={{
-                  fontFamily: DECK_FONTS.display,
-                  fontWeight: 700,
-                  fontSize: 15,
-                  color: '#fff',
-                  margin: '12px 0 4px',
-                }}
-              >
-                {pack.name}
-              </div>
-              <p
-                style={{
-                  fontFamily: DECK_FONTS.body,
-                  fontSize: 12.5,
-                  lineHeight: 1.45,
-                  color: SURFACE_TOKENS.textSecondary,
-                  margin: '0 0 14px',
-                  flex: 1,
-                }}
-              >
-                {pack.blurb}
-              </p>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-                <span style={{ fontFamily: DECK_FONTS.display, fontWeight: 700, fontSize: 15, color: DECK_GOLD }}>
-                  {formatPrice(pack.priceCents)}
-                </span>
-                {live ? (
-                  <a
-                    href={pack.gumroadUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      fontFamily: DECK_FONTS.display,
-                      fontWeight: 700,
-                      fontSize: 13,
-                      color: '#150a04',
-                      background: DECK_GOLD,
-                      padding: '8px 14px',
-                      borderRadius: 999,
-                      textDecoration: 'none',
-                    }}
-                  >
-                    Add →
-                  </a>
-                ) : (
-                  <span
-                    style={{
-                      fontFamily: DECK_FONTS.mono,
-                      fontSize: 10,
-                      letterSpacing: '.1em',
-                      textTransform: 'uppercase',
-                      color: SURFACE_TOKENS.textSecondary,
-                      border: '1px dashed rgba(255,255,255,.2)',
-                      padding: '6px 10px',
-                      borderRadius: 999,
-                    }}
-                  >
-                    Coming soon
-                  </span>
-                )}
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </section>
-  )
-}
-
-function SectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <h2 style={{ ...kicker, color: SURFACE_TOKENS.textSecondary, textAlign: 'center', margin: 0 }}>{children}</h2>
-  )
-}
-
-const kicker: CSSProperties = {
-  fontFamily: DECK_FONTS.mono,
-  fontSize: 11,
-  letterSpacing: '0.18em',
-  textTransform: 'uppercase',
-}
-
-const primaryCta: CSSProperties = {
-  display: 'inline-block',
-  padding: '13px 28px',
-  borderRadius: 999,
-  background: DECK_GOLD,
-  color: '#150a04',
-  fontFamily: DECK_FONTS.display,
-  fontWeight: 700,
-  fontSize: 15,
-  textDecoration: 'none',
-  boxShadow: '0 10px 30px -12px rgba(201,168,76,.7)',
-}
-
-const secondaryCta: CSSProperties = {
-  display: 'inline-block',
-  padding: '13px 24px',
-  borderRadius: 999,
-  background: 'transparent',
-  color: SURFACE_TOKENS.textPrimary,
-  fontFamily: DECK_FONTS.display,
-  fontWeight: 600,
-  fontSize: 15,
-  textDecoration: 'none',
-  border: '1px solid rgba(255,255,255,.2)',
 }

--- a/src/components/deck/DeckSalesExperience.tsx
+++ b/src/components/deck/DeckSalesExperience.tsx
@@ -49,7 +49,7 @@ export interface DeckSalesExperienceProps {
 
 const PRICE_LINE_DEFAULT = 'price · format · what is included - pending'
 const GUARANTEE_LINE_DEFAULT =
-  'honest-terms guarantee - e.g. carry it a week; if not one move lands, send it back - pending'
+  'The whole promise is a move in the ten seconds that matter. Carry the deck thirty days; if not one lands there, one email gets your money back — no forms, and you keep the deck.'
 const CTA_PRICE_DEFAULT = 'cta destination + price - pending'
 
 const FACES: Operation[] = ['shaman', 'challenger', 'regent', 'architect', 'diplomat', 'sage']

--- a/src/components/deck/DeckSalesExperience.tsx
+++ b/src/components/deck/DeckSalesExperience.tsx
@@ -17,11 +17,40 @@ import { ELEMENT_TOKENS } from '@/lib/ui/card-tokens'
 
 type PartKey = 'title' | 'move' | 'face' | 'domain' | 'prompt' | 'meta'
 
-const CTA_HREF = '/launch'
-const BOOK_HREF = '/book/sales'
-const PRICE_LINE = 'price · format · what is included - pending'
-const GUARANTEE_LINE = 'honest-terms guarantee - e.g. carry it a week; if not one move lands, send it back - pending'
-const CTA_PRICE = 'cta destination + price - pending'
+/**
+ * An expansion pack, pre-formatted on the server from the launch offers registry
+ * so this client component never imports the offer logic. `live` is `isOfferLive`
+ * resolved server-side; a pack with no live Gumroad URL renders "coming soon".
+ */
+export interface SalesPack {
+  key: string
+  name: string
+  blurb: string
+  priceLabel: string
+  accent?: string
+  gumroadUrl?: string
+  live: boolean
+}
+
+export interface DeckSalesExperienceProps {
+  cards: MoveCard[]
+  /** The superpower expansion packs sold beside the deck (their only storefront). */
+  packs?: SalesPack[]
+  /** One-line lead above the pack grid, e.g. "…$8 a pack." */
+  packLead?: string
+  /** Campaign social proof; hidden when omitted. */
+  socialProof?: { raisedDollars: number; backers: number }
+  ctaHref?: string
+  bookHref?: string
+  priceLine?: string
+  guaranteeLine?: string
+  ctaPrice?: string
+}
+
+const PRICE_LINE_DEFAULT = 'price · format · what is included - pending'
+const GUARANTEE_LINE_DEFAULT =
+  'honest-terms guarantee - e.g. carry it a week; if not one move lands, send it back - pending'
+const CTA_PRICE_DEFAULT = 'cta destination + price - pending'
 
 const FACES: Operation[] = ['shaman', 'challenger', 'regent', 'architect', 'diplomat', 'sage']
 const MOVES: BasicMove[] = ['wake_up', 'open_up', 'clean_up', 'grow_up', 'show_up']
@@ -88,14 +117,30 @@ const OBJECTIONS = [
   },
   {
     q: "What if it doesn't work for me?",
-    a: GUARANTEE_LINE,
+    a: GUARANTEE_LINE_DEFAULT,
   },
 ] as const
 
-export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
+export function DeckSalesExperience({
+  cards,
+  packs = [],
+  packLead = 'Add your superpowers to the deck — 60 move-cards each, inner and outer.',
+  socialProof,
+  ctaHref = '/launch',
+  bookHref = '/mastering-allyship',
+  priceLine = PRICE_LINE_DEFAULT,
+  guaranteeLine = GUARANTEE_LINE_DEFAULT,
+  ctaPrice = CTA_PRICE_DEFAULT,
+}: DeckSalesExperienceProps) {
   const [anaIdx, setAnaIdx] = useState(0)
   const [activePart, setActivePart] = useState<PartKey>('title')
   const [selected, setSelected] = useState<MoveCard | null>(null)
+
+  // The last objection ("what if it doesn't work") carries the guarantee terms;
+  // keep it in sync with the prop so the copy has one source.
+  const objections = OBJECTIONS.map((o, i) =>
+    i === OBJECTIONS.length - 1 ? { ...o, a: guaranteeLine } : o,
+  )
 
   const heroCards = useMemo(() => {
     const pick = (move: BasicMove) => cards.find((card) => card.move === move) ?? cards[0]!
@@ -124,7 +169,7 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
           <span className="deck-sales-brand-mark">B</span>
           <span>the allyship deck</span>
         </Link>
-        <Link href={CTA_HREF} className="deck-sales-top-cta">
+        <Link href={ctaHref} className="deck-sales-top-cta">
           get the deck
         </Link>
       </header>
@@ -233,9 +278,11 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
           <Label>what it is</Label>
           <h2 className="deck-sales-h2 deck-sales-large-h2">120 cards.</h2>
           <p className="deck-sales-sub deck-sales-format">Physical, so they&apos;re in your bag when the phone isn&apos;t the move - and in bars-engine when your hands are full.</p>
-          <div className="deck-sales-dashed">{PRICE_LINE}</div>
+          <div className="deck-sales-dashed">{priceLine}</div>
         </div>
       </section>
+
+      {packs.length > 0 && <PackUpsell packs={packs} lead={packLead} />}
 
       <Band>
         <div className="deck-sales-col deck-sales-grid-copy">
@@ -244,7 +291,7 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
           <p className="deck-sales-p">
             If you want the world these moves came from - why these five, where the six faces come from, what game you&apos;ve been playing all along - that&apos;s the book. The deeper door. Recommended, never required.
           </p>
-          <div className="deck-sales-dashed deck-sales-left-dashed">{GUARANTEE_LINE}</div>
+          <div className="deck-sales-dashed deck-sales-left-dashed">{guaranteeLine}</div>
         </div>
       </Band>
 
@@ -254,10 +301,22 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
           <Label>the choice</Label>
           <p className="deck-sales-sub deck-sales-choice-lead">You were never short on care, or on understanding. You were short a move in the ten seconds it mattered.</p>
           <h2 className="deck-sales-h2 deck-sales-choice-title">put a hundred and twenty of them in your bag.</h2>
-          <Link href={CTA_HREF} className="deck-sales-final-cta">
+          {socialProof && (
+            <div className="deck-sales-stats">
+              <div className="deck-sales-stat">
+                <b>${socialProof.raisedDollars.toLocaleString('en-US')}</b>
+                <span>raised by the community</span>
+              </div>
+              <div className="deck-sales-stat">
+                <b>{socialProof.backers.toLocaleString('en-US')}</b>
+                <span>backers and counting</span>
+              </div>
+            </div>
+          )}
+          <Link href={ctaHref} className="deck-sales-final-cta">
             get the deck →
           </Link>
-          <div className="deck-sales-price">{CTA_PRICE}</div>
+          <div className="deck-sales-price">{ctaPrice}</div>
         </div>
       </section>
 
@@ -266,7 +325,7 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
           <div className="deck-sales-ember-label">before you go</div>
           <h2 className="deck-sales-h2 deck-sales-objections-title">the honest questions.</h2>
           <div className="deck-sales-objection-stack">
-            {OBJECTIONS.map((objection) => (
+            {objections.map((objection) => (
               <article className="deck-sales-objection" key={objection.q}>
                 <p>“{objection.q}”</p>
                 <span>{objection.a}</span>
@@ -283,7 +342,7 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
             <h2 className="deck-sales-h2 deck-sales-book-title">want the world these moves came from?</h2>
             <p>The field guide is the full playbook - why these five moves, where the six faces come from, and the game you&apos;ve been playing all along. Recommended, never required. Get both together.</p>
           </div>
-          <Link href={BOOK_HREF} className="deck-sales-book-cta">
+          <Link href={bookHref} className="deck-sales-book-cta">
             explore the book →
           </Link>
         </div>
@@ -291,7 +350,7 @@ export function DeckSalesExperience({ cards }: { cards: MoveCard[] }) {
 
       <footer className="deck-sales-footer">
         <span>the allyship deck · mastering the game of allyship · © wendell britt</span>
-        <Link href={BOOK_HREF}>the book</Link>
+        <Link href={bookHref}>the book</Link>
       </footer>
 
       {selected && (
@@ -511,6 +570,51 @@ function SalesCardMini({ card }: { card: MoveCard }) {
         <b>{card.remediation}</b>
       </footer>
     </article>
+  )
+}
+
+/**
+ * Expansion-pack upsell — the seven $8 superpower packs. This deck page is their
+ * only storefront (they are held back from the /launch grid), so the section is
+ * load-bearing, not decorative. A pack with no live Gumroad URL shows an honest
+ * "coming soon" instead of a dead link.
+ */
+function PackUpsell({ packs, lead }: { packs: SalesPack[]; lead: string }) {
+  return (
+    <section className="deck-sales-section deck-sales-band deck-sales-packs">
+      <div className="deck-sales-col deck-sales-grid-copy deck-sales-center">
+        <Label>go deeper · expansion packs</Label>
+        <p className="deck-sales-sub deck-sales-packs-lead">{lead}</p>
+      </div>
+      <div className="deck-sales-packs-grid">
+        {packs.map((pack) => (
+          <article
+            className="deck-sales-pack"
+            key={pack.key}
+            style={{ '--pack-accent': pack.accent ?? '#928b7d' } as CSSProperties}
+          >
+            <span className="deck-sales-pack-swatch" aria-hidden />
+            <h3>{pack.name}</h3>
+            <p>{pack.blurb}</p>
+            <div className="deck-sales-pack-foot">
+              <span className="deck-sales-pack-price">{pack.priceLabel}</span>
+              {pack.live && pack.gumroadUrl ? (
+                <a
+                  href={pack.gumroadUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="deck-sales-pack-add"
+                >
+                  add →
+                </a>
+              ) : (
+                <span className="deck-sales-pack-soon">coming soon</span>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
   )
 }
 

--- a/src/styles/allyship-deck.css
+++ b/src/styles/allyship-deck.css
@@ -815,6 +815,126 @@
   letter-spacing: .08em;
 }
 
+/* Social-proof stats — folded into the choice CTA (campaign figures). */
+.deck-sales-stats {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(24px, 8vw, 72px);
+  margin-top: 34px;
+}
+
+.deck-sales-stat b {
+  display: block;
+  color: var(--deck-sales-gold);
+  font-family: 'Jost', system-ui, sans-serif;
+  font-size: clamp(30px, 6vw, 44px);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.deck-sales-stat span {
+  display: block;
+  margin-top: 8px;
+  color: #9c9587;
+  font-family: 'Space Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+/* Expansion-pack upsell — the seven $8 superpower packs' only storefront. */
+.deck-sales-packs-lead {
+  max-width: 520px;
+  margin: 12px auto 0;
+}
+
+.deck-sales-packs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+  max-width: 860px;
+  margin: 40px auto 0;
+  padding: 0 26px;
+}
+
+.deck-sales-pack {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 18px;
+  border: 1px solid color-mix(in srgb, var(--pack-accent) 40%, rgba(232,200,120,.14));
+  border-radius: 14px;
+  background: radial-gradient(120% 100% at 82% 0%, color-mix(in srgb, var(--pack-accent) 12%, #14100a), #14100a 70%);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05), 0 0 30px -18px var(--pack-accent);
+  text-align: left;
+}
+
+.deck-sales-pack-swatch {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: var(--pack-accent);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.25);
+}
+
+.deck-sales-pack h3 {
+  margin: 12px 0 4px;
+  color: #f6f2e8;
+  font-family: 'Jost', system-ui, sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.deck-sales-pack p {
+  flex: 1;
+  margin: 0 0 14px;
+  color: #b8b3a8;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.deck-sales-pack-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.deck-sales-pack-price {
+  color: var(--deck-sales-gold);
+  font-family: 'Jost', system-ui, sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.deck-sales-pack-add {
+  border-radius: 999px;
+  background: linear-gradient(150deg, #e8c878, #c9a84c);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.3);
+  color: #1c1505;
+  font-family: 'Jost', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 14px;
+  text-decoration: none;
+  transition: transform .18s cubic-bezier(.16,1,.3,1);
+}
+
+.deck-sales-pack-add:hover {
+  transform: translateY(-1px);
+}
+
+.deck-sales-pack-soon {
+  border: 1px dashed rgba(255,255,255,.2);
+  border-radius: 999px;
+  color: #7d766a;
+  font-family: 'Space Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+}
+
 .deck-sales-objections {
   border-top: 1px solid rgba(232,200,120,.1);
   background: #0a0806;


### PR DESCRIPTION
## What

Updates the deck sales page (`/deck/sales`) with the cold-sales layout from the Claude Design handoff, and finalizes the guarantee copy that was left as a placeholder.

### Design handoff
- Parametrized `DeckSalesExperience` (price line, CTA price, guarantee line) and re-wired `src/app/deck/sales/page.tsx` to feed live pack data.
- Folded in the social-proof stats section and the superpower-pack upsell section, with supporting CSS.

### Guarantee copy
Replaced the pending placeholder (`honest-terms guarantee - ... - pending`) with final wording:

> The whole promise is a move in the ten seconds that matter. Carry the deck thirty days; if not one lands there, one email gets your money back — no forms, and you keep the deck.

Chosen terms: **30-day window**, **full refund**, **keep the deck** (no return). It renders in both spots that use the guarantee line — the dashed callout under "the deck plays complete on its own," and the answer to the last honest-question, "what if it doesn't work for me?" The wording reads correctly for digital access and physical alike.

## Verify
- `npm run check` — 0 errors (pre-existing warnings only; none in the touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFzpK53d9oMDyzBKJSy3Fu)_