### PR TITLE
Add Allyship Deck recommendation card view models

### DIFF
--- a/.specify/specs/allyship-deck-recommendation-card-v2/plan.md
+++ b/.specify/specs/allyship-deck-recommendation-card-v2/plan.md
@@ -1,0 +1,50 @@
+# Plan
+
+## Phase 1 — Presenter Contract
+
+Add `src/lib/allyship-deck/recommendation-card-view-model.ts`.
+
+Responsibilities:
+
+- create `RecommendationCardViewModel`
+- translate route-hand role into player-facing kicker
+- explain the card linkage using card move/domain/operation
+- format emotional vector
+- format blocker fallback
+- generate 3-5 executable protocol steps from the translated Show Up move
+- expose placeholder save targets
+
+## Phase 2 — UI Swap
+
+Update `src/components/deck/WorkThisCardButton.tsx`.
+
+Changes:
+
+- import presenter helper
+- build one view model per route-hand recommendation
+- update `RecommendationView` to render the v2 fields
+- preserve current choose/practice/reflect lifecycle
+
+## Phase 3 — Tests
+
+Add `src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts`.
+
+Run:
+
+```bash
+node --import tsx src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts
+NODE_OPTIONS=--max-old-space-size=6144 npm run build:type-check -- --pretty false
+```
+
+## File Impacts
+
+- `.specify/specs/allyship-deck-recommendation-card-v2/spec.md`
+- `.specify/specs/allyship-deck-recommendation-card-v2/plan.md`
+- `.specify/specs/allyship-deck-recommendation-card-v2/tasks.md`
+- `src/lib/allyship-deck/recommendation-card-view-model.ts`
+- `src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts`
+- `src/components/deck/WorkThisCardButton.tsx`
+
+## Risk
+
+The main risk is over-copying the recommendation and making the card visually heavy. Keep the presenter output compact and deterministic.

--- a/.specify/specs/allyship-deck-recommendation-card-v2/spec.md
+++ b/.specify/specs/allyship-deck-recommendation-card-v2/spec.md
@@ -1,0 +1,109 @@
+# Allyship Deck Recommendation Card v2
+
+## Problem
+
+The Allyship Deck "Work this card" flow can resolve an emotional vector and produce route-hand recommendations, but the recommendation screen still reads like raw engine output. Players can see a title, instruction, and completion prompt, yet they must infer:
+
+- why the drawn card matters
+- how the emotional vector shaped the route
+- where their blocker is being metabolized
+- what to do immediately
+- what trace proves the move happened
+
+This makes a correct recommendation feel less playable than the grammar underneath it.
+
+## Goal
+
+Turn each route-hand recommendation into a compact, executable recommendation card that explains:
+
+1. why this deck card is shaping the move
+2. the emotional vector being worked
+3. the blocker/context being metabolized
+4. 3-5 concrete protocol steps
+5. the trace required to complete the move
+6. future save/share affordances
+
+## Non-Goals
+
+- Do not replace `recommendChargeMetabolismMove()`.
+- Do not alter vector routing, primitive scoring, or route-hand planning.
+- Do not add persistence in this slice.
+- Do not add AI generation.
+- Do not redesign the entire deck reader.
+
+## Six Game Master Requirements
+
+- **Shaman:** The card must feel emotionally alive. Each view model includes a felt `whyThisMove` and a concrete protocol.
+- **Challenger:** Completion cannot be fake. The card must include a trace prompt and the existing lifecycle must still require an artifact, reflection, or outcome.
+- **Regent:** The UI must render a typed contract, not one-off copy.
+- **Architect:** Use a presenter/helper layer over the existing recommendation engine.
+- **Diplomat:** Copy must be compact, human, and player-facing.
+- **Sage:** The contract must include future hooks for BAR reflection, move-attempt persistence, and shareable artifacts.
+
+## Data Contract
+
+Add a pure presenter model:
+
+```ts
+export interface RecommendationCardViewModel {
+  id: string
+  kicker: string
+  title: string
+  whyThisCard: string
+  vectorLabel: string
+  blockerLabel: string
+  protocolSteps: string[]
+  tracePrompt: string
+  completionLabel: string
+  saveTargets: RecommendationSaveTarget[]
+}
+```
+
+`RecommendationSaveTarget` should include placeholder targets for:
+
+- `move_attempt`
+- `bar_reflection`
+- `share_card`
+
+The presenter should accept:
+
+- `MoveCard`
+- `CardSubject`
+- route-hand role
+- `ShowUpRecommendation`
+- optional `MoveAttemptDraft`
+
+## UX Requirements
+
+On the recommendation step, each route-hand card must display:
+
+- role/kicker, e.g. "Card 1 · metabolize"
+- recommendation title
+- "Why this card"
+- "Your vector"
+- "Where the work is"
+- "Do this now" with 3-5 numbered steps
+- "Leave this trace"
+- choose button
+- disabled or placeholder save/share affordances
+
+## Acceptance Criteria
+
+1. Route-hand recommendations render through `RecommendationCardViewModel`.
+2. Same route-hand count behavior is preserved: 1-3 cards can render.
+3. `WorkThisCardButton` still typechecks against the existing recommendation engine.
+4. Completion still requires a trace through existing move-attempt lifecycle rules.
+5. Unit tests cover:
+   - vector label creation
+   - blocker fallback
+   - protocol step shape
+   - save target placeholders
+   - route-hand role labeling
+
+## Future Hooks
+
+This slice intentionally stops at local prototype state, but the view model must make the next persistence slice obvious:
+
+- save selected move attempt
+- save completion as BAR reflection
+- render/share a compact image card

--- a/.specify/specs/allyship-deck-recommendation-card-v2/tasks.md
+++ b/.specify/specs/allyship-deck-recommendation-card-v2/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Create spec kit.
+- [x] Add typed recommendation card view model presenter.
+- [x] Add presenter unit tests.
+- [x] Swap Work This Card recommendation UI to render v2 fields.
+- [x] Run presenter test.
+- [x] Run merged-main typecheck.
+- [x] Review final diff.

--- a/src/components/deck/WorkThisCardButton.tsx
+++ b/src/components/deck/WorkThisCardButton.tsx
@@ -26,6 +26,10 @@ import {
   type MoveAttemptDraft,
   type MoveRecommendationServiceResult,
 } from '@/lib/charge-metabolism'
+import {
+  buildRecommendationCardViewModel,
+  type RecommendationCardViewModel,
+} from '@/lib/allyship-deck/recommendation-card-view-model'
 import type { CardSubject } from './AllyshipCard'
 
 type PanelStep =
@@ -608,11 +612,18 @@ function DeckWorkThisCardPanel({
                 {routeHandRecommendations.map((item, index) => {
                   const draft = routeHandAttemptDrafts[index] ?? null
                   const role = draft?.recommendationRole ?? 'single'
+                  const viewModel = buildRecommendationCardViewModel({
+                    card,
+                    subject,
+                    recommendation: item,
+                    role,
+                    attemptDraft: draft,
+                  })
                   return (
                     <RecommendationView
                       key={`${item.edge.vector}-${index}`}
-                      kickerLabel={`Card ${index + 1} · ${routeHandRoleLabel(role)}`}
-                      recommendation={item.move}
+                      kickerLabel={`Card ${index + 1} · ${viewModel.kicker}`}
+                      viewModel={viewModel}
                       action={
                         <button
                           type="button"
@@ -860,21 +871,51 @@ function OptionCard({
 }
 
 function RecommendationView({
-  recommendation,
+  viewModel,
   kickerLabel = 'Recommended move',
   action,
 }: {
-  recommendation: NonNullable<MoveRecommendationServiceResult['primaryRecommendation']>['move']
+  viewModel: RecommendationCardViewModel
   kickerLabel?: string
   action?: ReactNode
 }) {
   return (
     <div style={recommendationBox}>
       <p style={{ ...kicker, color: DECK_GOLD }}>{kickerLabel}</p>
-      <h3 style={{ ...panelHeading, marginTop: 5 }}>{recommendation.title}</h3>
-      <p style={smallLabel}>{recommendation.domainOutput}</p>
-      <div style={recommendationText}>{recommendation.instruction}</div>
-      <p style={{ ...bodyText, marginTop: 12 }}>{recommendation.completion}</p>
+      <h3 style={{ ...panelHeading, marginTop: 5 }}>{viewModel.title}</h3>
+      <div style={recommendationSection}>
+        <p style={smallLabel}>Why this card</p>
+        <p style={bodyText}>{viewModel.whyThisCard}</p>
+      </div>
+      <div style={recommendationMetaGrid}>
+        <div style={miniPanel}>
+          <p style={smallLabel}>Your vector</p>
+          <p style={compactText}>{viewModel.vectorLabel}</p>
+        </div>
+        <div style={miniPanel}>
+          <p style={smallLabel}>Where the work is</p>
+          <p style={compactText}>{viewModel.blockerLabel}</p>
+        </div>
+      </div>
+      <div style={recommendationSection}>
+        <p style={smallLabel}>Do this now</p>
+        <ol style={protocolList}>
+          {viewModel.protocolSteps.map((step, index) => (
+            <li key={`${viewModel.id}:step:${index}`}>{step}</li>
+          ))}
+        </ol>
+      </div>
+      <div style={traceBox}>
+        <p style={smallLabel}>Leave this trace</p>
+        <p style={compactText}>{viewModel.tracePrompt}</p>
+      </div>
+      <div style={saveTargetRow} aria-label="Future save targets">
+        {viewModel.saveTargets.map((target) => (
+          <button key={target.id} type="button" disabled={!target.enabled} style={disabledPill}>
+            {target.label}
+          </button>
+        ))}
+      </div>
       {action && <div style={{ marginTop: 14 }}>{action}</div>}
     </div>
   )
@@ -887,12 +928,6 @@ function stateEquals(left: AlchemyState | null, right: AlchemyState): boolean {
 function routeHandHeading(count: number): string {
   if (count === 1) return 'A card came forward.'
   return `${count} cards came forward.`
-}
-
-function routeHandRoleLabel(role: NonNullable<MoveAttemptDraft['recommendationRole']>): string {
-  if (role === 'single') return 'practice'
-  if (role === 'satisfaction') return 'transcend'
-  return role
 }
 
 function buildBlockerContext(choice: BlockerChoice | null, detail: string): string {
@@ -1110,6 +1145,70 @@ const recommendationGrid: CSSProperties = {
   gap: 12,
 }
 
+const recommendationSection: CSSProperties = {
+  display: 'grid',
+  gap: 6,
+  marginTop: 13,
+}
+
+const recommendationMetaGrid: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  gap: 9,
+  marginTop: 13,
+}
+
+const miniPanel: CSSProperties = {
+  borderRadius: 10,
+  border: '1px solid rgba(255,255,255,.1)',
+  background: SURFACE_TOKENS.surfaceInset,
+  padding: 11,
+}
+
+const compactText: CSSProperties = {
+  fontFamily: DECK_FONTS.body,
+  fontSize: 13,
+  lineHeight: 1.45,
+  color: SURFACE_TOKENS.textPrimary,
+  margin: '5px 0 0',
+}
+
+const protocolList: CSSProperties = {
+  display: 'grid',
+  gap: 7,
+  paddingLeft: 18,
+  margin: '6px 0 0',
+  fontFamily: DECK_FONTS.body,
+  fontSize: 13.5,
+  lineHeight: 1.45,
+  color: SURFACE_TOKENS.textPrimary,
+}
+
+const traceBox: CSSProperties = {
+  borderRadius: 10,
+  border: `1px solid color-mix(in srgb, ${DECK_GOLD} 45%, transparent)`,
+  background: 'rgba(230, 184, 90, .1)',
+  padding: 12,
+  marginTop: 13,
+}
+
+const saveTargetRow: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  marginTop: 13,
+}
+
+const disabledPill: CSSProperties = {
+  border: '1px solid rgba(255,255,255,.1)',
+  borderRadius: 999,
+  background: 'rgba(255,255,255,.04)',
+  color: SURFACE_TOKENS.textMuted,
+  fontFamily: DECK_FONTS.mono,
+  fontSize: 10,
+  padding: '7px 9px',
+}
+
 const smallLabel: CSSProperties = {
   fontFamily: DECK_FONTS.mono,
   fontSize: 10,
@@ -1117,15 +1216,6 @@ const smallLabel: CSSProperties = {
   textTransform: 'uppercase',
   color: SURFACE_TOKENS.textMuted,
   margin: '6px 0 0',
-}
-
-const recommendationText: CSSProperties = {
-  whiteSpace: 'pre-wrap',
-  fontFamily: DECK_FONTS.body,
-  fontSize: 13.5,
-  lineHeight: 1.5,
-  color: SURFACE_TOKENS.textPrimary,
-  marginTop: 12,
 }
 
 const errorText: CSSProperties = {

--- a/src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts
+++ b/src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import {
+  buildRecommendationCardViewModel,
+  formatAlchemyState,
+  recommendationRoleLabel,
+} from '../recommendation-card-view-model'
+import type { MoveCard } from '../types'
+import type { ShowUpRecommendation } from '@/lib/alchemy/show-up-primitives'
+
+const card: MoveCard = {
+  id: 'SHOW-DA-SAGE',
+  num: '120',
+  kind: 'move',
+  move: 'show_up',
+  operation: 'sage',
+  domain: 'DIRECT_ACTION',
+  outputBar: 'artifact',
+  title: 'Show Up Through Direct Action',
+  submovePrompt: 'Create a concrete artifact.',
+  primaryQuestion: 'What action wants to become real?',
+  campaignQuestion: 'What action does this campaign need?',
+  defaultSubject: 'self',
+  optimizesFor: 'movement',
+  forbiddenMoves: [],
+  failureModes: [],
+  remediation: 'Make it smaller.',
+  capabilities: ['agency'],
+  status: 'authored',
+}
+
+const recommendation: ShowUpRecommendation = {
+  edge: {
+    operation: 'stabilize',
+    from: { channel: 'anger', altitude: 'dissatisfied' },
+    to: { channel: 'anger', altitude: 'neutral' },
+    vector: 'anger:dissatisfied->anger:neutral',
+    moveId: 'anger_stabilize',
+    moveName: 'Clean Anger',
+    prompt: 'Stabilize anger.',
+  },
+  primitiveMatch: {
+    primitive: {
+      id: 'interrupt_pattern',
+      label: 'Interrupt Pattern',
+      vectorTypes: ['stabilize'],
+      preferredOperations: ['stabilize'],
+      chargeMechanic: 'Desire and boundary become precise force.',
+      baseAct: 'Stop the next repetition.',
+      innerArtifactFamilies: ['line statement'],
+      outerActFamilies: ['boundary'],
+      completionLogic: 'The next repetition is interrupted or the line is placed before it repeats.',
+      driftReflection: 'Did it protect the named value?',
+      proofPrototypeIds: [],
+    },
+    vectorType: 'stabilize',
+    score: 10,
+    reasons: ['channel match'],
+  },
+  move: {
+    primitiveId: 'interrupt_pattern',
+    stateVector: 'anger:dissatisfied->anger:neutral',
+    vectorMechanic: 'Frustration becomes clean boundary signal.',
+    orientation: 'external',
+    subject: 'self',
+    superpower: 'coach',
+    domain: 'DIRECT_ACTION',
+    domainOutput: 'a direct-action line',
+    blocker: 'The work needs direct action.',
+    title: 'Place The Line',
+    instruction: 'Write one sentence that names the line and the next action.',
+    completion: 'A boundary sentence or action artifact exists.',
+    reflectionPrompt: 'What did the line protect?',
+  },
+}
+
+function testFormatsStates() {
+  assert.equal(formatAlchemyState({ channel: 'anger', altitude: 'dissatisfied' }), 'Frustration')
+  assert.equal(formatAlchemyState({ channel: 'sadness', altitude: 'neutral' }), 'Clean Sadness')
+  assert.equal(formatAlchemyState({ channel: 'neutrality', altitude: 'satisfied' }), 'Peace')
+}
+
+function testRoleLabels() {
+  assert.equal(recommendationRoleLabel('single'), 'practice')
+  assert.equal(recommendationRoleLabel('metabolize'), 'metabolize')
+  assert.equal(recommendationRoleLabel('satisfaction'), 'transcend')
+}
+
+function testBuildsRecommendationCardViewModel() {
+  const vm = buildRecommendationCardViewModel({
+    card,
+    subject: 'campaign',
+    recommendation,
+    role: 'metabolize',
+  })
+
+  assert.equal(vm.kicker, 'metabolize')
+  assert.equal(vm.title, 'Place The Line')
+  assert.equal(vm.vectorLabel, 'Frustration -> Clean Anger')
+  assert.equal(vm.blockerLabel, 'The work needs direct action.')
+  assert.ok(vm.whyThisCard.includes('Show Up'))
+  assert.ok(vm.whyThisCard.includes('collective work'))
+  assert.ok(vm.protocolSteps.length >= 4)
+  assert.ok(vm.protocolSteps[0].includes('Frustration becomes clean boundary signal'))
+  assert.ok(vm.tracePrompt.includes('A boundary sentence'))
+  assert.deepEqual(vm.saveTargets.map((target) => target.id), ['move_attempt', 'bar_reflection', 'share_card'])
+  assert.ok(vm.saveTargets.every((target) => !target.enabled))
+}
+
+function testBlockerFallback() {
+  const vm = buildRecommendationCardViewModel({
+    card,
+    subject: 'self',
+    recommendation: {
+      ...recommendation,
+      move: {
+        ...recommendation.move,
+        blocker: 'The blocker has not been named yet.',
+      },
+    },
+    role: 'single',
+  })
+
+  assert.equal(vm.blockerLabel, 'No blocker named yet; work from the vector and the card.')
+}
+
+testFormatsStates()
+testRoleLabels()
+testBuildsRecommendationCardViewModel()
+testBlockerFallback()
+
+console.log('recommendation-card-view-model tests passed')

--- a/src/lib/allyship-deck/recommendation-card-view-model.ts
+++ b/src/lib/allyship-deck/recommendation-card-view-model.ts
@@ -1,0 +1,139 @@
+import { DOMAIN_LABELS, MOVE_LABELS, OPERATION_LABELS } from '@/lib/allyship-deck/card-visuals'
+import type { MoveCard } from '@/lib/allyship-deck/types'
+import type { ShowUpRecommendation } from '@/lib/alchemy/show-up-primitives'
+import type { AlchemyState } from '@/lib/alchemy/alchemy-graph'
+import type { CardSubject } from '@/components/deck/AllyshipCard'
+import type { MoveAttemptDraft, MoveRecommendationRole } from '@/lib/charge-metabolism/types'
+
+export type RecommendationSaveTargetId = 'move_attempt' | 'bar_reflection' | 'share_card'
+
+export interface RecommendationSaveTarget {
+  id: RecommendationSaveTargetId
+  label: string
+  enabled: boolean
+}
+
+export interface RecommendationCardViewModel {
+  id: string
+  kicker: string
+  title: string
+  whyThisCard: string
+  vectorLabel: string
+  blockerLabel: string
+  protocolSteps: string[]
+  tracePrompt: string
+  completionLabel: string
+  saveTargets: RecommendationSaveTarget[]
+}
+
+export function recommendationRoleLabel(role: MoveRecommendationRole): string {
+  if (role === 'single') return 'practice'
+  if (role === 'satisfaction') return 'transcend'
+  return role
+}
+
+export function formatAlchemyState(state: AlchemyState): string {
+  if (state.altitude === 'satisfied') return satisfiedLabelFor(state.channel)
+  if (state.altitude === 'neutral') return cleanChannelLabel(state.channel)
+  return dissatisfiedLabelFor(state.channel)
+}
+
+export function buildRecommendationCardViewModel(input: {
+  card: MoveCard
+  subject: CardSubject
+  recommendation: ShowUpRecommendation
+  role: MoveRecommendationRole
+  attemptDraft?: MoveAttemptDraft | null
+}): RecommendationCardViewModel {
+  const move = input.recommendation.move
+  const present = input.attemptDraft?.vectorSnapshot?.present ?? input.recommendation.edge.from
+  const desired = input.attemptDraft?.vectorSnapshot?.desired ?? input.recommendation.edge.to
+  const blocker = input.attemptDraft?.vectorSnapshot?.blocker ?? move.blocker
+  const roleLabel = recommendationRoleLabel(input.role)
+
+  return {
+    id: `${input.card.id}:${move.stateVector}:${roleLabel}`,
+    kicker: roleLabel,
+    title: move.title,
+    whyThisCard: whyThisCard(input.card, input.subject, input.recommendation),
+    vectorLabel: `${formatAlchemyState(present)} -> ${formatAlchemyState(desired)}`,
+    blockerLabel: blockerLabelFor(blocker),
+    protocolSteps: protocolStepsFor(input.card, input.recommendation),
+    tracePrompt: tracePromptFor(input.recommendation),
+    completionLabel: move.completion,
+    saveTargets: [
+      { id: 'move_attempt', label: 'Save move attempt', enabled: false },
+      { id: 'bar_reflection', label: 'Save as BAR reflection', enabled: false },
+      { id: 'share_card', label: 'Share card image', enabled: false },
+    ],
+  }
+}
+
+function whyThisCard(card: MoveCard, subject: CardSubject, recommendation: ShowUpRecommendation): string {
+  const moveLabel = MOVE_LABELS[card.move]
+  const domainLabel = DOMAIN_LABELS[card.domain]
+  const operationLabel = OPERATION_LABELS[card.operation]
+  const subjectLabel = subject === 'campaign' ? 'collective work' : 'your own practice'
+  return `${moveLabel} in ${domainLabel}, through the ${operationLabel} face, turns this into ${subjectLabel}: ${recommendation.move.domainOutput}.`
+}
+
+function protocolStepsFor(card: MoveCard, recommendation: ShowUpRecommendation): string[] {
+  const move = recommendation.move
+  const primitive = recommendation.primitiveMatch.primitive
+  const steps = [
+    `Name the charge: ${move.vectorMechanic}`,
+    `Use the card lens: ${MOVE_LABELS[card.move]} in ${DOMAIN_LABELS[card.domain]}.`,
+    move.instruction,
+    `Make it inspectable: ${primitive.completionLogic}`,
+  ]
+
+  if (recommendation.mechanicOperation?.steps.length) {
+    steps.splice(2, 0, ...recommendation.mechanicOperation.steps)
+  }
+
+  return steps.filter(Boolean).slice(0, 5)
+}
+
+function tracePromptFor(recommendation: ShowUpRecommendation): string {
+  const move = recommendation.move
+  return `Leave one trace: ${move.completion}`
+}
+
+function blockerLabelFor(blocker: string): string {
+  const trimmed = blocker.trim()
+  if (!trimmed || trimmed === 'The blocker has not been named yet.') {
+    return 'No blocker named yet; work from the vector and the card.'
+  }
+  return trimmed
+}
+
+function cleanChannelLabel(channel: AlchemyState['channel']): string {
+  if (channel === 'neutrality') return 'Clean Neutrality'
+  return `Clean ${capitalize(channel)}`
+}
+
+function dissatisfiedLabelFor(channel: AlchemyState['channel']): string {
+  const labels: Record<AlchemyState['channel'], string> = {
+    anger: 'Frustration',
+    sadness: 'Depression',
+    fear: 'Anxiety',
+    joy: 'Restlessness',
+    neutrality: 'Numbness',
+  }
+  return labels[channel]
+}
+
+function satisfiedLabelFor(channel: AlchemyState['channel']): string {
+  const labels: Record<AlchemyState['channel'], string> = {
+    anger: 'Triumph',
+    sadness: 'Poignance',
+    fear: 'Excitement',
+    joy: 'Bliss',
+    neutrality: 'Peace',
+  }
+  return labels[channel]
+}
+
+function capitalize(value: string): string {
+  return value.slice(0, 1).toUpperCase() + value.slice(1)
+}


### PR DESCRIPTION
## Summary
- add a Recommendation Card v2 spec kit for the Allyship Deck Work This Card flow
- add a typed recommendation card view-model presenter over the existing charge-metabolism recommendation engine
- render route-hand recommendations with why-this-card, vector, blocker, protocol steps, trace prompt, and future save targets

## Why
The current Work This Card recommendation screen exposed correct engine output, but players still had to infer how the drawn card, emotional vector, blocker, and trace fit together. This makes the move feel less playable than the grammar underneath it.

## Relationship to PR #178
This is not a duplicate of #178. PR #178 routes Kickstarter hub self-reports into steward-triageable leads and holding-pen bars. This PR focuses on the Allyship Deck recommendation surface. The overlap is strategic: both move lightweight player signals toward saved artifacts, but on different surfaces.

Future save targets here should harmonize with the artifact patterns introduced in #178, especially `CustomBar` handoff and lightweight public entry.

## Validation
- `node --import tsx src/lib/allyship-deck/__tests__/recommendation-card-view-model.test.ts`
- `npm run db:generate`
- `NODE_OPTIONS=--max-old-space-size=6144 npm run build:type-check -- --pretty false`