### PR TITLE
Add per-card landing pages at /deck/card/[id]

### DIFF
--- a/src/app/api/deck/events/route.ts
+++ b/src/app/api/deck/events/route.ts
@@ -1,0 +1,37 @@
+/**
+ * @route POST /api/deck/events
+ * @entity SYSTEM
+ * @description Log per-card landing-page analytics events (views + CTA click-throughs)
+ *   so we can compare which cards / operations / domains convert. Kept deliberately
+ *   simple (server-side structured log) per the card-landing spec — extend to a DB
+ *   counter or Vercel Analytics event later without changing the client contract.
+ * @permissions public
+ * @params event:string (body, required) — one of "card_view" | "cta_click"
+ * @params cardId:string (body, required) — the card slug, e.g. "WAKE-RA-SAGE"
+ * @dimensions WHO:visitor, WHAT:SYSTEM, WHERE:deck funnel, ENERGY:observability
+ * @agentDiscoverable false
+ * @example POST /api/deck/events with {event:"card_view",cardId:"WAKE-RA-SAGE"}
+ */
+import { NextResponse } from 'next/server'
+
+const KNOWN_EVENTS = new Set(['card_view', 'cta_click'])
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { event?: unknown; cardId?: unknown }
+    const event = typeof body.event === 'string' ? body.event : ''
+    const cardId = typeof body.cardId === 'string' ? body.cardId : ''
+
+    if (!KNOWN_EVENTS.has(event) || !cardId) {
+      return NextResponse.json({ error: 'Missing or invalid event/cardId' }, { status: 400 })
+    }
+
+    // Structured, greppable log — one line per event, keyed by card id so the deck
+    // funnel can be sliced by move/operation/domain in Vercel logs. Extend to a
+    // persistent counter when we need more than log-based comparison.
+    console.log('[deck-card]', event, cardId)
+    return NextResponse.json({ ok: true })
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+}

--- a/src/app/deck/card/[id]/opengraph-image.tsx
+++ b/src/app/deck/card/[id]/opengraph-image.tsx
@@ -1,0 +1,100 @@
+import { ImageResponse } from 'next/og'
+import { assembleDeck, getMoveCardById } from '@/lib/allyship-deck/assemble'
+import type { MoveCard } from '@/lib/allyship-deck/types'
+import {
+  themeForMove,
+  DECK_GOLD,
+  MOVE_LABELS,
+  OPERATION_LABELS,
+  DOMAIN_LABELS,
+} from '@/lib/allyship-deck/card-visuals'
+
+/**
+ * Per-card Open Graph image (1200×630) for `/deck/card/[id]`. Renders the card's title,
+ * move/operation/domain, and its reading onto an element-tinted card template so the link
+ * preview *looks like the card* the marketing post was about — the whole reason these
+ * URLs exist. Uses `next/og` (Satori); keep the markup Satori-safe (flex only, plain hex
+ * colors, no color-mix / radial-gradient).
+ */
+
+export const alt = 'An Allyship Deck card'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+/** Pre-generate an image per move card so static links have a ready preview. */
+export function generateStaticParams(): { id: string }[] {
+  return assembleDeck()
+    .cards.filter((c): c is MoveCard => c.kind === 'move')
+    .map((c) => ({ id: c.id }))
+}
+
+export default async function OgImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const card = getMoveCardById(decodeURIComponent(id).trim().toUpperCase())
+
+  const t = card ? themeForMove(card.move) : { gradFrom: '#241a3e', gradTo: '#100a1f', gem: DECK_GOLD }
+  const title = card ? card.title : 'The Allyship Deck'
+  const question = card ? card.primaryQuestion : 'Moves for the moment it counts.'
+  const tags = card
+    ? [MOVE_LABELS[card.move], OPERATION_LABELS[card.operation], DOMAIN_LABELS[card.domain]]
+    : ['120 cards', 'Mastering Allyship']
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 64,
+          background: `linear-gradient(135deg, ${t.gradFrom}, ${t.gradTo})`,
+          border: `10px solid ${DECK_GOLD}`,
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* header row */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ display: 'flex', fontSize: 24, letterSpacing: 4, color: t.gem, textTransform: 'uppercase' }}>
+            {card ? card.id : 'The Allyship Deck'}
+          </div>
+          <div style={{ display: 'flex', fontSize: 24, letterSpacing: 4, color: DECK_GOLD, textTransform: 'uppercase' }}>
+            Mastering Allyship
+          </div>
+        </div>
+
+        {/* title + question */}
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div style={{ display: 'flex', fontSize: 76, fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
+          <div style={{ display: 'flex', fontSize: 34, marginTop: 28, color: '#e7c98a', fontStyle: 'italic', lineHeight: 1.3 }}>
+            {question}
+          </div>
+        </div>
+
+        {/* tag row */}
+        <div style={{ display: 'flex', gap: 16 }}>
+          {tags.map((tag) => (
+            <div
+              key={tag}
+              style={{
+                display: 'flex',
+                fontSize: 24,
+                letterSpacing: 3,
+                textTransform: 'uppercase',
+                color: '#ffffff',
+                padding: '10px 22px',
+                borderRadius: 999,
+                border: `2px solid ${t.gem}`,
+              }}
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/src/app/deck/card/[id]/page.tsx
+++ b/src/app/deck/card/[id]/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { assembleDeck, getMoveCardById } from '@/lib/allyship-deck/assemble'
+import type { MoveCard } from '@/lib/allyship-deck/types'
+import { DeckCardLanding } from '@/components/deck/DeckCardLanding'
+
+/**
+ * @route /deck/card/[id]
+ * @page /deck/card/:id
+ * @entity SYSTEM
+ * @description Public, ungated landing page for one Allyship Deck card — the destination
+ *   for card-specific marketing links (e.g. `/deck/card/WAKE-RA-SAGE`). Looks the card up
+ *   in the assembled deck by its canonical `MOVE-DOMAIN-OPERATION` id, renders the question
+ *   side plus a fixed CTA back to `/deck/sales`, and emits per-card Open Graph tags so the
+ *   social preview matches the card the post was about. Unknown ids redirect to `/deck/sales`.
+ * @permissions public
+ * @energyCost 0 (read-only)
+ * @dimensions WHO:visitor, WHAT:SYSTEM, WHERE:funnel, ENERGY:N/A
+ * @agentDiscoverable true
+ * @example /deck/card/WAKE-RA-SAGE
+ */
+
+type Props = { params: Promise<{ id: string }> }
+
+/** Normalize a URL slug to the canonical card id (ids are upper-case, e.g. WAKE-RA-SAGE). */
+function normalizeId(raw: string): string {
+  return decodeURIComponent(raw).trim().toUpperCase()
+}
+
+/** Pre-render every move card as a static page (HTML only; fast, SEO-friendly). */
+export function generateStaticParams(): { id: string }[] {
+  return assembleDeck()
+    .cards.filter((c): c is MoveCard => c.kind === 'move')
+    .map((c) => ({ id: c.id }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const card = getMoveCardById(normalizeId(id))
+
+  if (!card) {
+    return { title: 'The Allyship Deck' }
+  }
+
+  const description = card.primaryQuestion
+  const title = `${card.title} — The Allyship Deck`
+
+  return {
+    title,
+    description,
+    // og/twitter images come from the co-located `opengraph-image` route so each
+    // card link previews as itself. Titles/description are set here.
+    openGraph: {
+      title: card.title,
+      description,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: card.title,
+      description,
+    },
+  }
+}
+
+export default async function DeckCardPage({ params }: Props) {
+  const { id } = await params
+  const card = getMoveCardById(normalizeId(id))
+
+  // Unknown id → send them somewhere useful (the deck storefront) rather than a dead end.
+  if (!card) {
+    redirect('/deck/sales')
+  }
+
+  return <DeckCardLanding card={card} />
+}

--- a/src/components/deck/DeckCardLanding.tsx
+++ b/src/components/deck/DeckCardLanding.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { useEffect, useState, type CSSProperties } from 'react'
+import Link from 'next/link'
+import { SURFACE_TOKENS } from '@/lib/ui/card-tokens'
+import {
+  themeForMove,
+  DECK_GOLD,
+  INSET_TOP,
+  DECK_FONTS,
+  MOVE_LABELS,
+  OPERATION_LABELS,
+  DOMAIN_LABELS,
+} from '@/lib/allyship-deck/card-visuals'
+import {
+  glossaryHref,
+  moveTermId,
+  operationTermId,
+  domainTermId,
+} from '@/lib/allyship-deck/glossary'
+import type { MoveCard } from '@/lib/allyship-deck/types'
+import { MovePip } from './MovePip'
+import { FaceBadge } from './FaceBadge'
+import type { CardSubject } from './AllyshipCard'
+
+/**
+ * Public, ungated landing page for a single Allyship Deck card — the destination for
+ * card-specific marketing links (`/deck/card/[id]`). It shows only the *question* side
+ * of a card (title, move/operation/domain, both readings, the restored capability) and
+ * always closes with a fixed CTA back to `/deck/sales`. The card's full "working"
+ * (forbidden moves, failure modes, the remediation practice) is deliberately held back —
+ * that depth is the paid deck.
+ *
+ * Reuses the deck's visual primitives (MovePip / FaceBadge / element theming) so the
+ * landing card matches the real product; it does not reuse the full `AllyshipCard`
+ * because that surface intentionally reveals the practice well.
+ *
+ * @see .specify/specs — Individual Card Landing Pages
+ */
+export function DeckCardLanding({ card }: { card: MoveCard }) {
+  const [subject, setSubject] = useState<CardSubject>('self')
+  const t = themeForMove(card.move)
+  const question = subject === 'campaign' ? card.campaignQuestion : card.primaryQuestion
+
+  // Per-card view — fire once on mount so we can compare which cards convert.
+  useEffect(() => {
+    sendDeckEvent('card_view', card.id)
+  }, [card.id])
+
+  return (
+    <main style={{ minHeight: '100vh', display: 'flex', justifyContent: 'center', padding: '32px 16px 80px' }}>
+      <div style={{ width: '100%', maxWidth: 480 }}>
+        {/* The card — locked to the 5:7 poker proportion the deck uses everywhere
+            (same as AllyshipCard's full variant); longer readings scroll inside the
+            frame instead of stretching it. */}
+        <article
+          style={{
+            position: 'relative',
+            borderRadius: 14,
+            aspectRatio: '5 / 7',
+            overflowY: 'auto',
+            border: `2px solid ${DECK_GOLD}`,
+            background: `radial-gradient(120% 90% at 78% 8%, ${t.gradFrom}, ${t.gradTo} 64%)`,
+            boxShadow: `${INSET_TOP}, 0 0 30px 1px color-mix(in srgb, ${t.glow} 38%, transparent), 0 22px 48px -22px rgba(0,0,0,.9)`,
+            color: SURFACE_TOKENS.textPrimary,
+            padding: '22px 24px 24px',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <MovePip move={card.move} size={30} />
+            <span
+              style={{
+                fontFamily: DECK_FONTS.mono,
+                fontSize: 11,
+                letterSpacing: '0.1em',
+                color: SURFACE_TOKENS.textMuted,
+              }}
+            >
+              {card.id}
+            </span>
+            <FaceBadge operation={card.operation} size={28} />
+          </div>
+
+          <h1 style={{ fontFamily: DECK_FONTS.display, fontWeight: 800, fontSize: 30, color: '#fff', margin: '18px 0 0', lineHeight: 1.12 }}>
+            {card.title}
+          </h1>
+
+          {/* three tags — move / operation / domain, each deep-links to its glossary term */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
+            <Tag href={glossaryHref(moveTermId(card.move))} color={t.gem}>
+              {MOVE_LABELS[card.move]}
+            </Tag>
+            <Tag href={glossaryHref(operationTermId(card.operation))} color="#e7c98a">
+              {OPERATION_LABELS[card.operation]}
+            </Tag>
+            <Tag href={glossaryHref(domainTermId(card.domain))} color={t.gem}>
+              ◇ {DOMAIN_LABELS[card.domain]}
+            </Tag>
+          </div>
+
+          {/* subject toggle — same card, two readings */}
+          <div style={{ display: 'flex', gap: 8, marginTop: 20 }}>
+            <Chip active={subject === 'self'} onClick={() => setSubject('self')}>
+              For self
+            </Chip>
+            <Chip active={subject === 'campaign'} onClick={() => setSubject('campaign')}>
+              For others
+            </Chip>
+          </div>
+
+          <p
+            style={{
+              fontFamily: DECK_FONTS.body,
+              fontStyle: 'italic',
+              fontSize: 19,
+              color: '#e7c98a',
+              lineHeight: 1.45,
+              margin: '14px 0 0',
+            }}
+          >
+            {question}
+          </p>
+
+          {card.capabilities.length > 0 && (
+            <div
+              style={{
+                marginTop: 'auto',
+                paddingTop: 18,
+                borderTop: '1px solid color-mix(in srgb, #fff 10%, transparent)',
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 8,
+                flexWrap: 'wrap',
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: DECK_FONTS.mono,
+                  fontSize: 10,
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                  color: SURFACE_TOKENS.textMuted,
+                }}
+              >
+                Restores
+              </span>
+              <span style={{ fontFamily: DECK_FONTS.body, fontSize: 14, color: '#fff' }}>
+                {card.capabilities.join(' · ')}
+              </span>
+            </div>
+          )}
+        </article>
+
+        {/* CTA — fixed, brand voice, no scarcity. Always points back to the deck storefront. */}
+        <div style={{ textAlign: 'center', marginTop: 28 }}>
+          <p style={{ fontFamily: DECK_FONTS.body, fontSize: 15, color: SURFACE_TOKENS.textSecondary, margin: '0 auto 16px', maxWidth: 380 }}>
+            This is one of 120 cards in the Allyship Deck.
+          </p>
+          <Link href="/deck/sales" onClick={() => sendDeckEvent('cta_click', card.id)} style={cta}>
+            See the full deck →
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+/** Fire-and-forget analytics beacon; never blocks navigation or throws into the UI. */
+function sendDeckEvent(event: 'card_view' | 'cta_click', cardId: string) {
+  try {
+    const body = JSON.stringify({ event, cardId })
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      navigator.sendBeacon('/api/deck/events', new Blob([body], { type: 'application/json' }))
+      return
+    }
+    void fetch('/api/deck/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    /* analytics must never break the page */
+  }
+}
+
+function Tag({ href, color, children }: { href: string; color: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      style={{
+        fontFamily: DECK_FONTS.mono,
+        fontSize: 11,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        padding: '5px 10px',
+        borderRadius: 999,
+        color,
+        background: 'color-mix(in srgb, #000 24%, transparent)',
+        border: `1px solid color-mix(in srgb, ${color} 40%, transparent)`,
+        textDecoration: 'none',
+      }}
+    >
+      {children}
+    </Link>
+  )
+}
+
+function Chip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        fontFamily: DECK_FONTS.mono,
+        fontSize: 11,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        padding: '6px 12px',
+        borderRadius: 999,
+        cursor: 'pointer',
+        color: active ? '#150a04' : SURFACE_TOKENS.textSecondary,
+        background: active ? DECK_GOLD : SURFACE_TOKENS.surfaceInset,
+        border: active ? 'none' : '1px solid rgba(255,255,255,.12)',
+        fontWeight: active ? 700 : 400,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+const cta: CSSProperties = {
+  display: 'inline-block',
+  padding: '13px 28px',
+  borderRadius: 999,
+  background: DECK_GOLD,
+  color: '#150a04',
+  fontFamily: DECK_FONTS.display,
+  fontWeight: 700,
+  fontSize: 15,
+  textDecoration: 'none',
+  boxShadow: '0 10px 30px -12px rgba(201,168,76,.7)',
+}


### PR DESCRIPTION
## Why

Unblocks **Deck Sprint #1**. The Allyship Deck marketing content is drawn card-by-card, but every card-specific post could only link to the generic `/deck/sales` — a mismatch ("here's a specific move" → "here's a product page"), and no way to tell which cards convert. This adds a real page per card.

## What

- **`/deck/card/[id]`** — dynamic route reading the existing `allyship-deck` data by its canonical `MOVE-DOMAIN-OPERATION` id (via the already-present `getMoveCardById`). No new data modeling. Renders title, id, move/operation/domain tags (each glossary-linked), a self ↔ for-others reading toggle, and the restored capability.
  - Deliberately shows only the **question** side. `forbiddenMoves` / `failureModes` / `remediation` stay deck-only depth — the free card page is the question, the paid deck is the full working.
  - Unknown ids **redirect to `/deck/sales`**; slugs are case-normalized (`wake-ra-sage` resolves).
  - Locked to the deck's **5:7 poker aspect ratio** (matching `AllyshipCard`), with the restored-capability line seated as a footer.
- **Fixed CTA** back to `/deck/sales` in the brand's voice — no countdowns, no scarcity ("This is one of 120 cards in the Allyship Deck. → See the full deck").
- **Per-card Open Graph images** (`opengraph-image.tsx` via `next/og`) so each link previews as *its own card* (element-tinted template with title, question, and move/operation/domain badges), plus per-card `og`/`twitter` title + description. Statically generated at build via `generateStaticParams` — no runtime generation, fail-loud in CI.
- **`/api/deck/events`** — lightweight `card_view` + `cta_click` logging keyed by card id (fired via `sendBeacon`), so operations/domains can be compared for conversion.

Reuses the deck's visual primitives (`MovePip`, `FaceBadge`, element theming) rather than rebuilding card UI.

## The 6 sprint URLs, live-ready on deploy

`/deck/card/WAKE-RA-SAGE` · `/deck/card/OPEN-DA-SHAMAN` · `/deck/card/CLEAN-SO-CHALLENGER` · `/deck/card/CLEAN-RA-ARCHITECT` · `/deck/card/CLEAN-DA-DIPLOMAT` · `/deck/card/GROW-DA-SAGE`

(Posts 7–8 are intentionally whole-deck and keep linking to `/deck/sales`.)

## Verification

Exercised end-to-end against a dev server:
- All 6 sprint cards return `200`; lowercase slug normalizes; unknown id `307` → `/deck/sales`
- OG image endpoint returns a valid 1200×630 PNG per card
- Analytics endpoint returns `200` for valid events, `400` for invalid
- Card measures exactly 1.400 (5:7) on both desktop and mobile
- `tsc --noEmit` clean; pre-commit `npm run check` passes with 0 errors

Out of scope (spec's v2 / nice-to-haves): the `/deck/cards` browse index and a shared-image OG fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2fov6zUC8P5r3e7SdYFA)_