### PR TITLE
Gate Chapter 1 reader behind email signup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@prisma/client": "^5.22.0",
         "@prisma/extension-accelerate": "^3.0.1",
         "@react-email/components": "^1.0.12",
+        "@react-email/render": "^2.0.6",
         "@types/pathfinding": "^0.1.0",
         "@vercel/blob": "^2.3.1",
         "@xyflow/react": "^12.10.1",
@@ -2068,6 +2069,23 @@
       },
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.6.tgz",
+      "integrity": "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@react-email/components/node_modules/@react-email/render": {

--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "@prisma/client": "^5.22.0",
     "@prisma/extension-accelerate": "^3.0.1",
     "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.6",
     "@types/pathfinding": "^0.1.0",
     "@vercel/blob": "^2.3.1",
     "@xyflow/react": "^12.10.1",

--- a/src/app/mastering-allyship/chapter-1/read/page.tsx
+++ b/src/app/mastering-allyship/chapter-1/read/page.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import {
   CHAPTER_ONE_LEAD_PROMISE,
   CHAPTER_ONE_LEAD_TITLE,
 } from '@/lib/mastering-allyship/chapter-one-lead'
+import {
+  CHAPTER_ONE_ACCESS_COOKIE,
+  verifyChapterOneAccessGrant,
+} from '@/lib/mastering-allyship/chapter-one-access'
 
 export const metadata: Metadata = {
   title: 'Chapter 1: The Call to Play',
@@ -35,13 +41,20 @@ const sections = [
  * @page /mastering-allyship/chapter-1/read
  * @entity CAMPAIGN
  * @description Public Chapter 1 lead-magnet reader while the polished PDF receives design.
- * @permissions public
+ * @permissions chapter-one-signup-required
  * @relationships delivery target for FunnelSignup source mastering-allyship-chapter-1
  * @dimensions WHO:visitor, WHAT:Chapter 1 sample, WHERE:Mastering Allyship funnel, ENERGY:wake_up
  * @example /mastering-allyship/chapter-1/read
  * @agentDiscoverable true
  */
-export default function ChapterOneReadPage() {
+export default async function ChapterOneReadPage() {
+  const cookieStore = await cookies()
+  const accessGrant = cookieStore.get(CHAPTER_ONE_ACCESS_COOKIE)?.value
+
+  if (!verifyChapterOneAccessGrant(accessGrant)) {
+    redirect('/mastering-allyship/chapter-1?gate=required')
+  }
+
   return (
     <main className="min-h-screen bg-[#0a0908] px-4 py-10 text-[#e8e6e0] sm:px-6 lg:px-8">
       <article className="mx-auto max-w-3xl">

--- a/src/lib/mastering-allyship/__tests__/chapter-one-reader-gate.test.ts
+++ b/src/lib/mastering-allyship/__tests__/chapter-one-reader-gate.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const page = readFileSync('src/app/mastering-allyship/chapter-1/read/page.tsx', 'utf8')
+
+assert.match(page, /import \{ cookies \} from 'next\/headers'/)
+assert.match(page, /verifyChapterOneAccessGrant\(accessGrant\)/)
+assert.match(page, /\/mastering-allyship\/chapter-1\?gate=required/)
+assert.match(page, /@permissions chapter-one-signup-required/)
+
+console.log('✓ Chapter One reader requires a valid access grant before rendering')


### PR DESCRIPTION
## What changed

- Require a valid signed Chapter 1 access cookie before rendering `/mastering-allyship/chapter-1/read`.
- Redirect direct visitors without access to the Chapter 1 signup page.
- Add a focused regression test for the reader gate.
- Add `@react-email/render` as a direct production dependency.

## Why

PR #185 added the signup, access grant, and Resend delivery path, but the existing reader page remained public. This follow-up closes that gap so the email capture actually gates reading.

The first live test also exposed a separate deployment issue: Resend's React renderer was only available transitively through `@react-email/components`, so the serverless function failed before making any Resend API request. The renderer is now directly locked for production installs.

## Validation

- Chapter One reader-gate test passed.
- Signed access-grant test passed.
- Targeted ESLint passed.
- `git diff --check` passed.
- Vercel runtime logs confirmed the original failure and its pre-Resend rendering stage.
